### PR TITLE
Expose sync_state on APIAccount

### DIFF
--- a/lib/api_account.rb
+++ b/lib/api_account.rb
@@ -13,6 +13,7 @@ module Inbox
     parameter :object
     parameter :organization_unit
     parameter :provider
+    parameter :sync_state
 
     def self.collection_name
       "accounts"

--- a/spec/account_api_spec.rb
+++ b/spec/account_api_spec.rb
@@ -1,13 +1,10 @@
 require 'event'
 
-describe Inbox::Event do
-  before (:each) do
-    @app_id = 'ABC'
-    @app_secret = '123'
-    @access_token = 'UXXMOCJW-BKSLPCFI-UQAQFWLO'
-    @namespace_id = 'nnnnnnn'
-    @inbox = Inbox::API.new(@app_id, @app_secret, @access_token)
-  end
+describe Inbox::APIAccount do
+  let(:inbox) { Inbox::API.new(app_id, app_secret, access_token) }
+  let(:app_id) { 'ABC' }
+  let(:app_secret) { '123' }
+  let(:access_token) { 'UXXMOCJW-BKSLPCFI-UQAQFWLO' }
 
   describe "Inbox#account" do
     it "does a request to /account" do
@@ -15,9 +12,10 @@ describe Inbox::Event do
       stub = stub_request(:get, url).
            to_return(:status => 200, :body => File.read('spec/fixtures/account_api.txt'), :headers => {})
 
-      acc = @inbox.account
+      acc = inbox.account
       expect(a_request(:get, url)).to have_been_made.once
       expect(acc.provider).to eq('eas')
+      expect(acc.sync_state).to eq('running')
     end
   end
 end

--- a/spec/fixtures/account_api.txt
+++ b/spec/fixtures/account_api.txt
@@ -5,5 +5,6 @@
     "name": "",
     "object": "account",
     "organization_unit": "folder",
-    "provider": "eas"
+    "provider": "eas",
+    "sync_state": "running"
 }


### PR DESCRIPTION
The `/account` API exposes the current `sync_state`, but we were not pulling that across in the `APIAccount` object. Now we do!