### PR TITLE
Destroy draft object once it is sent successfully

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -37,7 +37,9 @@ module Nylas
 
     def send!
       save
-      execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))
+      message = execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))
+      destroy
+      message
     end
 
     def starred?

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -43,6 +43,8 @@ describe Nylas::Draft do
       expect(api).to have_received(:execute).with(method: :post, path: "/send",
                                                   payload: JSON.dump(draft_id: draft.id,
                                                                      version: draft.version))
+      expect(api).to have_received(:execute).with(method: :delete, path: "/drafts/#{draft.id}",
+      payload: {version: 6}.to_json )
     end
   end
 


### PR DESCRIPTION
This PR updates `send!` methods so that it destroys the draft object once it is sent out successfully.  I've noticed a scenario where the email client persists all the drafts even after it is sent out successfully and transformed into a message in the Nylas system. Please confirm if it is the right implementation.