### PR TITLE
Expose date fields as ruby dates

### DIFF
--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -45,6 +45,30 @@ module Nylas
       end
     end
 
+
+    # Convenience method to access a Ruby Date version of the `date` parameter
+    # Will replace the string version of`#date` when we move to 4.0
+    def parsed_date
+      if date.kind_of?(Numeric)
+        Time.at(date).to_datetime
+      else
+        DateTime.parse(date)
+      end
+    end
+
+    alias_method :orig_date=, :date=
+    # Ensures when we are setting the date on this instance
+    # that we are storing it to a unix timestamp.
+    def date=date
+      if date.respond_to?(:strftime)
+        self.orig_date = date.strftime("%s").to_i
+      elsif date.kind_of?(String)
+        self.orig_date = DateTime.parse(date).strftime("%s").to_i
+      else
+        self.orig_date = date
+      end
+    end
+
     def as_json(options = {})
       hash = {}
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -9,6 +9,29 @@ describe Nylas::Message do
     @inbox = Nylas::API.new(@app_id, @app_secret, @access_token)
   end
 
+  describe "#date=" do
+    it "casts the date object to a string for backwards compatibility reasons" do
+      msg = Nylas::Message.new(@inbox)
+      msg.date = Date.parse('2017-01-01')
+      expect(msg.date).to eql Date.parse('2017-01-01').strftime('%s').to_i
+    end
+  end
+
+  describe '#parsed_date' do
+    it "exposes the `date` field as a true ruby date object" do
+      msg = Nylas::Message.new(@inbox)
+      msg.date = '2017-01-01 01:00:00Z'
+      expect(msg.parsed_date).to eql DateTime.parse('2017-01-01 01:00:00Z')
+    end
+
+
+    it "supports dates set as unix timestamps" do
+      msg = Nylas::Message.new(@inbox)
+      msg.date = 1511305289
+      expect(msg.parsed_date).to eql Time.at(msg.date).to_datetime
+    end
+  end
+
   describe "#as_json" do
     it "doesn't send the the labels ids if the labels are empty" do
       labels = []

--- a/tests/system.rb
+++ b/tests/system.rb
@@ -2,7 +2,7 @@ require 'nylas'
 require 'rest-client'
 
 begin
-  load 'credentials.rb'
+  require_relative 'credentials.rb'
 rescue LoadError
   puts "It seems you didn't create a 'credentials.rb' file. Look at credentials.rb.template for an example."
   exit


### PR DESCRIPTION
Resolves https://github.com/nylas/nylas-ruby/issues/118

I chose to not overwrite the existing `date` method as that could result in surprises for our consumers. Instead, I went with overwriting the `date=` so that it coerces the date to a string when it's set with a real date object, and then it parses it back out as `parsed_date` for convenience.


I'll need to update this when we merge #113 