### PR TITLE
Update 'rest-client' to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rest-client', '~> 1.6'
+gem 'rest-client', '>= 1.6'
 gem 'yajl-ruby', '~> 1.2', '>= 1.2.1', platform: :ruby
 gem 'em-http-request', '~> 1.1', '>= 1.1.3', platform: :ruby
 

--- a/spec/restful_model_spec.rb
+++ b/spec/restful_model_spec.rb
@@ -48,7 +48,7 @@ describe 'RestfulModel' do
 
     it "should issue a DELETE when calling delete" do
       url = 'http://localhost:5555/messages/1'
-      message_url = stub_request(:delete, url)
+      stub_request(:delete, url)
       r = Nylas::RestfulModel.new(@api)
       allow(r).to receive_messages(:url => url)
 
@@ -58,8 +58,8 @@ describe 'RestfulModel' do
 
     it "should pass parameters as query parameters when calling delete" do
       url = 'http://localhost:5555/events/1'
-      stubbed_url = 'http://localhost:5555/events/1?param1=&param2=stuff&send_notifications=true'
-      message_url = stub_request(:delete, stubbed_url)
+      stubbed_url = 'http://localhost:5555/events/1?param1&param2=stuff&send_notifications=true'
+      stub_request(:delete, stubbed_url)
       r = Nylas::RestfulModel.new(@api)
       allow(r).to receive_messages(:url => url)
 


### PR DESCRIPTION
Actually, in our Rails project, we want to update `mailgun-ruby` gem but newer version of this gem is dependent on the `rest-client` `~> 2.0` but `nylas-ruby` gem is dependent on `rest-client` `~> 1.6` and this causing an issue. It would be good if we merge this as soon as possible.

Let me know your thoughts.