### PR TITLE
Include state param in authentication URL

### DIFF
--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -123,6 +123,9 @@ module Inbox
         'login_hint' => login_hint,
         'redirect_uri' => redirect_uri
       }
+      if state = options[:state]
+        query_params['state'] = state
+      end
       query_params = URI.encode_www_form(query_params)
       "https://#{@service_domain}/oauth/authorize?#{query_params}"
     end

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -3,6 +3,7 @@ require 'rest-client'
 require 'yajl'
 require 'em-http'
 require 'ostruct'
+require 'uri'
 
 require 'account'
 require 'api_account'
@@ -113,11 +114,17 @@ module Inbox
     end
 
     def url_for_authentication(redirect_uri, login_hint = '', options = {})
-      trialString = 'false'
-      if options[:trial] == true
-        trialString = 'true'
-      end
-      "https://#{@service_domain}/oauth/authorize?client_id=#{@app_id}&trial=#{trialString}&response_type=code&scope=email&login_hint=#{login_hint}&redirect_uri=#{redirect_uri}"
+      trial_string = options[:trial] ? 'true' : 'false'
+      query_params = {
+        'client_id' => @app_id,
+        'trial' => trial_string,
+        'response_type' => 'code',
+        'scope' => 'email',
+        'login_hint' => login_hint,
+        'redirect_uri' => redirect_uri
+      }
+      query_params = URI.encode_www_form(query_params)
+      "https://#{@service_domain}/oauth/authorize?#{query_params}"
     end
 
     def url_for_management

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -57,6 +57,11 @@ describe 'Inbox' do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com', {trial: true})
       expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben%40nylas.com&redirect_uri=http%3A%2F%2Fredirect.uri")
     end
+
+    it "should include the state if one is provided" do
+      url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com', {state: "somestatestring"})
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben%40nylas.com&redirect_uri=http%3A%2F%2Fredirect.uri&state=somestatestring")
+    end
   end
 
   describe "#self.interpret_response" do

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -45,17 +45,17 @@ describe 'Inbox' do
 
     it "should return the OAuth authorize endpoint with the provided redirect_uri" do
       url = @inbox.url_for_authentication('http://redirect.uri')
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http://redirect.uri")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http%3A%2F%2Fredirect.uri")
     end
 
     it "should include the login_hint if one is provided" do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com')
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben%40nylas.com&redirect_uri=http%3A%2F%2Fredirect.uri")
     end
 
     it "should use trial=true if the trial flag is passed" do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com', {trial: true})
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben%40nylas.com&redirect_uri=http%3A%2F%2Fredirect.uri")
     end
   end
 


### PR DESCRIPTION
* Encodes query parameters using `URI` instead of string interpolation
* Includes state query param as document [here](https://nylas.com/docs/#server_side_explicit_flow)