### PR TITLE
Add is_primary and other new Calendar attributes

### DIFF
--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -15,11 +15,18 @@ module Nylas
 
     attribute :name, :string
     attribute :description, :string
+    attribute :is_primary, :boolean
+    attribute :location, :string
+    attribute :timezone, :string
 
     attribute :read_only, :boolean
 
     def read_only?
       read_only == true
+    end
+
+    def primary?
+      is_primary
     end
 
     def events


### PR DESCRIPTION
This PR adds support for new attributes that were recently added to the Nylas calendar API: `is_primary`, `location` and `timezone`. To match the convention established by the `read_only?` method, it also adds a `primary?` method which simply returns the value of `is_primary`.

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.