### PR TITLE
Update lockfiles after changing the version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ The `bin/setup` script installs the different ruby versions we expect the gem to
 
 When you're ready to release a new version, edit `lib/version.rb` and then run:
 
+    bin/test
     gem build nylas.gemspec
     gem push nylas-0.0.0.gem # Update the version number
 

--- a/gemfiles/Gemfile.rails4.lock
+++ b/gemfiles/Gemfile.rails4.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nylas (3.1.1)
+    nylas (3.2.0)
       em-http-request (~> 1.1, >= 1.1.3)
       rest-client (>= 1.6)
       yajl-ruby (~> 1.2, >= 1.2.1)

--- a/gemfiles/Gemfile.rails5.lock
+++ b/gemfiles/Gemfile.rails5.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nylas (3.1.1)
+    nylas (3.2.0)
       em-http-request (~> 1.1, >= 1.1.3)
       rest-client (>= 1.6)
       yajl-ruby (~> 1.2, >= 1.2.1)

--- a/gemfiles/Gemfile.rest-client.1.lock
+++ b/gemfiles/Gemfile.rest-client.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nylas (3.1.1)
+    nylas (3.2.0)
       em-http-request (~> 1.1, >= 1.1.3)
       rest-client (>= 1.6)
       yajl-ruby (~> 1.2, >= 1.2.1)

--- a/gemfiles/Gemfile.rest-client.2.lock
+++ b/gemfiles/Gemfile.rest-client.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    nylas (3.1.1)
+    nylas (3.2.0)
       em-http-request (~> 1.1, >= 1.1.3)
       rest-client (>= 1.6)
       yajl-ruby (~> 1.2, >= 1.2.1)


### PR DESCRIPTION
When we upgrade the version, our cross-compatible gemfiles will need to have their lockfile update as well.

Otherwise CI will get nervous because we're trying to load a new version of the gem that isn't specified in the lockfile.