### PR TITLE
Drop support for Ruby 2.2 and 2.3 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: ruby
 rvm:
- - 2.2
- - 2.3
  - 2.4
+ - 2.5
+ - 2.6
 cache: bundler
 gemfile:
   - gemfiles/Gemfile.rails4
   - gemfiles/Gemfile.rails5
   - gemfiles/Gemfile.rest-client.1
   - gemfiles/Gemfile.rest-client.2
+
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+* Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
+* Add support for Ruby 2.5 and 2.6
+
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK
 * Fixes api attribute breakage on enumeration (https://github.com/nylas/nylas-ruby/issues/188)

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -8,7 +8,7 @@ module GemConfig
     gem.license = "MIT"
     gem.version = Nylas::VERSION
     gem.platform = "ruby"
-    gem.required_ruby_version = "~> 2.2"
+    gem.required_ruby_version = ">= 2.4"
     append_nylas_data(gem)
     dev_dependencies.each do |dependency|
       gem.add_development_dependency(*dependency)
@@ -33,7 +33,7 @@ module GemConfig
   end
 
   def self.dev_dependencies
-    [["bundler", "~> 1.3"],
+    [["bundler", ">= 1.3.0"],
      ["jeweler", "~> 2.1"],
      ["yard", "~> 0.9.0"],
      ["awesome_print", "~> 1.0"],


### PR DESCRIPTION
According to [the Ruby maintainence page](https://www.ruby-lang.org/en/downloads/branches/), Ruby 2.2 reached end-of-life on 2018-03-31, and Ruby 2.3 reaches end-of-life on 2019-03-31, less than a month from today. We should drop support for both of them.

However, we can add support for Ruby 2.5 and 2.6, which are both in normal maintenance.