### PR TITLE
Remove implicit dependency on ActiveSupport

### DIFF
--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'rest-client'
 
 require 'ostruct'
-require 'active_support/core_ext/hash'
+require_relative 'nylas/to_query'
 
 require 'nylas/account'
 require 'nylas/api_account'
@@ -138,7 +138,7 @@ module Nylas
         params[:state] = options[:state]
       end
 
-      "https://#{@service_domain}/oauth/authorize?" + params.to_query
+      "https://#{@service_domain}/oauth/authorize?" + ToQuery.new(params).to_s
     end
 
     def url_for_management

--- a/lib/nylas/to_query.rb
+++ b/lib/nylas/to_query.rb
@@ -1,0 +1,16 @@
+module Nylas
+  class ToQuery
+    attr_accessor :hash
+    def initialize(hash)
+      self.hash = hash
+    end
+
+    def to_s
+      hash.reduce("") do |query, (key, value)|
+        next query if value.nil?
+        pair = "#{key}=#{URI.escape(value.to_s)}"
+        query.empty? ? "#{query}#{pair}" : "#{query}&#{pair}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
For some reason, we had a require for `active_support` in lib/nylas,
which meant that even though we didn't declare a dependency on
ActiveSupport, we assumed that you would be using it.

This removes that in favor of a small class that casts hashes to query
strings.

We may be able to get rid of this if we leverage RestClient for
URL building.