### PR TITLE
Make type errors for message folders and labels explicit

### DIFF
--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -28,7 +28,7 @@ module Nylas
       @cc ||= []
       @bcc ||= []
       @labels ||= []
-      @folder ||= nil
+      self.folder ||= nil
 
       # This is a special case --- we receive label data from the API
       # as JSON but we want it to behave like an API object.
@@ -60,12 +60,19 @@ module Nylas
 
       if not @labels.nil? and @labels != []
         hash["label_ids"] = @labels.map do |label|
+          if !label.respond_to?(:id)
+            raise TypeError, "label #{label} does not respond to #id"
+          end
           label.id
         end
       end
 
-      if not @folder.nil?
-        hash["folder_id"] = @folder.id
+      if !folder.nil? && !folder.respond_to?(:id)
+        raise TypeError, "folder #{folder} does not respond to #id"
+      end
+
+      if !folder.nil? && folder.respond_to?(:id)
+        hash["folder_id"] = folder.id
       end
 
       hash


### PR DESCRIPTION
This resolves https://github.com/nylas/nylas-ruby/issues/57 by making the interface more explicit about the types it expects.

I generally prefer to do this on setting the data as opposed to on parsing, what do you think @khamidou? An example of doing the casting/validation on input is here: https://github.com/nylas/nylas-ruby/pull/133