### PR TITLE
Add support for delta streaming API to Namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rest-client', '~> 1.7'
+gem 'yajl-ruby'
+gem 'em-http-request'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You don't need to use this repo unless you're planning to modify the gem. If you
 
 - Ruby 1.8.7 or above. (Ruby 1.8.6 may work if you load ActiveSupport.)
 
-- rest-client, json
+- rest-client, json, yajl-ruby, em-http-request
 
 
 ## Example Rails App
@@ -293,6 +293,38 @@ end
 # Don't forget to save the last cursor so that we can pick up changes
 # from where we left.
 save_to_db(last_cursor)
+```
+
+### Using the Delta sync streaming API
+
+The streaming API will receive deltas in real time, without needing to repeatedly poll.
+
+````ruby
+# Get all the messages starting from timestamp
+#
+# we first need to get a cursor object a cursor is simply the id of
+# an individual change.
+cursor = inbox.namespaces.first.get_cursor(1407543195)
+
+last_cursor = nil
+inbox.namespaces.first.delta_stream(cursor) do |event, object|
+    if event == "create" or event == "modify"
+        if object.is_a?(Inbox::Contact)
+            puts "#{object.name} - #{object.email}"
+        elsif object.is_a?(Inbox::Event)
+            puts "Event!"
+        end
+    elsif event == "delete"
+        # In the case of a deletion, the API only returns the ID of the object.
+        # In this case, the Ruby SDK returns a dummy object with only the id field
+        # set.
+        puts "Deleting from collection #{object.class.name}, id: #{object}"
+    end
+    last_cursor = object.cursor
+
+    # This will loop indefintely
+end
+
 ```
 
 ### Exclude changes from a specific type --- get only messages

--- a/inbox.gemspec
+++ b/inbox.gemspec
@@ -47,6 +47,8 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rest-client>, ["~> 1.7"])
+      s.add_runtime_dependency(%q<yajl-ruby>, [">= 0"])
+      s.add_runtime_dependency(%q<em-http-request>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
@@ -58,6 +60,8 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<webmock>, [">= 0"])
     else
       s.add_dependency(%q<rest-client>, ["~> 1.7"])
+      s.add_dependency(%q<yajl-ruby>, [">= 0"])
+      s.add_dependency(%q<em-http-request>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
@@ -70,6 +74,8 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<rest-client>, ["~> 1.7"])
+    s.add_dependency(%q<yajl-ruby>, [">= 0"])
+    s.add_dependency(%q<em-http-request>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -36,7 +36,7 @@ module Inbox
 
     # Handle content expectation errors
     raise UnexpectedResponse.new if options[:expected_class] && result_content.empty?
-    json = JSON.parse(result_content)
+    json = options[:result_parsed]? result_content : JSON.parse(result_content)
     if json.is_a?(Hash) && (json['type'] == 'api_error' or json['type'] == 'invalid_request_error')
       if result.code.to_i == 400
         exc = InvalidRequest

--- a/lib/namespace.rb
+++ b/lib/namespace.rb
@@ -146,7 +146,7 @@ module Inbox
       end
     end
 
-    def delta_stream(cursor, exclude_types=[])
+    def delta_stream(cursor, exclude_types=[], timeout=0)
       raise 'Please provide a block for receiving the delta objects' if !block_given?
       exclude_string = ""
 
@@ -186,7 +186,7 @@ module Inbox
       end
 
       EventMachine.run do
-        http = EventMachine::HttpRequest.new(path, :connection_timeout => 0, :inactivity_timeout => 0).get(:keepalive => true, :timeout => 0)
+        http = EventMachine::HttpRequest.new(path, :connect_timeout => 0, :inactivity_timeout => timeout).get(:keepalive => true)
         http.stream do |chunk|
           parser << chunk
         end

--- a/spec/fixtures/delta_stream.txt
+++ b/spec/fixtures/delta_stream.txt
@@ -1,0 +1,70 @@
+{
+    "attributes": {
+        "bcc": [],
+        "body": "<div dir=\"ltr\">test again<br></div>",
+        "cc": [],
+        "date": 1424913199,
+        "files": [],
+        "from": [
+            {
+                "email": "karim@nylas.com",
+                "name": "Karim Hamidou"
+            }
+        ],
+        "id": "c7mllq7iag2ivlp6fxf7dhg9i",
+        "namespace_id": "5qmatk6w4v19dg3t24r1t69mm",
+        "object": "message",
+        "snippet": "test again",
+        "subject": "test moar",
+        "thread_id": "1xaax5p901bmy3yzy4ikk3ujz",
+        "to": [
+            {
+                "email": "inboxapptest.french@gmail.com",
+                "name": "Inbox Apptest"
+            }
+        ],
+        "unread": false
+    },
+    "cursor": "baublqvs9fi1amx9ibwmoua09",
+    "event": "create",
+    "id": "c7mllq7iag2ivlp6fxf7dhg9i",
+    "object": "message"
+}
+{
+    "attributes": {
+        "bcc": [],
+        "body": "<div dir=\"ltr\">test again<br></div>",
+        "cc": [],
+        "date": 1424913199,
+        "files": [],
+        "from": [
+            {
+                "email": "karim@nylas.com",
+                "name": "Karim Hamidou"
+            }
+        ],
+        "id": "c7mllq7iag2ivlp6fxf7dhg9i",
+        "namespace_id": "5qmatk6w4v19dg3t24r1t69mm",
+        "object": "message",
+        "snippet": "Hewlett again",
+        "subject": "test moar",
+        "thread_id": "1xaax5p901bmy3yzy4ikk3ujz",
+        "to": [
+            {
+                "email": "inboxapptest.french@gmail.com",
+                "name": "Inbox Apptest"
+            }
+        ],
+        "unread": false
+    },
+    "cursor": "baublqvs9fi1amx9ibwmoua09",
+    "event": "create",
+    "id": "c7mllq7iag2ivlp6fxf7dhg9i",
+    "object": "message"
+}
+{
+    "cursor": "379xgtj0ltcnu7rq4sokou2df",
+    "event": "delete",
+    "id": "db0isjjvqez51vdjeq5lx37dk",
+    "object": "event"
+}


### PR DESCRIPTION
As proposed in #21 :

My implementation adds two new dependencies - yajl-ruby for parsing JSON streams and em-http-request for streaming via HTTP.

Requesting feedback on the following:
I have not handled any HTTP errors in delta_stream because I am not entirely sure which errors the /delta/streaming endpoint can throw.

I have not implemented any sort of recovery if the connection fails. Not sure if this should be a part of the delta_stream function or not.

I am welcome to other feedback and proposals for alternate methods. I have also tried implementing this with yajl-ruby's HttpStream class, but it does not support HTTPS.