### PR TITLE
Clean up correctly returning Drafts, add use case in deltas_spec

### DIFF
--- a/lib/namespace.rb
+++ b/lib/namespace.rb
@@ -66,8 +66,8 @@ module Inbox
 
       cursor = nil
 
-      RestClient.post(path, data.to_json, :content_type => :json) do |response,request,result|
-        json = Inbox.interpret_response(result, response, {:expected_class => Object})
+      RestClient.post(path, data.to_json, :content_type => :json) do |response, request, result|
+        json = Inbox.interpret_response(result, response, { :expected_class => Object })
         cursor = json["cursor"]
       end
 
@@ -75,16 +75,16 @@ module Inbox
     end
 
     OBJECTS_TABLE = {
-      "account" => Inbox::Account,
-      "calendar" => Inbox::Calendar,
-      "draft" => Inbox::Draft,
-      "thread" => Inbox::Thread,
-      "contact" => Inbox::Contact,
-      "event" => Inbox::Event,
-      "file" => Inbox::File,
-      "message" => Inbox::Message,
-      "namespace" => Inbox::Namespace,
-      "tag" => Inbox::Tag,
+        "account" => Inbox::Account,
+        "calendar" => Inbox::Calendar,
+        "draft" => Inbox::Draft,
+        "thread" => Inbox::Thread,
+        "contact" => Inbox::Contact,
+        "event" => Inbox::Event,
+        "file" => Inbox::File,
+        "message" => Inbox::Message,
+        "namespace" => Inbox::Namespace,
+        "tag" => Inbox::Tag,
     }
 
     def deltas(cursor, exclude_types=[])
@@ -95,7 +95,6 @@ module Inbox
         exclude_string = "&exclude_types="
 
         exclude_types.each do |value|
-          count = 0
           if OBJECTS_TABLE.has_value?(value)
             param_name = OBJECTS_TABLE.key(value)
             exclude_string += "#{param_name},"
@@ -110,28 +109,30 @@ module Inbox
         path = @_api.url_for_path("/n/#{@namespace_id}/delta?cursor=#{cursor}#{exclude_string}")
         json = nil
 
-        RestClient.get(path) do |response,request,result|
-          json = Inbox.interpret_response(result, response, {:expected_class => Object})
+        RestClient.get(path) do |response, request, result|
+          json = Inbox.interpret_response(result, response, { :expected_class => Object })
         end
 
         start_cursor = json["cursor_start"]
         end_cursor = json["cursor_end"]
 
         json["deltas"].each do |delta|
-          object = delta['object']
-          if object == 'message'
-              # Drafts are messages underneath
-              object = delta['attributes']['object']
-          end
+          object = if delta['object'] == 'message'
+                     # Drafts are messages underneath
+                     delta['attributes']['object']
+                   else
+                     delta['object']
+                   end
+
           cls = OBJECTS_TABLE[object]
           obj = cls.new(@_api, @namespace_id)
 
           case delta["event"]
-          when 'create', 'modify'
+            when 'create', 'modify'
               obj.inflate(delta['attributes'])
               obj.cursor = delta["cursor"]
               yield delta["event"], obj
-          when 'delete'
+            when 'delete'
               obj.id = delta["id"]
               obj.cursor = delta["cursor"]
               yield delta["event"], obj

--- a/lib/namespace.rb
+++ b/lib/namespace.rb
@@ -119,7 +119,7 @@ module Inbox
         json["deltas"].each do |delta|
           object = if delta['object'] == 'message'
                      # Drafts are messages underneath
-                     delta['attributes']['object']
+                     delta.has_key?('attributes') ? delta['attributes']['object'] : 'message'
                    else
                      delta['object']
                    end

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -13,13 +13,13 @@ describe 'Delta sync API wrapper' do
     @inbox = Inbox::API.new(@app_id, @app_secret, @access_token)
 
     stub_request(:post, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/n/nnnnnnn/delta/generate_cursor").
-         to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
+        to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
 
     stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/n/nnnnnnn/delta?cursor=0").
-         to_return(:status => 200, :body => File.read('spec/fixtures/first_cursor.txt'), :headers => {'Content-Type' => 'application/json'})
+        to_return(:status => 200, :body => File.read('spec/fixtures/first_cursor.txt'), :headers => { 'Content-Type' => 'application/json' })
 
     stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/n/nnnnnnn/delta?cursor=a9vtneydekzye7uwfumdd4iu3").
-         to_return(:status => 200, :body => File.read('spec/fixtures/second_cursor.txt'), :headers => {})
+        to_return(:status => 200, :body => File.read('spec/fixtures/second_cursor.txt'), :headers => {})
 
   end
 
@@ -34,7 +34,9 @@ describe 'Delta sync API wrapper' do
     ns.deltas(timestamp=0) do |event, object|
 
       expect(object.cursor).to_not be_nil
-      if event == 'create' or event == 'modify'
+      if object.respond_to?(:version)
+        expect(object).to be_a Inbox::Draft
+      elsif event == 'create' or event == 'modify'
         expect(object).to be_a Inbox::Message
       elsif event == 'delete'
         expect(object).to be_a Inbox::Event
@@ -42,7 +44,7 @@ describe 'Delta sync API wrapper' do
       count += 1
     end
 
-    expect(count).to eq(3)
+    expect(count).to eq(4)
   end
 end
 

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -39,12 +39,16 @@ describe 'Delta sync API wrapper' do
       elsif event == 'create' or event == 'modify'
         expect(object).to be_a Inbox::Message
       elsif event == 'delete'
-        expect(object).to be_a Inbox::Event
+        if object.respond_to? :subject
+          expect(object).to be_a Inbox::Message
+        else
+          expect(object).to be_a Inbox::Event
+        end
       end
       count += 1
     end
 
-    expect(count).to eq(4)
+    expect(count).to eq(5)
   end
 end
 

--- a/spec/fixtures/second_cursor.txt
+++ b/spec/fixtures/second_cursor.txt
@@ -77,6 +77,13 @@
            "event": "create",
            "id": "b6quap82wul210vuk4rlmobwz",
            "object": "message"
+        },
+
+        {
+            "cursor": "379xgtj0ltcnu7rq4sokou2df",
+            "event": "delete",
+            "id": "qm0isjj19ezsmvdq055lxp7dk",
+            "object": "message"
         }
     ]
 }

--- a/spec/fixtures/second_cursor.txt
+++ b/spec/fixtures/second_cursor.txt
@@ -40,6 +40,43 @@
             "event": "delete",
             "id": "db0isjjvqez51vdjeq5lx37dk",
             "object": "event"
+        },
+
+        {
+           "attributes": {
+              "bcc": [],
+              "body": "<div dir=\"ltr\">hey it is a draft !!</div>",
+              "cc": [],
+              "date": 1431104767,
+              "events": [],
+              "files": [],
+              "from": [
+                 {
+                    "email":"karim@nilas.com",
+                    "name":"Karim Hamidou"
+                 }
+              ],
+              "id": "b6qucu82wul213vuk4rlmobwz",
+              "namespace_id": "4y7lh2wvugxx0gfazlz7adhnf",
+              "object": "draft",
+              "reply_to": [],
+              "reply_to_message_id": null,
+              "snippet": "hey it is a draft !!",
+              "subject": "t",
+              "thread_id": "61b853u3659ngir1z6hgp7nga",
+              "to": [
+                 {
+                    "email":"test@example.com",
+                    "name":"testing"
+                 }
+              ],
+              "unread": false,
+              "version": 0
+           },
+           "cursor": "9sta9simvpf1apkopm1sd2ilv",
+           "event": "create",
+           "id": "b6quap82wul210vuk4rlmobwz",
+           "object": "message"
         }
     ]
 }


### PR DESCRIPTION
Stemming from an Intercom thread with @khamidou / @jennielees 

Problem was that drafts were being interpreted as `Inbox::Message` objects when they were actually drafts. Adding a test case for this.