### PR TITLE
Add missing `provider` attribute to Account model

### DIFF
--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -11,6 +11,7 @@ module Nylas
     attribute :id, :string
     attribute :account_id, :string
     attribute :billing_state, :string
+    attribute :provider, :string
     attribute :sync_state, :string
 
     attribute :email, :string


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

See [API documentation](https://docs.nylas.com/reference#aclient_idaccountsid).

This avoids this log:

> WARN -- : provider is not defined as an attribute on Nylas::Account

Specs fail (on `master`, unrelated to this code) but that's fixed [in another PR](https://github.com/nylas/nylas-ruby/pull/246/files#diff-f70144802a6d2165eb08814271624f92).