### PR TITLE
Remove surprising behavior of not requiring enter on user input

### DIFF
--- a/tests/system.rb
+++ b/tests/system.rb
@@ -11,7 +11,7 @@ end
 def color_print(str)
   puts "\033[0m\033[94m"
   print str
-  STDIN.getc
+  input = gets.chomp
   puts "\033[0m"
 end
 


### PR DESCRIPTION
When I was running the feature tests, I got some surprising behavior where it would move forward two steps instead of one.

This is because it wasn't waiting for me to hit the return key to validate my input, so when I hit "Y" + Enter it moved twice instead of once.

I've changed to use `gets` instead, so that future contributors don't run into the same behavior.