### PR TITLE
Fix failing specs

### DIFF
--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -1,7 +1,6 @@
 ::ENV['RACK_ENV'] = 'test'
 $LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
-require 'namespace'
 require 'event'
 
 describe 'Delta sync API wrapper' do

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -30,7 +30,7 @@ describe Inbox::File do
 
       file = Inbox::File.new(@inbox, nil)
       file.id = 2
-      expect{ file.download }.to raise_error
+      expect{ file.download }.to raise_error(Inbox::ResourceNotFound)
       expect(a_request(:get, url)).to have_been_made.once
     end
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -69,7 +69,7 @@ describe Inbox::Message do
       msg = Inbox::Message.new(@inbox, nil)
       msg.subject = 'Test message'
       msg.id = 2
-      expect{ msg.raw }.to raise_error
+      expect{ msg.raw }.to raise_error(Inbox::ResourceNotFound)
       expect(a_request(:get, url)).to have_been_made.once
     end
   end


### PR DESCRIPTION
* Namespaces have been removed. This errant `require` will blow up.
* Fix RSpec warnings for raise_error