### PR TITLE
Allow limit and offset filters for collections

### DIFF
--- a/lib/restful_model_collection.rb
+++ b/lib/restful_model_collection.rb
@@ -15,8 +15,8 @@ module Inbox
     def each
       return enum_for(:each) unless block_given?
 
-      @filters[:offset] = 0
-      @filters[:limit] = 100
+      @filters[:offset] = 0 unless @filters.key?(:offset)
+      @filters[:limit] = 100 unless @filters.key?(:limit)
 
       finished = false
       while (!finished) do
@@ -65,16 +65,16 @@ module Inbox
       finished = false
       chunk_size = 100
 
-      if limit < chunk_size
-        chunk_size = limit
-      end
-
       while (!finished && accumulated.length < limit) do
-        #results = get_model_collection(offset + accumulated.length, chunk_size)
         @filters[:offset] = offset + accumulated.length
-        # TODO the below means that if we call range(0, 150) we will make two calls for
-        # 100 elements each, then cut off the last 50. This could be optimized.
+
+        # if the total items we want, minus how many we already have, is fewer than we plan to grab...
+        remaining = limit - accumulated.length
+        if remaining < chunk_size
+          chunk_size = remaining
+        end
         @filters[:limit] = chunk_size
+
         results = get_model_collection()
         accumulated = accumulated.concat(results)
 

--- a/lib/restful_model_collection.rb
+++ b/lib/restful_model_collection.rb
@@ -138,8 +138,11 @@ module Inbox
 
     def get_model_collection(offset = 0, limit = 100)
       filters = @filters.clone
-      filters[:offset] = offset
-      filters[:limit] = limit
+
+      # If filters have already been set for limit or offset, ignore the
+      # values passed in above. (i.e., the 'where' function has precedence)
+      filters[:limit] = limit unless filters.key?(:limit)
+      filters[:offset] = offset unless filters.key?(:offset)
       models = []
 
       RestClient.get(url, :params => filters){ |response,request,result|

--- a/lib/restful_model_collection.rb
+++ b/lib/restful_model_collection.rb
@@ -144,9 +144,6 @@ module Inbox
 
     def get_model_collection
       filters = @filters.clone
-
-      # If filters have already been set for limit or offset, ignore the
-      # values passed in above. (i.e., the 'where' function has precedence)
       models = []
 
       RestClient.get(url, :params => filters){ |response,request,result|

--- a/spec/fixtures/messages_reply_100.txt
+++ b/spec/fixtures/messages_reply_100.txt
@@ -1,0 +1,4602 @@
+[
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "another string",
+    "cc": [],
+    "date": 1452708479,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "Another short snippet",
+    "starred": false,
+    "subject": "Snappy subject",
+    "thread_id": "4gm1n96l058c3pyda1saroiz0",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  }
+]

--- a/spec/fixtures/messages_reply_2.txt
+++ b/spec/fixtures/messages_reply_2.txt
@@ -1,0 +1,94 @@
+[
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "some string",
+    "cc": [],
+    "date": 1452708475,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "This is a short snippet of the message",
+    "starred": false,
+    "subject": "Look sir, droids!",
+    "thread_id": "7uck6d29wqg3gc7coc3cuo58w",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  },
+  {
+    "account_id": "agu8c88u9ikf9x1yvt0r4zfrn",
+    "bcc": [],
+    "body": "another string",
+    "cc": [],
+    "date": 1452708479,
+    "events": [],
+    "files": [],
+    "from": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Nylas Team"
+      }
+    ],
+    "id": "2pnmgnlgvgl0szkicp68kzv5",
+    "labels": [
+      {
+        "display_name": "Inbox",
+        "id": "ancobq2c59ig25o92lfwp2afs",
+        "name": "inbox"
+      },
+      {
+        "display_name": "All Mail",
+        "id": "83jicmy7xhqsy6rvy4hmit3tx",
+        "name": "all"
+      }
+    ],
+    "object": "message",
+    "reply_to": [
+      {
+        "email": "hello@nylas.com",
+        "name": "Hello Nylas"
+      }
+    ],
+    "snippet": "Another short snippet",
+    "starred": false,
+    "subject": "Snappy subject",
+    "thread_id": "4gm1n96l058c3pyda1saroiz0",
+    "to": [
+      {
+        "email": "someone@nylas.com",
+        "name": "someone@nylas.com"
+      }
+    ],
+    "unread": true
+  }
+]

--- a/spec/restful_model_collection_spec.rb
+++ b/spec/restful_model_collection_spec.rb
@@ -41,4 +41,51 @@ describe Nylas::RestfulModelCollection do
       expect { api.threads.count }.to raise_error(Inbox::AccessDenied)
     end
   end
+
+  describe '#where' do
+    it 'should be able to limit the returned number of entities' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?limit=2").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:limit => 2)
+    end
+
+    it 'should be able to offset the returned entities' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?offset=2").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:offset => 2)
+    end
+
+    it 'should be able to both limit and offset returned entities' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?offset=3&limit=2").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:limit => 2, :offset => 3)
+    end
+
+    it 'should be able to return messages contained in a specific folder' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?in=inbox").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:in => 'inbox')
+    end
+
+    it 'should be able to return messages sent to a specific address' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?to=someone%40nylas%2ecom").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:to => 'someone@nylas.com')
+    end
+  end
 end

--- a/spec/restful_model_collection_spec.rb
+++ b/spec/restful_model_collection_spec.rb
@@ -128,4 +128,13 @@ describe Nylas::RestfulModelCollection do
         api.messages.where(:to => 'someone@nylas.com')
     end
   end
+
+  it 'can execute complex queries combining range and where' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?limit=10&offset=5&to=someone%40nylas%2ecom").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:to => 'someone@nylas.com').range(5, 10)
+  end
 end

--- a/spec/restful_model_collection_spec.rb
+++ b/spec/restful_model_collection_spec.rb
@@ -45,6 +45,23 @@ describe Nylas::RestfulModelCollection do
       expect(stub2).to have_been_requested
     end
 
+    it 'requests only the number of items required' do
+      stub1 = stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=100&offset=0").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_100.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+      stub2 = stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=50&offset=100").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+      api.threads.range(0, 150)
+
+      expect(stub1).to have_been_requested
+      expect(stub2).to have_been_requested
+    end
+
     it 'limits the number of returned items to the requested range' do
       stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=50&offset=0").
         to_return(:status => 200,
@@ -136,5 +153,25 @@ describe Nylas::RestfulModelCollection do
                   :headers => {'Content-Type' => 'application/json'})
 
         api.messages.where(:to => 'someone@nylas.com').range(5, 10)
+  end
+
+  it 'can chain each with range to form complex queries' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?limit=10&offset=5").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.range(5, 10).each do |a|
+        end
+  end
+
+  it 'can chain each with where to form complex queries' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/messages?limit=10&offset=5&to=someone%40nylas%2ecom").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+        api.messages.where(:to => 'someone@nylas.com', :limit => 10, :offset => 5).each do |a|
+        end
   end
 end

--- a/spec/restful_model_collection_spec.rb
+++ b/spec/restful_model_collection_spec.rb
@@ -24,6 +24,46 @@ describe Nylas::RestfulModelCollection do
     end
   end
 
+  describe '#range' do
+    before do
+    end
+
+    it 'can make multiple requests to retreive large numbers of items' do
+      stub1 = stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=100&offset=0").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_100.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+      stub2 = stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=100&offset=100").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_2.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+      api.threads.range(0, 200)
+
+      expect(stub1).to have_been_requested
+      expect(stub2).to have_been_requested
+    end
+
+    it 'limits the number of returned items to the requested range' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=50&offset=0").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_100.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+      api.threads.range(0, 50)
+    end
+
+    it 'can offset the requested items' do
+      stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?limit=50&offset=20").
+        to_return(:status => 200,
+                  :body => File.read('spec/fixtures/messages_reply_100.txt'),
+                  :headers => {'Content-Type' => 'application/json'})
+
+      api.threads.range(20, 50)
+    end
+  end
+
   describe '#count' do
     it 'should return number of entities' do
       stub_request(:get, "https://#{access_token}:@api.nylas.com/threads?view=count").


### PR DESCRIPTION
The limit and offset filters, which were set correctly in the `where`
function, were being overriden in the `get_model_collection` function
by the offset and limit parameters passed to it (with defaults). The
function now checks if limit or offset are already present in the list
of filters before applying its own.

Also includes new tests of the `where` function.

Close issue #66.