### PR TITLE
Return Enumerator from `#deltas` API when no block is given.

### DIFF
--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -275,7 +275,8 @@ module Inbox
     end
 
     def deltas(cursor, exclude_types=[], expanded_view=false)
-      raise 'Please provide a block for receiving the delta objects' if !block_given?
+      return enum_for(:deltas, cursor, exclude_types, expanded_view) unless block_given?
+
       exclude_string = ""
 
       if exclude_types.any?

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -1,6 +1,8 @@
 require 'event'
 
 describe 'Delta sync API wrapper' do
+  let(:nth_cursor) { 'a9vtneydekzye7uwfumdd4iu3' }
+
   before (:each) do
     @app_id = 'ABC'
     @app_secret = '123'
@@ -19,7 +21,7 @@ describe 'Delta sync API wrapper' do
     stub_request(:get, @cursor_zero_url).
          to_return(:status => 200, :body => File.read('spec/fixtures/first_cursor.txt'), :headers => {'Content-Type' => 'application/json'})
 
-    @nth_cursor_url = "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta?cursor=a9vtneydekzye7uwfumdd4iu3&exclude_folders=false"
+    @nth_cursor_url = "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta?cursor=#{nth_cursor}&exclude_folders=false"
     stub_request(:get, @nth_cursor_url).
          to_return(:status => 200, :body => File.read('spec/fixtures/second_cursor.txt'), :headers => {})
 
@@ -33,6 +35,12 @@ describe 'Delta sync API wrapper' do
   it "should get the latest cursor" do
     cursor = @inbox.latest_cursor
     expect(cursor).to eq('cx7ln1akyj2qgdu6o5d5bakuw')
+  end
+
+  it 'returns an external Enumerator when no block is given' do
+    expect(@inbox.deltas(nth_cursor)).to be_a(Enumerator)
+    expect(@inbox.deltas(nth_cursor).map { |e,o| [e, o.id]}).to contain_exactly(
+      ['create', 'c7mllq7iag2ivlp6fxf7dhg9i'], ['delete', 'db0isjjvqez51vdjeq5lx37dk'])
   end
 
   it "should continuously query the delta sync API" do

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -1,142 +1,133 @@
 require 'event'
 
-describe 'Delta sync API wrapper' do
+describe Inbox::API do
+  subject(:inbox) { Inbox::API.new(app_id, app_secret, access_token) }
   let(:nth_cursor) { 'a9vtneydekzye7uwfumdd4iu3' }
+  let(:app_id) { 'ABC' }
+  let(:app_secret) { '123' }
+  let(:access_token) { 'UXXMOCJW-BKSLPCFI-UQAQFWLO' }
+  let(:api_url_template) { 'https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta' }
 
-  before (:each) do
-    @app_id = 'ABC'
-    @app_secret = '123'
-    @access_token = 'UXXMOCJW-BKSLPCFI-UQAQFWLO'
-    @inbox = Inbox::API.new(@app_id, @app_secret, @access_token)
-
-    @generate_url = "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta/generate_cursor"
-    stub_request(:post, @generate_url).
-         to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
-
-    @latest_url = "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta/latest_cursor"
-    stub_request(:post, @latest_url).
-         to_return(:status => 200, :body => File.read('spec/fixtures/latest_cursor.txt'), :headers => {})
-
-    @cursor_zero_url = "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta?cursor=0&exclude_folders=false"
-    stub_request(:get, @cursor_zero_url).
-         to_return(:status => 200, :body => File.read('spec/fixtures/first_cursor.txt'), :headers => {'Content-Type' => 'application/json'})
-
-    @nth_cursor_url = "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta?cursor=#{nth_cursor}&exclude_folders=false"
-    stub_request(:get, @nth_cursor_url).
-         to_return(:status => 200, :body => File.read('spec/fixtures/second_cursor.txt'), :headers => {})
-
+  def api_url(resource)
+    "#{api_url_template}#{resource}"
   end
 
-  it "should get the initial cursor" do
-    @inbox.get_cursor(timestamp=0)
-    expect(a_request(:post, @generate_url)).to have_been_made.once
-  end
+  describe 'Delta sync API wrapper' do
+    let(:generate_cursor_url) { api_url('/generate_cursor') }
+    let(:latest_cursor_url) { api_url('/latest_cursor') }
+    let(:cursor_zero_url) { api_url('?cursor=0&exclude_folders=false') }
+    let(:nth_cursor_url) { api_url('?cursor=a9vtneydekzye7uwfumdd4iu3&exclude_folders=false') }
 
-  it "should get the latest cursor" do
-    cursor = @inbox.latest_cursor
-    expect(cursor).to eq('cx7ln1akyj2qgdu6o5d5bakuw')
-  end
-
-  it 'returns an external Enumerator when no block is given' do
-    expect(@inbox.deltas(nth_cursor)).to be_a(Enumerator)
-    expect(@inbox.deltas(nth_cursor).map { |e,o| [e, o.id]}).to contain_exactly(
-      ['create', 'c7mllq7iag2ivlp6fxf7dhg9i'], ['delete', 'db0isjjvqez51vdjeq5lx37dk'])
-  end
-
-  it "should continuously query the delta sync API" do
-    count = 0
-    @inbox.deltas(timestamp=0) do |event, object|
-      expect(object.cursor).to_not be_nil
-      if event == 'create' or event == 'modify'
-        expect(object).to be_a Inbox::Message
-      elsif event == 'delete'
-        expect(object).to be_a Inbox::Event
-      end
-      count += 1
+    before do
+      stub_request(:post, generate_cursor_url).
+        to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
+      stub_request(:post, latest_cursor_url).
+        to_return(:status => 200, :body => File.read('spec/fixtures/latest_cursor.txt'), :headers => {})
+      stub_request(:get, cursor_zero_url).
+        to_return(:status => 200, :body => File.read('spec/fixtures/first_cursor.txt'), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:get, nth_cursor_url).
+        to_return(:status => 200, :body => File.read('spec/fixtures/second_cursor.txt'), :headers => {})
     end
 
-    expect(a_request(:get, @cursor_zero_url)).to have_been_made.once
-    expect(a_request(:get, @nth_cursor_url)).to have_been_made.once
-    expect(count).to eq(3)
-  end
-end
-
-describe 'Delta sync streaming API wrapper' do
-  before (:each) do
-    @app_id = 'ABC'
-    @app_secret = '123'
-    @access_token = 'UXXMOCJW-BKSLPCFI-UQAQFWLO'
-    @inbox = Inbox::API.new(@app_id, @app_secret, @access_token)
-
-    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta/streaming?cursor=0&exclude_folders=false").
-      to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
-  end
-
-  it "should continuously query the delta sync API" do
-    count = 0
-    @inbox.delta_stream(0, []) do |event, object|
-
-      expect(object.cursor).to_not be_nil
-      if event == 'create' or event == 'modify'
-        expect(object).to be_a Inbox::Message
-      elsif event == 'delete'
-        expect(object).to be_a Inbox::Event
-      end
-      count += 1
-      break if count == 3
+    it 'should get the initial cursor' do
+      inbox.get_cursor(timestamp=0)
+      expect(a_request(:post, generate_cursor_url)).to have_been_made.once
     end
 
-    expect(count).to eq(3)
-  end
-end
-
-describe 'Delta sync bogus requests' do
-  before (:each) do
-    @app_id = 'ABC'
-    @app_secret = '123'
-    @access_token = 'UXXMOCJW-BKSLPCFI-UQAQFWLO'
-    @inbox = Inbox::API.new(@app_id, @app_secret, @access_token)
-
-    stub_request(:post, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta/generate_cursor").
-         to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
-
-    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta?cursor=0&exclude_folders=false").
-         to_return(:status => 200, :body => File.read('spec/fixtures/bogus_second.txt'), :headers => {'Content-Type' => 'application/json'})
-
-    stub_request(:get, "https://UXXMOCJW-BKSLPCFI-UQAQFWLO:@api.nylas.com/delta/streaming?cursor=0&exclude_folders=false").
-      to_return(:status => 200, :body => File.read('spec/fixtures/bogus_stream.txt'), :headers => {'Content-Type' => 'application/json'})
-  end
-
-  it "delta sync should skip bogus requests" do
-    count = 0
-    @inbox.deltas(timestamp=0, []) do |event, object|
-      expect(object.cursor).to_not be_nil
-      if event == 'create' or event == 'modify'
-        expect(object).to be_a Inbox::Message
-      elsif event == 'delete'
-        expect(object).to be_a Inbox::Event
-      end
-
-      count += 1
+    it 'should get the latest cursor' do
+      cursor = inbox.latest_cursor
+      expect(cursor).to eq('cx7ln1akyj2qgdu6o5d5bakuw')
     end
 
-    expect(count).to eq(3)
-  end
-
-  it "delta stream should skip bogus requests" do
-    count = 0
-    @inbox.delta_stream(0, []) do |event, object|
-      expect(object.cursor).to_not be_nil
-      if event == 'create' or event == 'modify'
-        expect(object).to be_a Inbox::Message
-      elsif event == 'delete'
-        expect(object).to be_a Inbox::Event
-        break
-      end
-
-      count += 1
+    it 'returns an external Enumerator when no block is given' do
+      expect(inbox.deltas(nth_cursor)).to be_a(Enumerator)
+      expect(inbox.deltas(nth_cursor).map { |e,o| [e, o.id]}).to contain_exactly(
+        ['create', 'c7mllq7iag2ivlp6fxf7dhg9i'], ['delete', 'db0isjjvqez51vdjeq5lx37dk'])
     end
 
-    expect(count).to eq(1)
+    it 'should continuously query the delta sync API' do
+      count = 0
+      inbox.deltas(timestamp=0) do |event, object|
+        expect(object.cursor).to_not be_nil
+        if event == 'create' or event == 'modify'
+          expect(object).to be_a Inbox::Message
+        elsif event == 'delete'
+          expect(object).to be_a Inbox::Event
+        end
+        count += 1
+      end
+
+      expect(a_request(:get, cursor_zero_url)).to have_been_made.once
+      expect(a_request(:get, nth_cursor_url)).to have_been_made.once
+      expect(count).to eq(3)
+    end
+  end
+
+  describe 'Delta sync streaming API wrapper' do
+    before do
+      stub_request(:get, api_url('/streaming?cursor=0&exclude_folders=false')).
+        to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
+    end
+
+    it 'should continuously query the delta sync API' do
+      count = 0
+      inbox.delta_stream(0, []) do |event, object|
+
+        expect(object.cursor).to_not be_nil
+        if event == 'create' or event == 'modify'
+          expect(object).to be_a Inbox::Message
+        elsif event == 'delete'
+          expect(object).to be_a Inbox::Event
+        end
+        count += 1
+        break if count == 3
+      end
+
+      expect(count).to eq(3)
+    end
+  end
+
+  describe 'Delta sync bogus requests' do
+    before do
+      stub_request(:post, api_url('/generate_cursor')).
+        to_return(:status => 200, :body => File.read('spec/fixtures/initial_cursor.txt'), :headers => {})
+      stub_request(:get, api_url('?cursor=0&exclude_folders=false')).
+        to_return(:status => 200, :body => File.read('spec/fixtures/bogus_second.txt'), :headers => {'Content-Type' => 'application/json'})
+      stub_request(:get, api_url('/streaming?cursor=0&exclude_folders=false')).
+        to_return(:status => 200, :body => File.read('spec/fixtures/bogus_stream.txt'), :headers => {'Content-Type' => 'application/json'})
+    end
+
+    it 'delta sync should skip bogus requests' do
+      count = 0
+      inbox.deltas(timestamp=0, []) do |event, object|
+        expect(object.cursor).to_not be_nil
+        if event == 'create' or event == 'modify'
+          expect(object).to be_a Inbox::Message
+        elsif event == 'delete'
+          expect(object).to be_a Inbox::Event
+        end
+
+        count += 1
+      end
+
+      expect(count).to eq(3)
+    end
+
+    it 'delta stream should skip bogus requests' do
+      count = 0
+      inbox.delta_stream(0, []) do |event, object|
+        expect(object.cursor).to_not be_nil
+        if event == 'create' or event == 'modify'
+          expect(object).to be_a Inbox::Message
+        elsif event == 'delete'
+          expect(object).to be_a Inbox::Event
+          break
+        end
+
+        count += 1
+      end
+
+      expect(count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
This behavior is consistent with other APIs which act on a collection.

I also refactored the Delta API specs to user RSpec features and organizational patterns.