### PR TITLE
Fix an error occurring on `message.save`

### DIFF
--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -37,7 +37,7 @@ module Nylas
     attribute :folder, :folder
     attribute :folder_id, :string
 
-    has_n_of_attribute :labels, :label
+    has_n_of_attribute :labels, :label, exclude_when: [:saving]
     has_n_of_attribute :label_ids, :string
 
     transfer :api, to: %i[events files folder labels]

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -25,12 +25,10 @@ module Nylas
     end
 
     def save
-      allowed_keys =  attributes.attribute_definitions.to_h.select {|k, v| !v.exclude_when.include?(:saving)}.keys
-
       result = if persisted?
                  raise ModelNotUpdatableError, self unless updatable?
 
-                 execute(method: :put, payload: attributes.serialize(keys: allowed_keys), path: resource_path)
+                 save_call
                else
                  create
                end
@@ -83,6 +81,22 @@ module Nylas
     # @return [String] JSON String of the model.
     def to_json(_opts = {})
       JSON.dump(to_h)
+    end
+
+    private
+
+    def allowed_keys_for_save
+      attributes.attribute_definitions.to_h.reject do |_k, v|
+        v.exclude_when.include?(:saving)
+      end.keys
+    end
+
+    def save_call
+      execute(
+        method: :put,
+        payload: attributes.serialize(keys: allowed_keys_for_save),
+        path: resource_path
+      )
     end
 
     # Allows you to narrow in exactly what kind of model you're working with

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -25,10 +25,12 @@ module Nylas
     end
 
     def save
+      allowed_keys =  attributes.attribute_definitions.to_h.select {|k, v| !v.exclude_when.include?(:saving)}.keys
+
       result = if persisted?
                  raise ModelNotUpdatableError, self unless updatable?
 
-                 execute(method: :put, payload: attributes.serialize, path: resource_path)
+                 execute(method: :put, payload: attributes.serialize(keys: allowed_keys), path: resource_path)
                else
                  create
                end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -127,7 +127,7 @@ describe Nylas::Message do
       it "removes `labels` from the payload" do
         api = instance_double(Nylas::API, execute: JSON.parse("{}"))
         data = {
-          id: 'message-1234',
+          id: "message-1234",
           labels: [
             { display_name: "All Mail", id: "label-all", name: "all" }
           ]
@@ -143,7 +143,7 @@ describe Nylas::Message do
         expect(api).to have_received(:execute).with(
           method: :put, path: "/messages/message-1234",
           payload: JSON.dump(
-            id: 'message-1234',
+            id: "message-1234",
             date: 0,
             received_date: 0
           )

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -122,9 +122,39 @@ describe Nylas::Message do
     end
   end
 
+  describe "#save" do
+    context "when `labels` key exists" do
+      it "removes `labels` from the payload" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        data = {
+          id: 'message-1234',
+          labels: [
+            { display_name: "All Mail", id: "label-all", name: "all" }
+          ]
+        }
+
+        message = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        message.save
+
+        expect(api).to have_received(:execute).with(
+          method: :put, path: "/messages/message-1234",
+          payload: JSON.dump(
+            id: 'message-1234',
+            date: 0,
+            received_date: 0
+          )
+        )
+      end
+    end
+  end
+
   describe "#update" do
     it "let's you set the starred, unread, folder, and label ids" do
-      api = instance_double(Nylas::API, execute: "{}")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
 
       message.update(


### PR DESCRIPTION
Right now when we call `.save` on a message it raises an error 
because `labels` attributes also being sent to server along with 
other attributes. Server won't know anything about `labels` so it
was failing. This issues also mentioned here https://github.com/nylas/nylas-ruby/issues/183

This PR right now rejecting the `labels` attribute to be sent to server so 
we can save a `message`. 

In this PR also using a feature where we can define `exclude_when` call 
for certain actions.