### PR TITLE
Transfer api attribute to included objects

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -31,6 +31,8 @@ module Nylas
     attribute :folder, :label
     has_n_of_attribute :labels, :label
 
+    transfer :api, to: %i[events files folder labels]
+
     def send!
       save
       execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -34,6 +34,8 @@ module Nylas
     attribute :folder, :label
     has_n_of_attribute :labels, :label
 
+    transfer :api, to: %i[events files folder labels]
+
     def starred?
       starred
     end

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -2,6 +2,7 @@ require_relative "model/attribute_definition"
 require_relative "model/list_attribute_definition"
 require_relative "model/attributable"
 require_relative "model/attributes"
+require_relative "model/transferable"
 module Nylas
   # Include this to define a class to represent an object returned from the API
   module Model
@@ -13,6 +14,7 @@ module Nylas
 
     def self.included(model)
       model.include(Attributable)
+      model.include(Transferable)
       model.extend(ClassMethods)
       model.extend(Forwardable)
       model.def_delegators :model_class, :creatable?, :filterable?, :listable?, :searchable?, :showable?,

--- a/lib/nylas/model/transferable.rb
+++ b/lib/nylas/model/transferable.rb
@@ -1,0 +1,47 @@
+module Nylas
+  module Model
+    # Allows definition of attributes, which should transfer to other dependent attributes
+    module Transferable
+      def self.included(model)
+        model.extend(ClassMethods)
+        model.init_attribute_recipients
+      end
+
+      def initialize(**initial_data)
+        assign(**initial_data)
+        transfer_attributes
+      end
+
+      private def transfer_attributes
+        self.class.attribute_recipients.each_pair do |name, recipient_names|
+          value = send(:"#{name}")
+          next if value.nil?
+          recipient_names.each do |recipient_name|
+            recipient = send(:"#{recipient_name}")
+            transfer_to_recipient(name, value, recipient) unless recipient.nil?
+          end
+        end
+      end
+
+      private def transfer_to_recipient(name, value, recipient)
+        if recipient.respond_to?(:each)
+          recipient.each { |item| item.send(:"#{name}=", value) }
+        else
+          recipient.send(:"#{name}=", value)
+        end
+      end
+
+      # Methods to call when tweaking Transferable classes
+      module ClassMethods
+        attr_accessor :attribute_recipients
+        def init_attribute_recipients
+          self.attribute_recipients ||= {}
+        end
+
+        def transfer(*attributes, **opts)
+          attributes.each { |name| self.attribute_recipients[name] = opts[:to] }
+        end
+      end
+    end
+  end
+end

--- a/lib/nylas/thread.rb
+++ b/lib/nylas/thread.rb
@@ -31,6 +31,8 @@ module Nylas
 
     has_n_of_attribute :label_ids, :string
 
+    transfer :api, to: %i[labels folders]
+
     UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread].freeze
     def update(data)
       unupdatable_attributes = data.keys.reject { |name| UPDATABLE_ATTRIBUTES.include?(name) }

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -99,24 +99,29 @@ describe Nylas::Draft do
       expect(draft.files[0].filename).to be_nil
       expect(draft.files[0].id).to eql "file-abc35"
       expect(draft.files[0].size).to be 1264
+      expect(draft.files[0].api).to be api
 
       expect(draft.files[1].content_type).to eql "application/ics"
       expect(draft.files[1].filename).to eql "invite.ics"
       expect(draft.files[1].id).to eql "file-xyz-9234"
       expect(draft.files[1].size).to be 1264
+      expect(draft.files[1].api).to be api
 
       # Note, drafts will either be in a folder *or* labeled, not both.
       expect(draft.folder.display_name).to eql "Inbox"
       expect(draft.folder.name).to eql "inbox"
       expect(draft.folder.id).to eql "folder-inbox"
+      expect(draft.folder.api).to be api
 
       expect(draft.labels[0].display_name).to eql "Inbox"
       expect(draft.labels[0].id).to eql "label-inbox"
       expect(draft.labels[0].name).to eql "inbox"
+      expect(draft.labels[0].api).to be api
 
       expect(draft.labels[1].display_name).to eql "All Mail"
       expect(draft.labels[1].id).to eql "label-all"
       expect(draft.labels[1].name).to eql "all"
+      expect(draft.labels[1].api).to be api
     end
   end
 end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -64,6 +64,7 @@ describe Nylas::Message do
       expect(event.object).to eql "event"
       expect(event.account_id).to eql "acc-1234"
       expect(event.message_id).to eql "mess-8766"
+      expect(event.api).to be api
 
       expect(event).to be_busy
       expect(event.calendar_id).to eql "cal-0987"
@@ -93,24 +94,29 @@ describe Nylas::Message do
       expect(message.files[0].filename).to be_nil
       expect(message.files[0].id).to eql "file-abc35"
       expect(message.files[0].size).to be 1264
+      expect(message.files[0].api).to be api
 
       expect(message.files[1].content_type).to eql "application/ics"
       expect(message.files[1].filename).to eql "invite.ics"
       expect(message.files[1].id).to eql "file-xyz-9234"
       expect(message.files[1].size).to be 1264
+      expect(message.files[1].api).to be api
 
       # Note, messages will either be in a folder *or* labeled, not both.
       expect(message.folder.display_name).to eql "Inbox"
       expect(message.folder.name).to eql "inbox"
       expect(message.folder.id).to eql "folder-inbox"
+      expect(message.folder.api).to be api
 
       expect(message.labels[0].display_name).to eql "Inbox"
       expect(message.labels[0].id).to eql "label-inbox"
       expect(message.labels[0].name).to eql "inbox"
+      expect(message.labels[0].api).to be api
 
       expect(message.labels[1].display_name).to eql "All Mail"
       expect(message.labels[1].id).to eql "label-all"
       expect(message.labels[1].name).to eql "all"
+      expect(message.labels[1].api).to be api
     end
   end
 end

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -42,6 +42,7 @@ describe Nylas::Thread do
 
     expect(thread.labels[1].id).to eql "label-inbox"
     expect(thread.labels[1].name).to eql "inbox"
+    expect(thread.labels[1].display_name).to eql "Inbox"
     expect(thread.labels[1].api).to be api
 
     expect(thread.last_message_received_timestamp).to eql Time.at(1_510_080_143)

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -14,6 +14,7 @@ describe Nylas::Thread do
   end
 
   it "can be deserialized from JSON" do
+    api = instance_double(Nylas::API)
     json = JSON.dump(id: "thread-2345", account_id: "acc-1234", draft_ids: ["dra-987"],
                      first_message_timestamp: 1_510_080_143, has_attachments: false,
                      labels: [{ display_name: "All Mail", id: "label-all-mail", name: "all" },
@@ -27,7 +28,7 @@ describe Nylas::Thread do
                                                         name: "Andy from Google" }],
                      snippet: "Hi there!", starred: false, subject: "Hello!", "unread": false, "version": 2)
 
-    thread = described_class.from_json(json, api: nil)
+    thread = described_class.from_json(json, api: api)
     expect(thread.id).to eql "thread-2345"
     expect(thread.account_id).to eql "acc-1234"
     expect(thread.draft_ids).to eql ["dra-987"]
@@ -37,10 +38,11 @@ describe Nylas::Thread do
     expect(thread.labels[0].id).to eql "label-all-mail"
     expect(thread.labels[0].name).to eql "all"
     expect(thread.labels[0].display_name).to eql "All Mail"
+    expect(thread.labels[0].api).to be api
 
     expect(thread.labels[1].id).to eql "label-inbox"
     expect(thread.labels[1].name).to eql "inbox"
-    expect(thread.labels[1].display_name).to eql "Inbox"
+    expect(thread.labels[1].api).to be api
 
     expect(thread.last_message_received_timestamp).to eql Time.at(1_510_080_143)
     expect(thread.last_message_timestamp).to eql Time.at(1_510_080_143)


### PR DESCRIPTION
When some model object initialized, also initialized and included dependent model objects.
For example when **message** is initialized, also will be initialized:  **events**, **files**, **folder** and **labels**. But this objects api will be nil, and it is not possible and easy to start using execute api methods.

Example:
```
message = api.messages.find(id)
content = message.files[0].download
```

Download will fail, api is not initialized for file.

This PR add `Transferable` class extension, using it it is possible to specify transfer of attributes to dependent objects using following notation:
```
module Nylas
  class Message
...
      transfer :api, to: %i[events files folder labels]
  end
end
```

Transfer api added to message, draft, thread. It is rspec covered.