### PR TITLE
Add `include_types` option to filter deltas

### DIFF
--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -258,13 +258,13 @@ module Inbox
     def _build_types_list(types)
       type_string = ""
       types.each do |value|
-        count = 0
         if OBJECTS_TABLE.has_value?(value)
           param_name = OBJECTS_TABLE.key(value)
           type_string += "#{param_name},"
         end
       end
 
+      # remove the dangling comma on the end of the string
       type_string = type_string[0..-2]
     end
 
@@ -279,10 +279,6 @@ module Inbox
         filter_string = _build_exclude_types(exclude_types)
       elsif include_types.any?
         filter_string = _build_include_types(include_types)
-      end
-
-      if include_types.any?
-        include_string = _build_include_types(include_types)
       end
 
       # loop and yield deltas until we've come to the end.
@@ -339,9 +335,7 @@ module Inbox
 
       if exclude_types.any?
         filter_string = _build_exclude_types(exclude_types)
-      end
-
-      if include_types.any?
+      elsif include_types.any?
         filter_string = _build_include_types(include_types)
       end
 

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -258,13 +258,13 @@ module Inbox
     def _build_types_list(types)
       type_string = ""
       types.each do |value|
+        count = 0
         if OBJECTS_TABLE.has_value?(value)
           param_name = OBJECTS_TABLE.key(value)
           type_string += "#{param_name},"
         end
       end
 
-      # remove the dangling comma on the end of the string
       type_string = type_string[0..-2]
     end
 
@@ -279,6 +279,10 @@ module Inbox
         filter_string = _build_exclude_types(exclude_types)
       elsif include_types.any?
         filter_string = _build_include_types(include_types)
+      end
+
+      if include_types.any?
+        include_string = _build_include_types(include_types)
       end
 
       # loop and yield deltas until we've come to the end.
@@ -326,15 +330,8 @@ module Inbox
       end
     end
 
-    def delta_stream(cursor, options={})
+    def delta_stream(cursor, exclude_types=[], include_types=[], timeout=0, expanded_view=false)
       raise 'Please provide a block for receiving the delta objects' if !block_given?
-
-      raise 'Options argument must be a hash' unless options.is_a? Hash
-
-      exclude_types = options[:exclude_types] || []
-      include_types = options[:include_types] || []
-      timeout = options[:timeout] || 0
-      expanded_view = options[:expanded_view] || false
 
       if exclude_types.any? and include_types.any?
         raise "Cannot pass both include_types and exclude_types parameters"
@@ -342,7 +339,9 @@ module Inbox
 
       if exclude_types.any?
         filter_string = _build_exclude_types(exclude_types)
-      elsif include_types.any?
+      end
+
+      if include_types.any?
         filter_string = _build_include_types(include_types)
       end
 

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -326,8 +326,15 @@ module Inbox
       end
     end
 
-    def delta_stream(cursor, exclude_types=[], include_types=[], timeout=0, expanded_view=false)
+    def delta_stream(cursor, options={})
       raise 'Please provide a block for receiving the delta objects' if !block_given?
+
+      raise 'Options argument must be a hash' unless options.is_a? Hash
+
+      exclude_types = options[:exclude_types] || []
+      include_types = options[:include_types] || []
+      timeout = options[:timeout] || 0
+      expanded_view = options[:expanded_view] || false
 
       if exclude_types.any? and include_types.any?
         raise "Cannot pass both include_types and exclude_types parameters"

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -258,13 +258,13 @@ module Inbox
     def _build_types_list(types)
       type_string = ""
       types.each do |value|
-        count = 0
         if OBJECTS_TABLE.has_value?(value)
           param_name = OBJECTS_TABLE.key(value)
           type_string += "#{param_name},"
         end
       end
 
+      # remove the dangling comma on the end of the string
       type_string = type_string[0..-2]
     end
 
@@ -276,16 +276,14 @@ module Inbox
       end
 
       if exclude_types.any?
-        exclude_string = _build_exclude_types(exclude_types)
-      end
-
-      if include_types.any?
-        include_string = _build_include_types(include_types)
+        filter_string = _build_exclude_types(exclude_types)
+      elsif include_types.any?
+        filter_string = _build_include_types(include_types)
       end
 
       # loop and yield deltas until we've come to the end.
       loop do
-        path = self.url_for_path("/delta?exclude_folders=false&cursor=#{cursor}#{exclude_string}#{include_string}")
+        path = self.url_for_path("/delta?exclude_folders=false&cursor=#{cursor}#{filter_string}")
         if expanded_view
           path += '&view=expanded'
         end
@@ -337,9 +335,7 @@ module Inbox
 
       if exclude_types.any?
         filter_string = _build_exclude_types(exclude_types)
-      end
-
-      if include_types.any?
+      elsif include_types.any?
         filter_string = _build_include_types(include_types)
       end
 

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -60,7 +60,7 @@ describe Inbox::API do
       stub_request(:get, api_url("/streaming?cursor=#{cursor}&exclude_folders=false&exclude_types=thread")).
         to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
 
-      inbox.delta_stream(cursor, exclude_types=[Nylas::Thread]) do |event, object|
+      inbox.delta_stream(cursor, {:exclude_types => [Nylas::Thread]}) do |event, object|
         break
       end
     end
@@ -71,7 +71,7 @@ describe Inbox::API do
       stub_request(:get, api_url("/streaming?cursor=#{cursor}&exclude_folders=false&include_types=thread")).
         to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
 
-      inbox.delta_stream(cursor, exclude_types=[], include_types=[Nylas::Thread]) do |event, object|
+      inbox.delta_stream(cursor, {:exclude_types => [], :include_types => [Nylas::Thread]}) do |event, object|
         break
       end
     end
@@ -80,7 +80,7 @@ describe Inbox::API do
       cursor = inbox.latest_cursor
 
       expect {
-        inbox.delta_stream(cursor, include_types=[Nylas::Thread], exclude_types=[Nylas::Thread]) do |event, object|
+        inbox.delta_stream(cursor, {:include_types => [Nylas::Thread], :exclude_types => [Nylas::Thread]}) do |event, object|
           break
         end
       }.to raise_error(RuntimeError)
@@ -95,17 +95,13 @@ describe Inbox::API do
 
     it 'should continuously query the delta sync API' do
       count = 0
-      EM.run do
-        inbox.delta_stream(0) do |event, object|
+      inbox.delta_stream(0) do |event, object|
 
-          expect(object.cursor).to_not be_nil
-          if event == 'create' or event == 'modify'
-            expect(object).to be_a Inbox::Message
-          elsif event == 'delete'
-            expect(object).to be_a Inbox::Event
-          end
-          count += 1
-          EM.stop if count == 3
+        expect(object.cursor).to_not be_nil
+        if event == 'create' or event == 'modify'
+          expect(object).to be_a Inbox::Message
+        elsif event == 'delete'
+          expect(object).to be_a Inbox::Event
         end
       end
 
@@ -141,16 +137,13 @@ describe Inbox::API do
 
     it 'delta stream should skip bogus requests' do
       count = 0
-      EventMachine.run do
-        inbox.delta_stream(0) do |event, object|
-          expect(object.cursor).to_not be_nil
-          if event == 'create' or event == 'modify'
-            expect(object).to be_a Inbox::Message
-            count += 1
-          elsif event == 'delete'
-            expect(object).to be_a Inbox::Event
-            EM.stop
-          end
+      inbox.delta_stream(0) do |event, object|
+        expect(object.cursor).to_not be_nil
+        if event == 'create' or event == 'modify'
+          expect(object).to be_a Inbox::Message
+        elsif event == 'delete'
+          expect(object).to be_a Inbox::Event
+          break
         end
       end
 

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -60,8 +60,10 @@ describe Inbox::API do
       stub_request(:get, api_url("/streaming?cursor=#{cursor}&exclude_folders=false&exclude_types=thread")).
         to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
 
-      inbox.delta_stream(cursor, exclude_types=[Nylas::Thread]) do |event, object|
-        break
+      EM.run do
+        inbox.delta_stream(cursor, {:exclude_types => [Nylas::Thread]}) do |event, object|
+          EM.stop
+        end
       end
     end
 
@@ -71,8 +73,10 @@ describe Inbox::API do
       stub_request(:get, api_url("/streaming?cursor=#{cursor}&exclude_folders=false&include_types=thread")).
         to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
 
-      inbox.delta_stream(cursor, exclude_types=[], include_types=[Nylas::Thread]) do |event, object|
-        break
+      EM.run do
+        inbox.delta_stream(cursor, {:exclude_types => [], :include_types => [Nylas::Thread]}) do |event, object|
+          EM.stop
+        end
       end
     end
 
@@ -80,7 +84,7 @@ describe Inbox::API do
       cursor = inbox.latest_cursor
 
       expect {
-        inbox.delta_stream(cursor, include_types=[Nylas::Thread], exclude_types=[Nylas::Thread]) do |event, object|
+        inbox.delta_stream(cursor, {:include_types => [Nylas::Thread], :exclude_types => [Nylas::Thread]}) do |event, object|
           break
         end
       }.to raise_error(RuntimeError)
@@ -96,7 +100,7 @@ describe Inbox::API do
     it 'should continuously query the delta sync API' do
       count = 0
       EM.run do
-        inbox.delta_stream(0, []) do |event, object|
+        inbox.delta_stream(0) do |event, object|
 
           expect(object.cursor).to_not be_nil
           if event == 'create' or event == 'modify'
@@ -142,7 +146,7 @@ describe Inbox::API do
     it 'delta stream should skip bogus requests' do
       count = 0
       EventMachine.run do
-        inbox.delta_stream(0, []) do |event, object|
+        inbox.delta_stream(0) do |event, object|
           expect(object.cursor).to_not be_nil
           if event == 'create' or event == 'modify'
             expect(object).to be_a Inbox::Message

--- a/spec/deltas_spec.rb
+++ b/spec/deltas_spec.rb
@@ -60,10 +60,8 @@ describe Inbox::API do
       stub_request(:get, api_url("/streaming?cursor=#{cursor}&exclude_folders=false&exclude_types=thread")).
         to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
 
-      EM.run do
-        inbox.delta_stream(cursor, {:exclude_types => [Nylas::Thread]}) do |event, object|
-          EM.stop
-        end
+      inbox.delta_stream(cursor, exclude_types=[Nylas::Thread]) do |event, object|
+        break
       end
     end
 
@@ -73,10 +71,8 @@ describe Inbox::API do
       stub_request(:get, api_url("/streaming?cursor=#{cursor}&exclude_folders=false&include_types=thread")).
         to_return(:status => 200, :body => File.read('spec/fixtures/delta_stream.txt'), :headers => {'Content-Type' => 'application/json'})
 
-      EM.run do
-        inbox.delta_stream(cursor, {:exclude_types => [], :include_types => [Nylas::Thread]}) do |event, object|
-          EM.stop
-        end
+      inbox.delta_stream(cursor, exclude_types=[], include_types=[Nylas::Thread]) do |event, object|
+        break
       end
     end
 
@@ -84,7 +80,7 @@ describe Inbox::API do
       cursor = inbox.latest_cursor
 
       expect {
-        inbox.delta_stream(cursor, {:include_types => [Nylas::Thread], :exclude_types => [Nylas::Thread]}) do |event, object|
+        inbox.delta_stream(cursor, include_types=[Nylas::Thread], exclude_types=[Nylas::Thread]) do |event, object|
           break
         end
       }.to raise_error(RuntimeError)


### PR DESCRIPTION
`include_types` is now a valid parameter for both `delta_stream` and
`deltas`. Note that positional parameters for those two functions are
now in a different order after the addition of the `include_types`
parameter.

Closes #68.
