### PR TITLE
Remove unused attribute `web_page` from contact

### DIFF
--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -29,7 +29,6 @@ module Nylas
     attribute :manager_name, :string
     attribute :office_location, :string
     attribute :notes, :string
-    attribute :web_page, :web_page
     attribute :source, :string
 
     has_n_of_attribute :groups, :contact_group


### PR DESCRIPTION
We are not using a single webpage anywhere so we can remove this from the attribute list