### PR TITLE
Add Nylas::When for generic time object handling

### DIFF
--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -35,6 +35,7 @@ require_relative "nylas/rsvp"
 require_relative "nylas/timespan"
 require_relative "nylas/web_page"
 require_relative "nylas/nylas_date"
+require_relative "nylas/when"
 
 # Custom collection types
 require_relative "nylas/search_collection"
@@ -86,4 +87,5 @@ module Nylas
   Types.registry[:web_page] = Types::ModelType.new(model: WebPage)
   Types.registry[:nylas_date] = NylasDateType.new
   Types.registry[:contact_group] = Types::ModelType.new(model: ContactGroup)
+  Types.registry[:when] = Types::ModelType.new(model: When)
 end

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -25,7 +25,7 @@ module Nylas
     attribute :read_only, :boolean
     attribute :status, :string
     attribute :title, :string
-    attribute :when, :timespan
+    attribute :when, :when
     attribute :original_start_time, :unix_timestamp
 
     def busy?

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -1,0 +1,48 @@
+module Nylas
+  # Structure to represent all the Nylas time types.
+  # @see https://docs.nylas.com/reference#section-time
+  class When
+    extend Forwardable
+
+    include Model::Attributable
+
+    attribute :object, :string
+
+    # when object == 'date'
+    attribute :date, :date
+
+    # when object == 'datespan'
+    attribute :start_date, :date
+    attribute :end_date, :date
+
+    # when object == 'time'
+    attribute :time, :unix_timestamp
+
+    # when object == 'timespan'
+    attribute :start_time, :unix_timestamp
+    attribute :end_time, :unix_timestamp
+
+    def_delegators :range, :cover?
+
+    def as_timespan
+      if object == 'timespan'
+        Timespan.new(object: object,
+                     start_time: start_time,
+                     end_time: end_time)
+      end
+    end
+
+    def range
+      case object
+      when 'timespan'
+        Range.new(start_time, end_time)
+      when 'datespan'
+        Range.new(start_date, end_date)
+      when 'date'
+        Range.new(date, date)
+      when 'time'
+        Range.new(time, time)
+      end
+    end
+  end
+end

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent all the Nylas time types.
   # @see https://docs.nylas.com/reference#section-time
@@ -25,22 +27,19 @@ module Nylas
     def_delegators :range, :cover?
 
     def as_timespan
-      if object == 'timespan'
-        Timespan.new(object: object,
-                     start_time: start_time,
-                     end_time: end_time)
-      end
+      return unless object == "timespan"
+      Timespan.new(object: object, start_time: start_time, end_time: end_time)
     end
 
     def range
       case object
-      when 'timespan'
+      when "timespan"
         Range.new(start_time, end_time)
-      when 'datespan'
+      when "datespan"
         Range.new(start_date, end_date)
-      when 'date'
+      when "date"
         Range.new(date, date)
-      when 'time'
+      when "time"
         Range.new(time, time)
       end
     end

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -28,6 +28,7 @@ module Nylas
 
     def as_timespan
       return unless object == "timespan"
+
       Timespan.new(object: object, start_time: start_time, end_time: end_time)
     end
 


### PR DESCRIPTION
This PR adds support for `when` in `Nylas::Event` for types other than `timespan`. I did this in the quickest/most obvious way to me - if there's a better way to implement this, I'll be happy to make any changes.

This is related to #199 and may fix that issue.