### PR TITLE
Support hosted authentication

### DIFF
--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -36,6 +36,21 @@ module Nylas
       )
     end
 
+    # @return [String] A url for hosted authentication
+    def hosted_authentication_url(redirect_uri, login_hint = "", options = {})
+      params = {
+        client_id: app_id,
+        redirect_uri: redirect_uri,
+        response_type: options.fetch(:response_type, "code"),
+        scope: options.fetch(:scope, "email"),
+        login_hint: login_hint
+      }
+
+      params[:state] = options[:state] if options.key?(:state)
+
+      "https://#{client.service_domain}/oauth/authorize?" + URI.encode_www_form(params)
+    end
+
     # @return [Collection<Contact>] A queryable collection of Contacts
     def contacts
       @contacts ||= Collection.new(model: Contact, api: self)

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -37,16 +37,17 @@ module Nylas
     end
 
     # @return [String] A url for hosted authentication
-    def hosted_authentication_url(redirect_uri, login_hint = "", options = {})
+    def hosted_authentication_url(redirect_uri:, login_hint: "", response_type: "code",
+                                  scope: "email", state: nil)
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,
-        response_type: options.fetch(:response_type, "code"),
-        scope: options.fetch(:scope, "email"),
+        response_type: response_type,
+        scope: scope,
         login_hint: login_hint
       }
 
-      params[:state] = options[:state] if options.key?(:state)
+      params[:state] = state if state
 
       "https://#{client.service_domain}/oauth/authorize?" + URI.encode_www_form(params)
     end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -38,12 +38,12 @@ module Nylas
 
     # @return [String] A url for hosted authentication
     def hosted_authentication_url(redirect_uri:, login_hint: "", response_type: "code",
-                                  scope: "email", state: nil)
+                                  scopes: "email", state: nil)
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,
         response_type: response_type,
-        scope: scope,
+        scopes: scopes,
         login_hint: login_hint
       }
 

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -29,6 +29,22 @@ describe Nylas::API do
     end
   end
 
+  describe "#hosted_authentication_url" do
+    it "generates a url for hosted authentication" do
+      client = Nylas::HttpClient.new(app_id: "fake-app-id", app_secret: "fake-secret",
+                                     access_token: "knockoff-token")
+      api = described_class.new(client: client)
+
+      hosted_auth_url = api.hosted_authentication_url(
+        "https://googs.com", "boba@boba.com"
+      )
+      expected_url = "https://api.nylas.com/oauth/authorize?client_id=fake-app-id&trial=false&" \
+        "response_type=code&scope=email&login_hint=boba%40boba.com&redirect_uri=https%3A%2F%2Fgoogs.com"
+
+      expect(hosted_auth_url).to eql(expected_url)
+    end
+  end
+
   describe "#execute" do
     it "builds the URL based upon the api_server it was initialized with"
     it "adds the nylas headers to the request"

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -36,10 +36,10 @@ describe Nylas::API do
       api = described_class.new(client: client)
 
       hosted_auth_url = api.hosted_authentication_url(
-        "https://googs.com", "boba@boba.com"
+        redirect_uri: "https://googs.com", login_hint: "boba@boba.com"
       )
-      expected_url = "https://api.nylas.com/oauth/authorize?client_id=fake-app-id&trial=false&" \
-        "response_type=code&scope=email&login_hint=boba%40boba.com&redirect_uri=https%3A%2F%2Fgoogs.com"
+      expected_url = "https://api.nylas.com/oauth/authorize?client_id=fake-app-id&" \
+        "redirect_uri=https%3A%2F%2Fgoogs.com&response_type=code&scope=email&login_hint=boba%40boba.com"
 
       expect(hosted_auth_url).to eql(expected_url)
     end

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -39,7 +39,7 @@ describe Nylas::API do
         redirect_uri: "https://googs.com", login_hint: "boba@boba.com"
       )
       expected_url = "https://api.nylas.com/oauth/authorize?client_id=fake-app-id&" \
-        "redirect_uri=https%3A%2F%2Fgoogs.com&response_type=code&scope=email&login_hint=boba%40boba.com"
+        "redirect_uri=https%3A%2F%2Fgoogs.com&response_type=code&scopes=email&login_hint=boba%40boba.com"
 
       expect(hosted_auth_url).to eql(expected_url)
     end


### PR DESCRIPTION
This PR adds a helper method to generate urls for hosted authentication (requested in https://github.com/nylas/nylas-ruby/issues/223)

We need this so that we can support hosted authentication (https://docs.nylas.com/reference#oauthauthorize) using this `nylas-ruby` gem without having to make out own separate http requests.