### PR TITLE
Add scopes arg for native authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Unreleased
 * Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
 * Add support for Ruby 2.5 and 2.6
+* Add `scopes` argument to `Nylas::API#authenticate` for
+  [selective sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
 
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ api.authenticate(
 )
 ```
 
+If you do not pass any scopes, then the SDK will default to using all of them.
+
 ### Handling Errors
 The Nylas API uses conventional HTTP response codes to indicate success or failure of an API request. The ruby gem raises these as native exceptions.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ We support Rails 4.2 and above. A more detailed compatibility list can be found 
 
 Examples are located in the [examples](./examples) directory. Examples in plain ruby are in [examples/plain-ruby/](./examples/plain-ruby). They are grouped by the API endpoints they interact with.
 
+## Scopes
+
+The Nylas API allows you to set various scopes during the authentication process
+in order to use the [Selective Sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
+feature. Currently, these scopes are `email`, `calendar`, and `contacts`.
+You can pass an array of scopes to `Nylas::API#authenticate`, like this:
+
+```ruby
+api = Nylas::API.new()
+api.authenticate(
+    name: 'fake',
+    email_address: 'fake@example.com',
+    provider: :gmail,
+    settings: {},
+    scopes: ["email"]
+)
+```
+
 ### Handling Errors
 The Nylas API uses conventional HTTP response codes to indicate success or failure of an API request. The ruby gem raises these as native exceptions.
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,6 +47,7 @@ module GemConfig
      ["pry-nav", "~> 0.2.4"],
      ["pry-stack_explorer", "~> 0.4.9"],
      ["rspec", "~> 3.7"],
+     ["rspec-json_matcher", "~> 0.1"],
      ["webmock", "~> 3.0"],
      ["faker", "~> 1.8"],
      ["informed", "~> 1.0"],

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -25,10 +25,15 @@ module Nylas
     # rubocop:enable Metrics/ParameterLists
 
     # @return [String] A Nylas access token for that particular user.
-    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil)
-      NativeAuthentication.new(api: self).authenticate(name: name, email_address: email_address,
-                                                       provider: provider, settings: settings,
-                                                       reauth_account_id: reauth_account_id)
+    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil)
+      NativeAuthentication.new(api: self).authenticate(
+        name: name,
+        email_address: email_address,
+        provider: provider,
+        settings: settings,
+        reauth_account_id: reauth_account_id,
+        scopes: scopes,
+      )
     end
 
     # @return [Collection<Contact>] A queryable collection of Contacts

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -17,7 +17,7 @@ module Nylas
       exchange_code_for_access_token(code)
     end
 
-    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes: nil)
+    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes:)
       payload = { client_id: api.client.app_id, name: name, email_address: email_address,
                   provider: provider, settings: settings, scopes: scopes }
       payload[:reauth_account_id] = reauth_account_id

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -7,16 +7,19 @@ module Nylas
       self.api = api
     end
 
-    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil)
+    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil,
+                     scopes: nil)
+      scopes ||= ["email", "calendar", "contacts"]
+      scopes = scopes.join(",") unless scopes.is_a?(String)
       code = retrieve_code(name: name, email_address: email_address, provider: provider,
-                           settings: settings, reauth_account_id: reauth_account_id)
+                           settings: settings, reauth_account_id: reauth_account_id, scopes: scopes)
 
       exchange_code_for_access_token(code)
     end
 
-    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:)
+    private def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes: nil)
       payload = { client_id: api.client.app_id, name: name, email_address: email_address,
-                  provider: provider, settings: settings }
+                  provider: provider, settings: settings, scopes: scopes }
       payload[:reauth_account_id] = reauth_account_id
       response = api.execute(method: :post, path: "/connect/authorize", payload: JSON.dump(payload))
       response[:code]

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -26,7 +26,7 @@ describe Nylas::NativeAuthentication do
       ).to eql("fake-token")
     end
 
-    it "allows customizable scopes" do
+    it "allows arrays of one scope" do
       client = Nylas::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
@@ -47,6 +47,56 @@ describe Nylas::NativeAuthentication do
           provider: :gmail,
           settings: {},
           scopes: ["email"]
+        )
+      ).to eql("fake-token")
+    end
+
+    it "allows arrays of two scopes" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email,contacts")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {},
+          scopes: ["email", "contacts"]
+        )
+      ).to eql("fake-token")
+    end
+
+    it "allows string scopes" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "calendar")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {},
+          scopes: "calendar"
         )
       ).to eql("fake-token")
     end

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe Nylas::NativeAuthentication do
+  describe "#authenticate" do
+    it "sets all scopes by default" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email,calendar,contacts")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {}
+        )
+      ).to eql("fake-token")
+    end
+
+    it "allows customizable scopes" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real",
+        access_token: "seriously-unreal"
+      )
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/authorize", payload: be_json_including("scopes" => "email")
+      ).and_return(code: 1234)
+      expect(client).to receive(:execute).with(
+        method: :post, path: "/connect/token", payload: be_json_including("code" => 1234)
+      ).and_return(access_token: "fake-token")
+      api = Nylas::API.new(client: client)
+
+      expect(
+        api.authenticate(
+          name: 'fake',
+          email_address: 'fake@example.com',
+          provider: :gmail,
+          settings: {},
+          scopes: ["email"]
+        )
+      ).to eql("fake-token")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ SimpleCov.start
 require "nylas"
 require "pry"
 require "webmock/rspec"
+require "rspec-json_matcher"
+
+RSpec.configuration.include RSpec::JsonMatcher
 
 class FakeAPI
   def execute(method:, path:, payload: nil)


### PR DESCRIPTION
Add `scopes` argument to `Nylas::API#authenticate` for [selective sync](https://docs.nylas.com/docs/how-to-use-selective-sync).

Python SDK: https://github.com/nylas/nylas-python/pull/106