### PR TITLE
Refactor building the exclude_types query param

### DIFF
--- a/lib/delta_filters.rb
+++ b/lib/delta_filters.rb
@@ -7,7 +7,7 @@ module Inbox
       new.build_exclude_types(object_types)
     end
 
-    def initialize(filter_map: API::OBJECTS_TABLE)
+    def initialize(filter_map=API::OBJECTS_TABLE)
       @filter_map = filter_map
     end
 

--- a/lib/delta_filters.rb
+++ b/lib/delta_filters.rb
@@ -1,0 +1,23 @@
+module Inbox
+  class DeltaFilters
+
+    attr_reader :filter_map
+
+    def self.build_exclude_types(object_types)
+      new.build_exclude_types(object_types)
+    end
+
+    def initialize(filter_map: API::OBJECTS_TABLE)
+      @filter_map = filter_map
+    end
+
+    def build_exclude_types(object_types)
+      filters = Array(object_types).map { |type| filter_map.key(type) }.compact.join(',')
+
+      return filters if filters.empty?
+
+      "&exclude_types=#{filters}"
+    end
+
+  end
+end

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -90,6 +90,20 @@ module Inbox
     attr_reader :app_id
     attr_reader :app_secret
 
+    OBJECTS_TABLE = {
+      'account' => Inbox::Account,
+      'calendar' => Inbox::Calendar,
+      'contact' => Inbox::Contact,
+      'draft' => Inbox::Draft,
+      'event' => Inbox::Event,
+      'file' => Inbox::File,
+      'folder' => Inbox::Folder,
+      'label' => Inbox::Label,
+      'message' => Inbox::Message,
+      'tag' => Inbox::Tag,
+      'thread' => Inbox::Thread,
+    }
+
     def initialize(app_id, app_secret, access_token = nil, api_server = 'https://api.nylas.com',
                    service_domain = 'api.nylas.com')
       raise "When overriding the Inbox API server address, you must include https://" unless api_server.include?('://')
@@ -240,20 +254,6 @@ module Inbox
       cursor
     end
 
-    OBJECTS_TABLE = {
-      "account" => Inbox::Account,
-      "calendar" => Inbox::Calendar,
-      "draft" => Inbox::Draft,
-      "thread" => Inbox::Thread,
-      "contact" => Inbox::Contact,
-      "event" => Inbox::Event,
-      "file" => Inbox::File,
-      "message" => Inbox::Message,
-      "tag" => Inbox::Tag,
-      "folder" => Inbox::Folder,
-      "label" => Inbox::Label,
-    }
-
     # It's possible to ask the API to expand objects.
     # In this case, we do the right thing and return
     # an expanded object.
@@ -361,12 +361,8 @@ module Inbox
     private
 
     def build_exclude_types(exclude_types)
-      return '' unless exclude_types.any?
-
-      filters = exclude_types.map { |type| OBJECTS_TABLE.key(type) }.compact.join(',')
-      "&exclude_types=#{filters}"
+      DeltaFilters.build_exclude_types(exclude_types)
     end
-
   end
 end
 

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -261,27 +261,9 @@ module Inbox
       "message" => Inbox::ExpandedMessage,
     }
 
-    def _build_exclude_types(exclude_types)
-      exclude_string = "&exclude_types="
-
-      exclude_types.each do |value|
-        count = 0
-        if OBJECTS_TABLE.has_value?(value)
-          param_name = OBJECTS_TABLE.key(value)
-          exclude_string += "#{param_name},"
-        end
-      end
-
-      exclude_string = exclude_string[0..-2]
-    end
-
     def deltas(cursor, exclude_types=[], expanded_view=false)
       raise 'Please provide a block for receiving the delta objects' if !block_given?
-      exclude_string = ""
-
-      if exclude_types.any?
-        exclude_string = _build_exclude_types(exclude_types)
-      end
+      exclude_string = build_exclude_types(exclude_types)
 
       # loop and yield deltas until we've come to the end.
       loop do
@@ -330,12 +312,7 @@ module Inbox
 
     def delta_stream(cursor, exclude_types=[], timeout=0, expanded_view=false)
       raise 'Please provide a block for receiving the delta objects' if !block_given?
-
-      exclude_string = ""
-
-      if exclude_types.any?
-        exclude_string = _build_exclude_types(exclude_types)
-      end
+      exclude_string = build_exclude_types(exclude_types)
 
       # loop and yield deltas indefinitely.
       path = self.url_for_path("/delta/streaming?cursor=#{cursor}#{exclude_string}")
@@ -380,6 +357,16 @@ module Inbox
         end
       end
     end
+
+    private
+
+    def build_exclude_types(exclude_types)
+      return '' unless exclude_types.any?
+
+      filters = exclude_types.map { |type| OBJECTS_TABLE.key(type) }.compact.join(',')
+      "&exclude_types=#{filters}"
+    end
+
   end
 end
 

--- a/spec/delta_filters_spec.rb
+++ b/spec/delta_filters_spec.rb
@@ -1,0 +1,33 @@
+require 'delta_filters'
+
+describe Inbox::DeltaFilters do
+  describe 'building exclude_types filter' do
+    subject(:delta_filters) { described_class.new }
+
+    it 'maps the object type to filter parameter, joining them with a comma' do
+      types = Inbox::API::OBJECTS_TABLE.values
+      parameters = Inbox::API::OBJECTS_TABLE.keys
+
+      exclude_filter = delta_filters.build_exclude_types(types)
+      expect(exclude_filter).to eq("&exclude_types=#{parameters.join(',')}")
+    end
+
+    it 'skips unknown object types' do
+      UnknownType = Class.new
+      types = [Inbox::Account, UnknownType, Inbox::Tag ]
+      exclude_filter = delta_filters.build_exclude_types(types)
+      expect(exclude_filter).to eq('&exclude_types=account,tag')
+    end
+
+    it 'is empty when no exclude types are specified' do
+      exclude_filter = delta_filters.build_exclude_types([])
+      expect(exclude_filter).to be_empty
+    end
+
+    it 'accepts a single object type' do
+      types = Inbox::Message
+      exclude_filter = delta_filters.build_exclude_types(types)
+      expect(exclude_filter).to eq('&exclude_types=message')
+    end
+  end
+end

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -51,6 +51,16 @@ describe 'Delta sync API wrapper' do
     expect(a_request(:get, @nth_cursor_url)).to have_been_made.once
     expect(count).to eq(3)
   end
+
+  it 'will filter deltas based on the specified exclude types' do
+    stub_request(:get, 'https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta?cursor=a9vtneydekzye7uwfumdd4iu3&exclude_types=calendar,event,tag').
+      to_return(status: 200, body: File.read('spec/fixtures/second_cursor.txt'), headers: {'Content-Type' => 'application/json'})
+
+    filters = [Inbox::Calendar, Inbox::Event, Inbox::Tag, 'FakeFilter']
+    @inbox.deltas('a9vtneydekzye7uwfumdd4iu3', filters) do |event, object|
+      expect(object.cursor).to_not be_nil
+    end
+  end
 end
 
 describe 'Delta sync streaming API wrapper' do


### PR DESCRIPTION
Leverage Ruby to make this more functional, and shorter! We were also able to clean up some incidental duplication.

I also added a test for `exclude_types` to make sure I didn't break anything. :)
