### PR TITLE
Test against Rails 6 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
- - 2.3
- - 2.4
  - 2.5
  - 2.6
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ env:
 
 matrix:
   include:
-  - rvm: 2.5
-    gemfile: gemfiles/Gemfile.rails6
-  - rvm: 2.6
-    gemfile: gemfiles/Gemfile.rails6
   - rvm: 2.4
     gemfile: gemfiles/Gemfile.rails4
     before_install:
     - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
     - gem install bundler -v '< 2'
+  - rvm: 2.5
+    gemfile: gemfiles/Gemfile.rails6
+  - rvm: 2.6
+    gemfile: gemfiles/Gemfile.rails6
 
   - name: "RuboCop"
     rvm: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 rvm:
+ - 2.3
+ - 2.4
  - 2.5
  - 2.6
 cache: bundler
 gemfile:
-  - gemfiles/Gemfile.rails6
   - gemfiles/Gemfile.rails5
   - gemfiles/Gemfile.rest-client.1
   - gemfiles/Gemfile.rest-client.2
@@ -22,6 +23,10 @@ env:
 
 matrix:
   include:
+  - rvm: 2.5
+    gemfile: gemfiles/Gemfile.rails6
+  - rvm: 2.6
+    gemfile: gemfiles/Gemfile.rails6
   - rvm: 2.4
     gemfile: gemfiles/Gemfile.rails4
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
  - 2.6
 cache: bundler
 gemfile:
+  - gemfiles/Gemfile.rails6
   - gemfiles/Gemfile.rails5
   - gemfiles/Gemfile.rest-client.1
   - gemfiles/Gemfile.rest-client.2

--- a/gemfiles/Gemfile.rails6
+++ b/gemfiles/Gemfile.rails6
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 6'
+
+gemspec path: "..", name: 'nylas-streaming'

--- a/gemfiles/Gemfile.rails6
+++ b/gemfiles/Gemfile.rails6
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 6'
 
+# Load all gems from `gemspec` file.
 gemspec path: "..", name: 'nylas-streaming'


### PR DESCRIPTION
As Rails 6.0 is released we can should also add that to CI.
As Rails 6 only supports ruby 2.5 and above we need to 
add custom matrix for that in CI.

- Gemfile.rails6 added.
- >travis.yml update to run tests with Rails 6.
