### PR TITLE
Refactor `delta_stream` to allow multiple streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Upcoming Release
 
 * Remove get_cursor method that calls deprecated generate_cursor endpoint
+* Modify `delta_stream method` to remove built-in `EventMachine.run` block and allow for multiple streams. `delta_stream` must now be called from inside an `EventMachine.run` block
 
 ### 1.3.0 / 2015-12-07
 

--- a/README.md
+++ b/README.md
@@ -476,15 +476,10 @@ EventMachine.run do
 end
 ```
 
-In order to receive streams from multiple accounts, simply create multiple API handles (one for each account), then open a `delta_stream` for each of them.
+To receive streams from multiple accounts, call `delta_stream` for each of them inside an `EventMachine.run` block.
 
 ```ruby
-api_handles = []
-nylas.accounts.each {
-  |a|
-  account_id = a.id
-  api_handles.push(Nylas::API.new(nil, nil, account_id, 'http://localhost:5555/'))
-}
+api_handles = [] # a list of Nylas::API objects
 
 EventMachine.run do
   api_handles.each do |a|

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -354,6 +354,10 @@ module Inbox
         parser << chunk
       end
 
+      http.errback do
+        raise UnexpectedResponse.new http.error
+      end
+
     end
   end
 end

--- a/lib/inbox.rb
+++ b/lib/inbox.rb
@@ -347,15 +347,13 @@ module Inbox
         end
       end
 
-      EventMachine.run do
-        http = EventMachine::HttpRequest.new(path, :connect_timeout => 0, :inactivity_timeout => timeout).get(:keepalive => true)
-        http.stream do |chunk|
-          parser << chunk
-        end
-        http.errback do
-          raise UnexpectedResponse.new http.error
-        end
+      http = EventMachine::HttpRequest.new(path, :connect_timeout => 0, :inactivity_timeout => timeout).get(:keepalive => true)
+
+      # set a callback on the HTTP stream that parses incoming chunks as they come in
+      http.stream do |chunk|
+        parser << chunk
       end
+
     end
   end
 end


### PR DESCRIPTION
`delta_stream` is a blocking call, and previously had no good way to run
in parallel in order to stream several accounts at once.

EventMachine's run loop was removed from the library so that SDK
implementers can create multiple streams inside their own EventMachine
run block.

`delta_stream` must be wrapped in an `EventMachine.run` block in order
to function, whereas before it could be called plain. Two tests have
been refactored to reflect this, and documentation has been updated.