### PR TITLE
Add expanded method to message

### DIFF
--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -41,5 +41,12 @@ module Nylas
     def unread?
       unread
     end
+
+    def expanded
+      return self unless headers.nil?
+
+      assign(api.execute(method: :get, path: resource_path, query: { view: "expanded" }))
+      self
+    end
   end
 end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -113,4 +113,25 @@ describe Nylas::Message do
       expect(message.labels[1].name).to eql "all"
     end
   end
+
+  describe "#expanded" do
+    it "fetch or return expanded version of message" do
+      api = instance_double(Nylas::API, execute: "{}")
+      message = described_class.from_json('{ "id": "message-1234" }', api: api)
+      data = { id: "draft-1234",
+               headers: { "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>",
+                          "Message-Id": "<84umizq7c4jtrew491brpa6iu-0@example.com>",
+                          "References": ["<evh5uy0shhpm5d0le89goor17-0@example.com>"] } }
+
+      allow(api).to receive(:execute).with(method: :get,
+                                           path: "/messages/message-1234",
+                                           query: { view: "expanded" })
+                                     .and_return(data)
+      message.expanded
+
+      expect(message.expanded.headers.in_reply_to).to eql "<evh5uy0shhpm5d0le89goor17-0@example.com>"
+      expect(message.expanded.headers.message_id).to eql "<84umizq7c4jtrew491brpa6iu-0@example.com>"
+      expect(message.expanded.headers.references[0]).to eql "<evh5uy0shhpm5d0le89goor17-0@example.com>"
+    end
+  end
 end


### PR DESCRIPTION
When message fetched using `find`, it is always not expanded. Allow to use `expanded` method of message to return expanded version always.

If headers nil, just re-fetch expanded view of message.

It allows to run following:
```
message = api.messages.find(id)
message.expanded.headers.in_reply_to
```

Fix issue https://github.com/nylas/nylas-ruby/issues/189