### PR TITLE
update readme with granular scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ api.authenticate(
     name: 'fake',
     email_address: 'fake@example.com',
     provider: :gmail,
-    settings: {},
+    settings: {
+      google_client_id: ENV['GOOGLE_CLIENT_ID'],
+      google_client_secret: ENV['GOOGLE_CLIENT_SECRET'],
+      google_refresh_token: auth_hash[:credentials][:refresh_token]
+    },
     scopes: ['email.read_only', 'email.send']
 )
 ```

--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ Examples are located in the [examples](./examples) directory. Examples in plain 
 
 ## Scopes
 
-The Nylas API allows you to set various scopes during the authentication process
-in order to use the [Selective Sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
-feature. Currently, these scopes are `email`, `calendar`, and `contacts`.
-You can pass an array of scopes to `Nylas::API#authenticate`, like this:
+The Nylas API provides granular authentication scopes that empower users with control over what level of access your application has to their data. See supported [Authentication Scopes](https://docs.nylas.com/docs/authentication-scopes) for a full list of scopes and details behind the scopes. Below is an example of how you can pass an array of scopes to `Nylas::API#authenticate`:
 
 ```ruby
 api = Nylas::API.new()
@@ -55,11 +52,9 @@ api.authenticate(
     email_address: 'fake@example.com',
     provider: :gmail,
     settings: {},
-    scopes: ["email"]
+    scopes: ['email.read_only', 'email.send']
 )
 ```
-
-If you do not pass any scopes, then the SDK will default to using all of them.
 
 ### Handling Errors
 The Nylas API uses conventional HTTP response codes to indicate success or failure of an API request. The ruby gem raises these as native exceptions.


### PR DESCRIPTION
Update scopes section of readme to reference granular scopes and point to new authentication document instead of selective sync.