### PR TITLE
Use the bundled version of rubocop instead of system version

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -12,6 +12,7 @@ PreCommit:
   RuboCop:
     enabled: true
     on_warn: fail # Treat all warnings as failures
+    required_executable: './bin/rubocop'
   TrailingWhitespace:
     enabled: true
 


### PR DESCRIPTION
This extends #161 a bit so that you don't have to `bundle exec git commit` if you have multiple versions of rubocop installed.