### PR TITLE
"state" param for OAuth

### DIFF
--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -113,11 +113,16 @@ module Inbox
     end
 
     def url_for_authentication(redirect_uri, login_hint = '', options = {})
-      trialString = 'false'
-      if options[:trial] == true
-        trialString = 'true'
-      end
-      "https://#{@service_domain}/oauth/authorize?client_id=#{@app_id}&trial=#{trialString}&response_type=code&scope=email&login_hint=#{login_hint}&redirect_uri=#{redirect_uri}&state=#{options[:state]}"
+      params = {
+        :client_id     => @app_id,
+        :trial         => options[:trial] ? 'true' : 'false',
+        :response_type => 'code',
+        :scope         => 'email',
+        :login_hint    => login_hint,
+        :redirect_uri  => redirect_uri,
+        :state         => options[:state],
+      }.reject { |_, v| v.nil? || /\A[[:space:]]*\z/ === v }.map { |k, v| "#{k}=#{v}" }.join('&')
+      "https://#{@service_domain}/oauth/authorize?#{params}"
     end
 
     def url_for_management

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -117,7 +117,7 @@ module Inbox
       if options[:trial] == true
         trialString = 'true'
       end
-      "https://#{@service_domain}/oauth/authorize?client_id=#{@app_id}&trial=#{trialString}&response_type=code&scope=email&login_hint=#{login_hint}&redirect_uri=#{redirect_uri}"
+      "https://#{@service_domain}/oauth/authorize?client_id=#{@app_id}&trial=#{trialString}&response_type=code&scope=email&login_hint=#{login_hint}&redirect_uri=#{redirect_uri}&state=#{options[:state]}"
     end
 
     def url_for_management

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -45,17 +45,22 @@ describe 'Inbox' do
 
     it "should return the OAuth authorize endpoint with the provided redirect_uri" do
       url = @inbox.url_for_authentication('http://redirect.uri')
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http://redirect.uri")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http://redirect.uri&state=")
     end
 
     it "should include the login_hint if one is provided" do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com')
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri&state=")
     end
 
     it "should use trial=true if the trial flag is passed" do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com', {trial: true})
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri&state=")
+    end
+
+    it "should use the state if it is present" do
+      url = @inbox.url_for_authentication('http://redirect.uri', nil, {state: 'preserveme'})
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http://redirect.uri&state=preserveme")
     end
   end
 

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -45,22 +45,22 @@ describe 'Inbox' do
 
     it "should return the OAuth authorize endpoint with the provided redirect_uri" do
       url = @inbox.url_for_authentication('http://redirect.uri')
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http://redirect.uri&state=")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&redirect_uri=http://redirect.uri")
     end
 
     it "should include the login_hint if one is provided" do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com')
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri&state=")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri")
     end
 
     it "should use trial=true if the trial flag is passed" do
       url = @inbox.url_for_authentication('http://redirect.uri', 'ben@nylas.com', {trial: true})
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri&state=")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=true&response_type=code&scope=email&login_hint=ben@nylas.com&redirect_uri=http://redirect.uri")
     end
 
     it "should use the state if it is present" do
       url = @inbox.url_for_authentication('http://redirect.uri', nil, {state: 'preserveme'})
-      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&login_hint=&redirect_uri=http://redirect.uri&state=preserveme")
+      expect(url).to eq("https://api.nylas.com/oauth/authorize?client_id=#{@app_id}&trial=false&response_type=code&scope=email&redirect_uri=http://redirect.uri&state=preserveme")
     end
   end
 


### PR DESCRIPTION
Added state param (from options hash) to url_for_authentication method to help pass contextual information around with OAuth requests.

This is available in the Nylas API here: https://nylas.com/docs/platform?ruby#server_side_explicit_flow but it is not exposed in the ruby gem which is what this PR addresses.