### PR TITLE
Handle new attributes added to API gracefully

### DIFF
--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -27,8 +27,6 @@ module Nylas
         data.each do |attribute_name, value|
           if respond_to?(:"#{attribute_name}=")
             send(:"#{attribute_name}=", value)
-          else
-            Logging.logger.warn("#{attribute_name} is not defined as an attribute on #{self.class.name}")
           end
         end
       end

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -17,6 +17,8 @@ module Nylas
 
       def []=(key, value)
         data[key] = cast(key, value)
+      rescue Nylas::Registry::MissingKeyError
+        # Don't crash when a new attribute is added
       end
 
       # Merges data into the registry while casting input types correctly


### PR DESCRIPTION
A couple of problems came up in our production app when Nylas added new attributes to API objects. One was a constant barrage of Rails logger warnings upon each request that drowned out other log traffic. A second more serious issue was that upon certain operations, the gem would raise exceptions about the unexpected attributes, causing failures in our code even though the requests were successful.

The [Nylas API docs](https://docs.nylas.com/reference#api-versioning) state:
> Nylas considers additive changes to be non-breaking. This means we may add additional fields to an API response object without releasing a new API version, so your application should handle this possibility.

I believe these changes to the gem are necessary in order to respect this very reasonable policy.

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.