### PR TITLE
Fix encoding issue when download attachments

### DIFF
--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -49,7 +49,7 @@ module Nylas
     private def retrieve_file
       response = api.get(path: "#{resource_path}/download")
       filename = response.headers.fetch(:content_disposition, "").gsub("attachment; filename=", "")
-      temp_file = Tempfile.new(filename)
+      temp_file = Tempfile.new(filename, :encoding => 'ascii-8bit')
       temp_file.write(response.body)
       temp_file.seek(0)
       temp_file


### PR DESCRIPTION
When downloading file exception raised:
`Encoding::UndefinedConversionError: "\x84" from ASCII-8BIT to UTF-8`

It fix following code to run:
```
message = api.messages.find(id)
content = message.files[0].download
```
