### PR TITLE
Change url constructor in url_for_authentication

### DIFF
--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -117,7 +117,7 @@ module Inbox
       arguments = {
         trial: false
       }.merge(options)
-      URI::HTTPS.build(host: @service_domain, query: arguments.to_query)
+      URI::HTTPS.build(host: @service_domain, query: arguments.to_query).to_s
     end
 
     def url_for_management

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -116,7 +116,11 @@ module Inbox
     def url_for_authentication(redirect_uri, login_hint = '', options = {})
       arguments = {
         trial: false,
-        login_hint: login_hint
+        login_hint: login_hint,
+        client_id: @app_id,
+        response_type: 'code',
+        scpe: 'email',
+        redirect_uri: redirect_uri
       }.merge(options)
       URI::HTTPS.build(host: @service_domain, query: arguments.to_query).to_s
     end

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -122,7 +122,7 @@ module Inbox
         scpe: 'email',
         redirect_uri: redirect_uri
       }.merge(options)
-      URI::HTTPS.build(host: @service_domain, query: arguments.to_query).to_s
+      URI::HTTPS.build(host: "#{@service_domain}/oauth/authorize", query: arguments.to_query).to_s
     end
 
     def url_for_management

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -3,7 +3,7 @@ require 'rest-client'
 require 'yajl'
 require 'em-http'
 require 'ostruct'
-
+require 'uri'
 require 'account'
 require 'api_account'
 require 'api_thread'
@@ -114,11 +114,10 @@ module Inbox
     end
 
     def url_for_authentication(redirect_uri, login_hint = '', options = {})
-      trialString = 'false'
-      if options[:trial] == true
-        trialString = 'true'
-      end
-      "https://#{@service_domain}/oauth/authorize?client_id=#{@app_id}&trial=#{trialString}&response_type=code&scope=email&login_hint=#{login_hint}&redirect_uri=#{redirect_uri}"
+      arguments = {
+        trial: false
+      }.merge(options)
+      URI::HTTPS.build(host: @service_domain, query: arguments.to_query)
     end
 
     def url_for_management

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -115,7 +115,8 @@ module Inbox
 
     def url_for_authentication(redirect_uri, login_hint = '', options = {})
       arguments = {
-        trial: false
+        trial: false,
+        login_hint: login_hint
       }.merge(options)
       URI::HTTPS.build(host: @service_domain, query: arguments.to_query).to_s
     end


### PR DESCRIPTION
You can't pass `state` argument with this method (which should be possible according to your docs). 

Constructing url with string interpolation is not really readable. I believe using URI helpers will make it much more easier and fun to maintain. 

It needs specs probably, I'm not sure if `to_s` casting is necessary  but I'm just giving you idea, maybe I will polish it a bit later.