### PR TITLE
fix count with `where` api request

### DIFF
--- a/lib/nylas/constraints.rb
+++ b/lib/nylas/constraints.rb
@@ -13,7 +13,7 @@ module Nylas
     end
 
     def merge(where: {}, limit: nil, offset: nil, view: nil, per_page: nil, accept: nil)
-      Constraints.new(where: where.merge(where),
+      Constraints.new(where: self.where.merge(where),
                       limit: limit || self.limit,
                       per_page: per_page || self.per_page,
                       offset: offset || self.offset,

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -82,4 +82,24 @@ describe Nylas::Collection do
       expect { collection.create(string: "1234") }.to raise_error(Nylas::ModelNotCreatableError)
     end
   end
+
+  describe "#count" do
+    it "returns collection count" do
+      collection = described_class.new(model: FullModel, api: api)
+      allow(api).to receive(:execute)
+        .with(method: :get, path: "/collection", query: { limit: 100, offset: 0, view: "count"}, headers: {})
+        .and_return(count: 1)
+
+      expect(collection.count).to eql 1
+    end
+
+    it "returns collection count filtered by `where`" do
+      collection = described_class.new(model: FullModel, api: api)
+      allow(api).to receive(:execute)
+        .with(method: :get, path: "/collection", query: { id: "1234", limit: 100, offset: 0, view: "count"}, headers: {})
+        .and_return(count: 1)
+
+      expect(collection.where(id: "1234").count).to eql 1
+    end
+  end
 end


### PR DESCRIPTION
Count request with `where` constraints is not working. Method `Nylas::Constraints#merge` erases `where` from parent constraints. It merges `where` from args to themselves.