### PR TITLE
Allow setting `label_ids` on a message

### DIFF
--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -61,6 +61,7 @@ require_relative "nylas/native_authentication"
 require_relative "nylas/http_client"
 require_relative "nylas/api"
 
+require_relative "nylas/filter_attributes"
 # an SDK for interacting with the Nylas API
 # @see https://docs.nylas.com/reference
 module Nylas

--- a/lib/nylas/filter_attributes.rb
+++ b/lib/nylas/filter_attributes.rb
@@ -11,8 +11,7 @@ module Nylas
     def check
       return if extra_attributes.empty?
 
-      raise ArgumentError, "Cannot update #{extra_attributes} only " \
-        "#{allowed_attributes} are updatable"
+      raise ArgumentError, "Only #{allowed_attributes} are allowed to be sent"
     end
 
     private

--- a/lib/nylas/filter_attributes.rb
+++ b/lib/nylas/filter_attributes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Methods to check and raise error if extra attributes are present
+  class FilterAttributes
+    def initialize(attributes:, allowed_attributes:)
+      @attributes = attributes
+      @allowed_attributes = allowed_attributes
+    end
+
+    def check
+      return if extra_attributes.empty?
+
+      raise ArgumentError, "Cannot update #{extra_attributes} only " \
+        "#{allowed_attributes} are updatable"
+    end
+
+    private
+
+    attr_reader :attributes, :allowed_attributes
+
+    def extra_attributes
+      attributes - allowed_attributes
+    end
+  end
+end

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -34,7 +34,10 @@ module Nylas
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
     attribute :folder, :folder
+    attribute :folder_id, :string
+
     has_n_of_attribute :labels, :label
+    has_n_of_attribute :label_ids, :string
 
     transfer :api, to: %i[events files folder labels]
 
@@ -44,6 +47,16 @@ module Nylas
 
     def unread?
       unread
+    end
+
+    UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread].freeze
+    def update(data)
+      unupdatable_attributes = data.keys.reject { |name| UPDATABLE_ATTRIBUTES.include?(name) }
+      unless unupdatable_attributes.empty?
+        raise ArgumentError, "Cannot update #{unupdatable_attributes} only " \
+                             "#{UPDATABLE_ATTRIBUTES} are updatable"
+      end
+      super(data)
     end
 
     def expanded

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -8,6 +8,7 @@ module Nylas
     self.raw_mime_type = "message/rfc822"
     self.resources_path = "/messages"
     allows_operations(showable: true, listable: true, filterable: true, searchable: true, updatable: true)
+    UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread].freeze
 
     attribute :id, :string
     attribute :object, :string
@@ -49,7 +50,6 @@ module Nylas
       unread
     end
 
-    UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread].freeze
     def update(data)
       unupdatable_attributes = data.keys.reject { |name| UPDATABLE_ATTRIBUTES.include?(name) }
       unless unupdatable_attributes.empty?

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -50,13 +50,10 @@ module Nylas
       unread
     end
 
-    def update(data)
-      unupdatable_attributes = data.keys.reject { |name| UPDATABLE_ATTRIBUTES.include?(name) }
-      unless unupdatable_attributes.empty?
-        raise ArgumentError, "Cannot update #{unupdatable_attributes} only " \
-                             "#{UPDATABLE_ATTRIBUTES} are updatable"
-      end
-      super(data)
+    def update(payload)
+      check_for_update(payload)
+
+      super(payload)
     end
 
     def expanded
@@ -64,6 +61,17 @@ module Nylas
 
       assign(api.execute(method: :get, path: resource_path, query: { view: "expanded" }))
       self
+    end
+
+    def check_for_update(payload)
+      unless unupdatable_attributes(payload).empty?
+        raise ArgumentError, "Cannot update #{unupdatable_attributes(payload)} only " \
+                             "#{UPDATABLE_ATTRIBUTES} are updatable"
+      end
+    end
+
+    def unupdatable_attributes(payload)
+      @unupdatable_attributes ||= payload.keys.reject { |name| UPDATABLE_ATTRIBUTES.include?(name) }
     end
   end
 end

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -51,7 +51,10 @@ module Nylas
     end
 
     def update(payload)
-      check_for_update(payload)
+      FilterAttributes.new(
+        attributes: payload.keys,
+        allowed_attributes: UPDATABLE_ATTRIBUTES
+      ).check
 
       super(payload)
     end
@@ -61,17 +64,6 @@ module Nylas
 
       assign(api.execute(method: :get, path: resource_path, query: { view: "expanded" }))
       self
-    end
-
-    def check_for_update(payload)
-      unless unupdatable_attributes(payload).empty?
-        raise ArgumentError, "Cannot update #{unupdatable_attributes(payload)} only " \
-                             "#{UPDATABLE_ATTRIBUTES} are updatable"
-      end
-    end
-
-    def unupdatable_attributes(payload)
-      @unupdatable_attributes ||= payload.keys.reject { |name| UPDATABLE_ATTRIBUTES.include?(name) }
     end
   end
 end

--- a/spec/nylas/filter_attributes_spec.rb
+++ b/spec/nylas/filter_attributes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Nylas::FilterAttributes do
+  describe '#check' do
+    context 'when `attributes` and `allowed_attributes` are similar' do
+      it 'does not raise any error' do
+        attributes = %i[foo bar]
+        allowed_attributes = %i[foo bar]
+        filter = Nylas::FilterAttributes.new(attributes: attributes, allowed_attributes: allowed_attributes)
+
+        expect{filter.check}.not_to raise_error
+      end
+    end
+
+    context 'when `attributes` and `allowed_attributes` are different' do
+      it 'raises an error' do
+        attributes = %i[foo bar]
+        allowed_attributes = %i[foo]
+        filter = Nylas::FilterAttributes.new(attributes: attributes, allowed_attributes: allowed_attributes)
+
+        expect{filter.check}.to raise_error(ArgumentError, 'Only [:foo] are allowed to be sent')
+      end
+    end
+  end
+end

--- a/spec/nylas/filter_attributes_spec.rb
+++ b/spec/nylas/filter_attributes_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 describe Nylas::FilterAttributes do
-  describe '#check' do
-    context 'when `attributes` and `allowed_attributes` are similar' do
-      it 'does not raise any error' do
+  describe "#check" do
+    context "when `attributes` and `allowed_attributes` are similar" do
+      it "does not raise any error" do
         attributes = %i[foo bar]
         allowed_attributes = %i[foo bar]
-        filter = Nylas::FilterAttributes.new(attributes: attributes, allowed_attributes: allowed_attributes)
+        filter = described_class.new(attributes: attributes, allowed_attributes: allowed_attributes)
 
-        expect{filter.check}.not_to raise_error
+        expect { filter.check }.not_to raise_error
       end
     end
 
-    context 'when `attributes` and `allowed_attributes` are different' do
-      it 'raises an error' do
+    context "when `attributes` and `allowed_attributes` are different" do
+      it "raises an error" do
         attributes = %i[foo bar]
         allowed_attributes = %i[foo]
-        filter = Nylas::FilterAttributes.new(attributes: attributes, allowed_attributes: allowed_attributes)
+        filter = described_class.new(attributes: attributes, allowed_attributes: allowed_attributes)
 
-        expect{filter.check}.to raise_error(ArgumentError, 'Only [:foo] are allowed to be sent')
+        expect { filter.check }.to raise_error(ArgumentError, "Only [:foo] are allowed to be sent")
       end
     end
   end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -152,8 +152,7 @@ describe Nylas::Message do
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
       expect do
         message.update(subject: "A new subject!")
-      end.to raise_error ArgumentError, "Cannot update [:subject] only " \
-                                        "#{described_class::UPDATABLE_ATTRIBUTES} are updatable"
+      end.to raise_error ArgumentError, "Only #{described_class::UPDATABLE_ATTRIBUTES} are allowed to be sent"
     end
   end
 

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -124,7 +124,7 @@ describe Nylas::Message do
 
   describe "#update" do
     it "let's you set the starred, unread, folder, and label ids" do
-      api =  instance_double(Nylas::API, execute: "{}")
+      api = instance_double(Nylas::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
 
       message.update(
@@ -148,7 +148,7 @@ describe Nylas::Message do
     end
 
     it "raises an argument error if the data has any keys that aren't allowed to be updated" do
-      api =  instance_double(Nylas::API, execute: "{}")
+      api = instance_double(Nylas::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
       expect do
         message.update(subject: "A new subject!")

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -122,6 +122,41 @@ describe Nylas::Message do
     end
   end
 
+  describe "#update" do
+    it "let's you set the starred, unread, folder, and label ids" do
+      api =  instance_double(Nylas::API, execute: "{}")
+      message = described_class.from_json('{ "id": "message-1234" }', api: api)
+
+      message.update(
+        starred: true,
+        unread: false,
+        folder_id: "folder-1234",
+        label_ids: %w[label-1234 label-4567]
+      )
+
+      expect(api).to have_received(:execute).with(
+        method: :put, path: "/messages/message-1234",
+        payload: JSON.dump(
+          starred: true, unread: false,
+          folder_id: "folder-1234",
+          label_ids: %w[
+            label-1234
+            label-4567
+          ]
+        )
+      )
+    end
+
+    it "raises an argument error if the data has any keys that aren't allowed to be updated" do
+      api =  instance_double(Nylas::API, execute: "{}")
+      message = described_class.from_json('{ "id": "message-1234" }', api: api)
+      expect do
+        message.update(subject: "A new subject!")
+      end.to raise_error ArgumentError, "Cannot update [:subject] only " \
+                                        "#{described_class::UPDATABLE_ATTRIBUTES} are updatable"
+    end
+  end
+
   describe "#expanded" do
     it "fetch or return expanded version of message" do
       api = instance_double(Nylas::API, execute: "{}")


### PR DESCRIPTION
Right now there is no way to set a `label` on a `message`.

API accepts `label_ids` as an array of string of label ids.

This PR also add `UPDATABLE_ATTRIBUTES` to just allow few attributes to
be updated allowed by API instead of having all attributes to be
updated.