### PR TITLE
Remove FS specific characters from downloaded filename

### DIFF
--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -56,6 +56,7 @@ module Nylas
     def retrieve_file
       response = api.get(path: "#{resource_path}/download")
       filename = response.headers.fetch(:content_disposition, "").gsub("attachment; filename=", "")
+      filename.gsub!(%r{[\x00-\x1F\/\\:\*\?\"<>\|]}, "-")
       temp_file = Tempfile.new(filename, encoding: "ascii-8bit")
       temp_file.write(response.body)
       temp_file.seek(0)


### PR DESCRIPTION
Just now filename for Tempfile creation is based on `response.headers`.
It is not safe, in my case a response from Nylas was
`:content_disposition=>"attachment; filename==?utf-8?b?S0lOTyBQT1AgLSBDb3Jwb3JhdGUgZG9jdW1lbnRzIC0gY2/MgXBpYS5wZGY=?=",`
Tempfile creation with such names is impossible because of special characters.