### PR TITLE
Finding a model works when new fields are added to the API

### DIFF
--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -53,7 +53,7 @@ module Nylas
     end
 
     def reload
-      merge(execute(method: :get, path: resource_path))
+      assign(execute(method: :get, path: resource_path))
       true
     end
 
@@ -136,8 +136,7 @@ module Nylas
       end
 
       def from_hash(data, api:)
-        instance = new(**data)
-        instance.api = api
+        instance = new(**data.merge(api: api))
         instance
       end
     end

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -53,7 +53,7 @@ module Nylas
     end
 
     def reload
-      attributes.merge(execute(method: :get, path: resource_path))
+      merge(execute(method: :get, path: resource_path))
       true
     end
 

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -7,12 +7,12 @@ module Nylas
       end
 
       def initialize(**initial_data)
-        merge(**initial_data)
+        assign(**initial_data)
       end
 
-      protected def merge(**data)
+      protected def assign(**data)
         data.each do |attribute_name, value|
-          if self.class.attribute_definitions.key?(attribute_name)
+          if respond_to?(:"#{attribute_name}=")
             send(:"#{attribute_name}=", value)
           else
             Logging.logger.warn("#{attribute_name} is not defined as an attribute on #{self.class.name}")

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -7,7 +7,11 @@ module Nylas
       end
 
       def initialize(**initial_data)
-        initial_data.each do |attribute_name, value|
+        merge(**initial_data)
+      end
+
+      protected def merge(**data)
+        data.each do |attribute_name, value|
           if self.class.attribute_definitions.key?(attribute_name)
             send(:"#{attribute_name}=", value)
           else

--- a/spec/nylas/model_spec.rb
+++ b/spec/nylas/model_spec.rb
@@ -42,6 +42,14 @@ describe Nylas::Model do
     end
   end
 
+  describe "#reload" do
+    it "does not explode if using an invalid attribute" do
+      allow(api).to receive(:execute).and_return(fake_attribute: "not real")
+      instance = FullModel.from_json('{ "id": 1234 }', api: api)
+      expect { instance.reload }.not_to raise_error
+    end
+  end
+
   describe ".from_json(json, api:)" do
     it "instantiates a ruby version of the Model with pas the data" do
       instance = FullModel.from_json("{}", api: api)

--- a/spec/nylas/model_spec.rb
+++ b/spec/nylas/model_spec.rb
@@ -48,6 +48,15 @@ describe Nylas::Model do
       instance = FullModel.from_json('{ "id": 1234 }', api: api)
       expect { instance.reload }.not_to raise_error
     end
+
+    it "assigns the attributes that do exist" do
+      allow(api).to receive(:execute).and_return(string: "I am real", fake_attribute: "not real")
+      instance = FullModel.from_json('{ "id": 1234 }', api: api)
+      instance.reload
+      expect(instance.id).to eql "1234"
+      expect(instance.string).to eql "I am real"
+      expect { instance.attributes[:fake_attribute] }.to raise_error Nylas::Registry::MissingKeyError
+    end
   end
 
   describe ".from_json(json, api:)" do


### PR DESCRIPTION
When finding a particular record after the API had new fields added to
it, exceptions would be raised as the model would reload itself and
attempt to set a field that doesn't exist.

By making reload use the same logic as instantiation, we're able to
avoid exceptions being raised on find when new fields are added to the
API

This covers an additional use case from https://github.com/nylas/nylas-ruby/pull/186, which slipped past me.

This also resolves #188 