### PR TITLE
Remove global RestClient hooks.

### DIFF
--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -12,9 +12,10 @@ module Nylas
       raise UnexpectedAccountAction.new unless action == "upgrade" || action == "downgrade"
 
       collection = ManagementModelCollection.new(Account, @_api, {:account_id=>@account_id})
-      ::RestClient.post("#{collection.url}/#{@account_id}/#{action}",{}) do |response, request, result|
+      url = "#{collection.url}/#{@account_id}/#{action}"
+      @_api.post(url,{}) do |response, _request, result|
           # Throw any exceptions
-        json = Nylas.interpret_response(result, response, :expected_class => Object)
+        Nylas.interpret_response(result, response, expected_class: Object)
       end
     end
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -32,8 +32,8 @@ module Nylas
         data = as_json()
       end
 
-      ::RestClient.post(url, data.to_json, :content_type => :json) do |response, request, result|
-        response = Nylas.interpret_response(result, response, {:expected_class => Object})
+      @_api.post(url, data.to_json, :content_type => :json) do |response, request, result|
+        response = Nylas.interpret_response(result, response, expected_class: Object)
         self.inflate(response)
       end
 
@@ -41,10 +41,10 @@ module Nylas
     end
 
     def destroy
-      ::RestClient::Request.execute(method: :delete, url: self.url, payload: ({ :version => self.version }).to_json) do |response, request, result|
-        response = Nylas.interpret_response(result, response, options={:raw_response=>true})
+      payload = { version: version }.to_json
+      @_api.delete(url, payload) do |response, _request, result|
+        Nylas.interpret_response(result, response, raw_response: true)
       end
     end
-
   end
 end

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -34,14 +34,12 @@ module Nylas
       url = @_api.url_for_path("/send-rsvp")
       data = {:event_id => @id, :status => status, :comment => comment}
 
-      ::RestClient.post(url, data.to_json, :content_type => :json) do |response, request, result|
-        json = Nylas.interpret_response(result, response, :expected_class => Object)
+      @_api.post(url, data.to_json, content_type: :json) do |response, _request, result|
+        json = Nylas.interpret_response(result, response, expected_class: Object)
         self.inflate(json)
       end
 
       self
     end
-
-
   end
 end

--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -19,8 +19,8 @@ module Nylas
     end
 
     def save!
-      ::RestClient.post(url, {:file => @file}) do |response, request, result|
-        json = Nylas.interpret_response(result, response, :expected_class => Object)
+      @_api.post(url, {:file => @file}) do |response, request, result|
+        json = Nylas.interpret_response(result, response, expected_class: Object)
         json = json[0] if (json.class == Array)
         inflate(json)
       end
@@ -29,12 +29,10 @@ module Nylas
 
     def download
       download_url = self.url('download')
-      ::RestClient.get(download_url) do |response, request, result|
-        Nylas.interpret_response(result, response, {:raw_response => true})
-        response
+      @_api.get(download_url) do |response, _request, result|
+        Nylas.interpret_response(result, response, raw_response: true)
       end
     end
-
   end
 end
 

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -80,23 +80,20 @@ module Nylas
     end
 
     def raw
-      collection = RestfulModelCollection.new(Message, @_api, {:message_id=>@id})
-      RestClient.get("#{collection.url}/#{id}/", :accept => 'message/rfc822'){ |response,request,result|
-        Nylas.interpret_response(result, response, {:raw_response => true})
-        response
-      }
+      collection = RestfulModelCollection.new(Message, @_api, message_id: @id)
+      url = "#{collection.url}/#{id}/"
+      @_api.get(url, accept: 'message/rfc822') do |response, _request, result|
+        Nylas.interpret_response(result, response, raw_response: true)
+      end
     end
 
     def expanded
-      expanded_url = url(action='?view=expanded')
-
-      RestClient.get(expanded_url){ |response,request,result|
-        json = Nylas.interpret_response(result, response, :expected_class => Object)
+      @_api.get(url('?view=expanded')) do |response, _request, result|
+        json = Nylas.interpret_response(result, response, expected_class: Object)
         expanded_message = Nylas::ExpandedMessage.new(@_api)
         expanded_message.inflate(json)
         expanded_message
-      }
-
+      end
     end
   end
 end

--- a/lib/nylas/restful_model.rb
+++ b/lib/nylas/restful_model.rb
@@ -63,9 +63,17 @@ module Nylas
     def update(http_method, action, data = {}, params = {})
       http_method = http_method.downcase
 
-      ::RestClient.send(http_method, self.url(action), data.to_json, :content_type => :json, :params => params) do |response, request, result|
-        unless http_method == 'delete'
-          json = Nylas.interpret_response(result, response, :expected_class => Object)
+      @_api.execute(
+        http_method,
+        url(action),
+        payload: data.to_json,
+        headers: {
+          content_type: :json,
+          params: params
+        }
+      ) do |response, request, result|
+        unless request.method == 'delete'
+          json = Nylas.interpret_response(result, response, expected_class: Object)
           inflate(json)
         end
       end
@@ -73,10 +81,9 @@ module Nylas
     end
 
     def destroy(params = {})
-      ::RestClient.send('delete', self.url, :params => params) do |response, request, result|
-        Nylas.interpret_response(result, response, {:raw_response => true})
+      @_api.delete(url, nil, params: params) do |response, _request, result|
+        Nylas.interpret_response(result, response, raw_response: true)
       end
     end
-
   end
 end

--- a/spec/inbox_spec.rb
+++ b/spec/inbox_spec.rb
@@ -8,21 +8,6 @@ describe 'Nylas' do
     @access_token = 'UXXMOCJW-BKSLPCFI-UQAQFWLO'
   end
 
-  describe "initialize" do
-    it "should add the 'before_execution_proc' to the RestClient to set the header" do
-      if ::RestClient.before_execution_procs.empty?
-        @inbox = Nylas::API.new(@app_id, @app_secret)
-        expect(::RestClient.before_execution_procs.empty?).to eq(false)
-      end
-    end
-
-    it "should not do this multiple times if multiple copies of the Nylas::API are initialized" do
-      @inbox = Nylas::API.new(@app_id, @app_secret)
-      @inbox = Nylas::API.new(@app_id, @app_secret)
-      expect(::RestClient.before_execution_procs.count).to eq(1)
-    end
-  end
-
   describe "#url_for_path" do
     before (:each) do
       @inbox = Nylas::API.new(@app_id, @app_secret, @access_token)

--- a/spec/nylas_spec.rb
+++ b/spec/nylas_spec.rb
@@ -20,4 +20,20 @@ describe Nylas::API do
       end
     end
   end
+
+  describe 'default headers' do
+    let!(:request) do
+      stub_request(:post, 'https://api.nylas.com/oauth/token')
+        .with(headers: {
+                'X-Nylas-API-Wrapper' => 'ruby',
+                'User-Agent' => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}"
+              })
+        .to_return(status: 200, body: '{"access_token": "456"}', headers: {})
+    end
+
+    it 'adds default headers' do
+      api.token_for_code('123')
+      expect(request).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
In our project we use `RestClient` not only for Nylas so we get our http headers corrupted with Nylas stuff :(