### PR TITLE
Adding secondary_address field to physical address model

### DIFF
--- a/lib/nylas/physical_address.rb
+++ b/lib/nylas/physical_address.rb
@@ -12,5 +12,6 @@ module Nylas
     attribute :state, :string
     attribute :city, :string
     attribute :country, :string
+    attribute :secondary_address, :string
   end
 end


### PR DESCRIPTION
Adding this new field to address the changes for https://app.clubhouse.io/nylas/story/22758/missing-street-address-line-2-data-from-google-contacts-even-though-it-shows-in-the-gdata