### PR TITLE
Fix wrong type for folder attribute in message, draft

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -28,7 +28,7 @@ module Nylas
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
-    attribute :folder, :label
+    attribute :folder, :folder
     has_n_of_attribute :labels, :label
 
     def send!

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -31,7 +31,7 @@ module Nylas
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
-    attribute :folder, :label
+    attribute :folder, :folder
     has_n_of_attribute :labels, :label
 
     def starred?


### PR DESCRIPTION
It looks like mistype, but i think, for folder attribute type should be `folder`
PR fix it for message and draft models