### PR TITLE
Standardize RSpec configuration

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/account_api_spec.rb
+++ b/spec/account_api_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 require 'webmock/rspec'
 

--- a/spec/account_api_spec.rb
+++ b/spec/account_api_spec.rb
@@ -1,5 +1,4 @@
 require 'event'
-require 'webmock/rspec'
 
 describe Inbox::Event do
   before (:each) do

--- a/spec/account_api_spec.rb
+++ b/spec/account_api_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 require 'webmock/rspec'

--- a/spec/account_api_spec.rb
+++ b/spec/account_api_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'event'
 require 'webmock/rspec'
 

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 
 describe Inbox::Account do

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'event'
 
 describe Inbox::Account do

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'event'
 
 describe 'Delta sync API wrapper' do

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 
 describe 'Delta sync API wrapper' do

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'draft'
 

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'draft'
 
 describe Inbox::Draft do

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'draft'
 
 describe Inbox::Draft do

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 require 'webmock/rspec'
 

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -1,5 +1,4 @@
 require 'event'
-require 'webmock/rspec'
 
 describe Inbox::Event do
   before (:each) do

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 require 'webmock/rspec'

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'event'
 require 'webmock/rspec'
 

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'webmock/rspec'
 require 'file'
 require 'folder'

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -1,4 +1,3 @@
-require 'webmock/rspec'
 require 'file'
 require 'folder'
 

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'webmock/rspec'
 require 'file'
 require 'folder'

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'webmock/rspec'
 require 'file'

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 
 describe 'Inbox' do
   before (:each) do

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 
 describe 'Inbox' do
   before (:each) do

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'webmock/rspec'
 require 'message'
 require 'folder'

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,4 +1,3 @@
-require 'webmock/rspec'
 require 'message'
 require 'folder'
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'webmock/rspec'
 require 'message'
 require 'folder'

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'webmock/rspec'
 require 'message'

--- a/spec/opensource_spec.rb
+++ b/spec/opensource_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'event'
 
 describe Inbox::APIAccount do

--- a/spec/opensource_spec.rb
+++ b/spec/opensource_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 
 describe Inbox::APIAccount do

--- a/spec/opensource_spec.rb
+++ b/spec/opensource_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'event'
 

--- a/spec/restful_model_collection_spec.rb
+++ b/spec/restful_model_collection_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 
 describe 'RestfulModelCollection' do
   before (:each) do

--- a/spec/restful_model_collection_spec.rb
+++ b/spec/restful_model_collection_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 
 describe 'RestfulModelCollection' do
   before (:each) do

--- a/spec/restful_model_spec.rb
+++ b/spec/restful_model_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 
 describe 'RestfulModel' do
   before (:each) do

--- a/spec/restful_model_spec.rb
+++ b/spec/restful_model_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 
 describe 'RestfulModel' do
   before (:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+::ENV['RACK_ENV'] ||= 'test'
+
 require 'inbox'
 require 'webmock/rspec'

--- a/spec/thread_spec.rb
+++ b/spec/thread_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'thread'
 require 'folder'
 

--- a/spec/thread_spec.rb
+++ b/spec/thread_spec.rb
@@ -1,5 +1,4 @@
 ::ENV['RACK_ENV'] = 'test'
-$LOAD_PATH << './lib'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'thread'
 require 'folder'

--- a/spec/thread_spec.rb
+++ b/spec/thread_spec.rb
@@ -1,4 +1,3 @@
-::ENV['RACK_ENV'] = 'test'
 require 'thread'
 require 'folder'
 


### PR DESCRIPTION
* Remove explicit LOAD_PATH mutation
* Require `spec_helper` via .rspec command line arg
* Set RACK_ENV to test in the spec_helper
* Remove extraneous requires for webmock/rspec

NOTE: The specs still won't pass until #36 is merged. This PR builds upon the work done there.