### PR TITLE
Add ability to get collection of expanded messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gem install nylas
 
 ### Sinatra App
 
-A small example of a Sintra app is included in the `examples/sinatra` directory. You can check-out the `README.md` in the sinatra folder to learn more about the example
+A small example of a Sinatra app is included in the `examples/sinatra` directory. You can check-out the `README.md` in the sinatra folder to learn more about the example
 
 ```
 cd examples/sinatra
@@ -236,6 +236,11 @@ thread.messages.each do |message|
   puts message.subject
 end
 
+# List expanded messages (with Message-Id, In-Reply-To and References fields)
+thread.messages(expanded: true).each do |message|
+  puts message.subject
+end
+
 # List all messages sent by Ben where Helena was cc'ed:
 thread.messages.where(:from => 'ben@nylas.com').each.select { |t|
   t.cc.any? {|p| p['email'] == 'helena@nylas.com' }
@@ -306,6 +311,48 @@ msg.star!
 msg.unstar!
 ```
 
+#### Getting a message's Message-Id, References and In-Reply-To headers
+
+If you've building your own threading solution, you'll probably need access to a handful of headers like
+`Message-Id`, `In-Reply-To` and `References`. Here's how to access them:
+
+```ruby
+msg = nylas.messages.first
+expanded_message = msg.expanded
+puts expanded_message.message_id
+puts expanded_message.references
+puts expanded_message.in_reply_to
+```
+
+The better way (because only one http request will be made)
+
+```ruby
+expanded_message = nylas.messages(expanded: true).first
+
+puts expanded_message.message_id
+puts expanded_message.references
+puts expanded_message.in_reply_to
+```
+
+
+#### Getting a collection of the messages with Message-Id, References and In-Reply-To headers
+
+```ruby
+expanded_messages = nylas.messages(expanded: true).each do |message|
+  puts message.message_id
+  puts message.references
+  puts message.in_reply_to
+end
+```
+
+#### Getting the raw contents of a message
+
+It's possible to access the unprocessed contents of a message using the raw method:
+
+```ruby
+raw_contents = message.raw
+```
+
 ### Working with API Objects
 
 #### Filtering
@@ -355,27 +402,6 @@ puts contact.raw_json #=>
 #   "account_id": "aqau8ta87ndh6cwv0o3ajfoo2",
 #   "object": "contact"
 # }
-```
-
-#### Getting a message's Message-Id, References and In-Reply-To headers
-
-If you've building your own threading solution, you'll probably need access to a handful of headers like
-`Message-Id`, `In-Reply-To` and `References`. Here's how to access them:
-
-```ruby
-msg = nylas.messages.first
-expanded_message = msg.expanded
-puts expanded_message.message_id
-puts expanded_message.references
-puts expanded_message.in_reply_to
-```
-
-#### Getting the raw contents of a message
-
-It's possible to access the unprocessed contents of a message using the raw method:
-
-```ruby
-raw_contents = message.raw
 ```
 
 ### Creating and Sending Drafts

--- a/lib/api_thread.rb
+++ b/lib/api_thread.rb
@@ -41,8 +41,16 @@ module Nylas
       end
     end
 
-    def messages
-      @messages ||= RestfulModelCollection.new(Message, @_api, {:thread_id=>@id})
+    def messages(expanded: false)
+      @messages ||= Hash.new do |h, is_expanded|
+        h[is_expanded] = \
+          if is_expanded
+            RestfulModelCollection.new(ExpandedMessage, @_api, thread_id: @id, view: 'expanded')
+          else
+            RestfulModelCollection.new(Message, @_api, thread_id: @id)
+          end
+      end
+      @messages[expanded]
     end
 
     def drafts

--- a/lib/expanded_message.rb
+++ b/lib/expanded_message.rb
@@ -1,0 +1,20 @@
+module Nylas
+  class ExpandedMessage < Message
+    # override inflate because expanded messages have some special parameters
+    # like In-Reply-To and Message-Id.
+    attr_reader :message_id
+    attr_reader :in_reply_to
+    attr_reader :references
+
+    def self.collection_name
+      'messages'
+    end
+
+    def inflate(json)
+      super
+      @message_id = json['headers']['Message-Id']
+      @in_reply_to = json['headers']['In-Reply-To']
+      @references = json['headers']['References']
+    end
+  end
+end

--- a/lib/message.rb
+++ b/lib/message.rb
@@ -99,19 +99,4 @@ module Nylas
 
     end
   end
-
-  class ExpandedMessage < Message
-    # override inflate because expanded messages have some special parameters
-    # like In-Reply-To and Message-Id.
-    attr_reader :message_id
-    attr_reader :in_reply_to
-    attr_reader :references
-
-    def inflate(json)
-      super
-      @message_id = json['headers']['Message-Id']
-      @in_reply_to = json['headers']['In-Reply-To']
-      @references = json['headers']['References']
-    end
-  end
 end

--- a/spec/expanded_message_spec.rb
+++ b/spec/expanded_message_spec.rb
@@ -1,0 +1,7 @@
+describe Nylas::ExpandedMessage do
+  describe '.collection_name' do
+    it 'equals to "messages"' do
+      expect(Nylas::Message.collection_name).to eq('messages')
+    end
+  end
+end

--- a/spec/nylas_spec.rb
+++ b/spec/nylas_spec.rb
@@ -1,0 +1,23 @@
+describe Nylas::API do
+  let(:api) { Nylas::API.new('app_id', 'app_secret', 'key') }
+
+  describe '#messages' do
+    context 'when expanded param is true' do
+      it 'requests expanded messages' do
+        stub_request(:get, 'https://api.nylas.com/messages?limit=100&offset=0&view=expanded')
+          .to_return(status: 200, body: '[]', headers: {})
+
+        api.messages(expanded: true).all
+      end
+    end
+
+    context 'when expanded param is false' do
+      it 'requests messages' do
+        stub_request(:get, 'https://api.nylas.com/messages?limit=100&offset=0')
+          .to_return(status: 200, body: '[]', headers: {})
+
+        api.messages.all
+      end
+    end
+  end
+end

--- a/spec/thread_spec.rb
+++ b/spec/thread_spec.rb
@@ -9,6 +9,32 @@ describe Nylas::Thread do
     @inbox = Nylas::API.new(@app_id, @app_secret, @access_token)
   end
 
+  describe '#messages' do
+    let(:thread) { Nylas::Thread.new(@inbox, nil) }
+
+    before do
+      thread.id = 'thread_id'
+    end
+
+    context 'when expanded param is true' do
+      it 'requests expanded messages' do
+        stub_request(:get, "https://api.nylas.com/messages?limit=100&offset=0&thread_id=#{thread.id}&view=expanded")
+          .to_return(status: 200, body: '[]', headers: {})
+
+        thread.messages(expanded: true).all
+      end
+    end
+
+    context 'when expanded param is false' do
+      it 'requests messages' do
+        stub_request(:get, "https://api.nylas.com/messages?limit=100&offset=0&thread_id=#{thread.id}")
+          .to_return(status: 200, body: '[]', headers: {})
+
+        thread.messages.all
+      end
+    end
+  end
+
   describe "#as_json" do
     it "only includes labels/folder info" do
       thr = Nylas::Thread.new(@inbox, nil)


### PR DESCRIPTION
Sometimes you need to get collection of expanded messages and it's not efficient to do

```ruby
api.messages.each do |message|
  expanded_message = message.expanded
  puts expanded_message.message_id
end
```

because it produces an additional query to the Nylas API for each `expanded` method call.

This PR adds ability to request the collection of expanded messages, like

```ruby
api.messages(expanded: true).each do |expanded_message|
  puts expanded_message.message_id
end
```

or 

```ruby
thread.messages(expanded: true).each do |expanded_message|
  puts expanded_message.message_id
end
```

It also allows getting single expanded message in one API call with

```ruby
expanded_message = api.messages(expanded: true).find(id)
```

which is more efficient than getting it with two queries

```ruby
message = api.messages.find(id) # gets a message
expanded_message = message.expended # gets an expanded message
```