### PR TITLE
Remove folder on message.save for updates

### DIFF
--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -34,8 +34,8 @@ module Nylas
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
-    attribute :folder, :folder
     attribute :folder, :folder, exclude_when: [:saving]
+    attribute :folder_id, :string
 
     has_n_of_attribute :labels, :label, exclude_when: [:saving]
     has_n_of_attribute :label_ids, :string

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -35,7 +35,7 @@ module Nylas
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
     attribute :folder, :folder
-    attribute :folder_id, :string
+    attribute :folder, :folder, exclude_when: [:saving]
 
     has_n_of_attribute :labels, :label, exclude_when: [:saving]
     has_n_of_attribute :label_ids, :string

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -34,7 +34,7 @@ module Nylas
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
-    attribute :folder, :folder, exclude_when: [:saving]
+    attribute :folder, :folder
     attribute :folder_id, :string
 
     has_n_of_attribute :labels, :label, exclude_when: [:saving]
@@ -69,5 +69,26 @@ module Nylas
       assign(api.execute(method: :get, path: resource_path, query: { view: "expanded" }))
       self
     end
+    
+    def save_call
+      handle_folder()
+
+      execute(
+        method: :put,
+        payload: attributes.serialize(keys: allowed_keys_for_save),
+        path: resource_path
+      )
+    end
+
+    def handle_folder
+      return if folder.nil?
+      
+      if folder_id.nil? && !self.to_h.dig(:folder, :id).nil?
+        self.folder_id = folder.id 
+      end
+      
+      self.folder = nil
+    end
+
   end
 end

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -69,9 +69,9 @@ module Nylas
       assign(api.execute(method: :get, path: resource_path, query: { view: "expanded" }))
       self
     end
-    
+
     def save_call
-      handle_folder()
+      handle_folder
 
       execute(
         method: :put,
@@ -82,13 +82,10 @@ module Nylas
 
     def handle_folder
       return if folder.nil?
-      
-      if folder_id.nil? && !self.to_h.dig(:folder, :id).nil?
-        self.folder_id = folder.id 
-      end
-      
+
+      self.folder_id = folder.id if folder_id.nil? && !self.to_h.dig(:folder, :id).nil?
+
       self.folder = nil
     end
-
   end
 end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -152,10 +152,10 @@ describe Nylas::Message do
     it "removes the folder node and replaces with folder_id" do
       api = instance_double(Nylas::API, execute: JSON.parse("{}"))
       data = {
-          id: "message-1234",
-          folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
-          starred: true
-        }
+        id: "message-1234",
+        folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+        starred: true
+      }
 
       message = described_class.from_json(
         JSON.dump(data),
@@ -173,15 +173,14 @@ describe Nylas::Message do
         )
       )
     end
-    
     it "does not overwrite folder_id if set" do
       api = instance_double(Nylas::API, execute: JSON.parse("{}"))
       data = {
-          id: "message-1234",
-          folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
-          folder_id: "folder-1234",
-          starred: true
-        }
+        id: "message-1234",
+        folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+        folder_id: "folder-1234",
+        starred: true
+      }
 
       message = described_class.from_json(
         JSON.dump(data),
@@ -199,7 +198,6 @@ describe Nylas::Message do
         )
       )
     end
-
   end
 
   describe "#update" do
@@ -226,7 +224,6 @@ describe Nylas::Message do
         )
       )
     end
-   
     it "raises an argument error if the data has any keys that aren't allowed to be updated" do
       api = instance_double(Nylas::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -148,6 +148,58 @@ describe Nylas::Message do
         )
       end
     end
+
+    it "removes the folder node and replaces with folder_id" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      data = {
+          id: "message-1234",
+          folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+          starred: true
+        }
+
+      message = described_class.from_json(
+        JSON.dump(data),
+        api: api
+      )
+
+      message.save
+
+      expect(api).to have_received(:execute).with(
+        method: :put, path: "/messages/message-1234",
+        payload: JSON.dump(
+          id: "message-1234",
+          starred: true,
+          folder_id: "folder-inbox"
+        )
+      )
+    end
+    
+    it "does not overwrite folder_id if set" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      data = {
+          id: "message-1234",
+          folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+          folder_id: "folder-1234",
+          starred: true
+        }
+
+      message = described_class.from_json(
+        JSON.dump(data),
+        api: api
+      )
+
+      message.save
+
+      expect(api).to have_received(:execute).with(
+        method: :put, path: "/messages/message-1234",
+        payload: JSON.dump(
+          id: "message-1234",
+          starred: true,
+          folder_id: "folder-1234"
+        )
+      )
+    end
+
   end
 
   describe "#update" do
@@ -174,6 +226,58 @@ describe Nylas::Message do
         )
       )
     end
+
+    
+   
+    # it "replaces folder with folder_id" do
+    #   api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+    #   data = {
+    #       id: "message-1234",
+    #       folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" }
+    #     }
+
+    #   message = described_class.from_json(
+    #     JSON.dump(data),
+    #     api: api
+    #   )
+
+    #   message.update(starred: false)
+
+    #   expect(api).to have_received(:execute).with(
+    #     method: :put, path: "/messages/message-1234",
+    #     payload: JSON.dump(
+    #       starred: false,
+    #       folder_id: "folder-inbox"
+    #     )
+    #   )
+    # end
+
+    # it "does not overwrite folder_id if set" do
+    #   api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+    #   # message = described_class.from_json('{ "id": "message-1234" }', api: api)
+
+    #   data = {
+    #     id: "message-1234",
+    #     folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+    #     folder_id: "folder-7890",
+    #     starred: true
+    #   }
+
+    #   message = described_class.from_json(
+    #     JSON.dump(data),
+    #     api: api
+    #   )
+
+    #   message.update(starred: false)
+
+    #   expect(api).to have_received(:execute).with(
+    #     method: :put, path: "/messages/message-1234",
+    #     payload: JSON.dump(
+    #       starred: false,
+    #       folder_id: "folder-7890"
+    #     )
+    #   )
+    # end
 
     it "raises an argument error if the data has any keys that aren't allowed to be updated" do
       api = instance_double(Nylas::API, execute: "{}")

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -226,59 +226,7 @@ describe Nylas::Message do
         )
       )
     end
-
-    
    
-    # it "replaces folder with folder_id" do
-    #   api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-    #   data = {
-    #       id: "message-1234",
-    #       folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" }
-    #     }
-
-    #   message = described_class.from_json(
-    #     JSON.dump(data),
-    #     api: api
-    #   )
-
-    #   message.update(starred: false)
-
-    #   expect(api).to have_received(:execute).with(
-    #     method: :put, path: "/messages/message-1234",
-    #     payload: JSON.dump(
-    #       starred: false,
-    #       folder_id: "folder-inbox"
-    #     )
-    #   )
-    # end
-
-    # it "does not overwrite folder_id if set" do
-    #   api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-    #   # message = described_class.from_json('{ "id": "message-1234" }', api: api)
-
-    #   data = {
-    #     id: "message-1234",
-    #     folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
-    #     folder_id: "folder-7890",
-    #     starred: true
-    #   }
-
-    #   message = described_class.from_json(
-    #     JSON.dump(data),
-    #     api: api
-    #   )
-
-    #   message.update(starred: false)
-
-    #   expect(api).to have_received(:execute).with(
-    #     method: :put, path: "/messages/message-1234",
-    #     payload: JSON.dump(
-    #       starred: false,
-    #       folder_id: "folder-7890"
-    #     )
-    #   )
-    # end
-
     it "raises an argument error if the data has any keys that aren't allowed to be updated" do
       api = instance_double(Nylas::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)


### PR DESCRIPTION
## Issue
When updating a message in Outlook, we throw an error if the folder sub-object is present in the request.
```
/Users/nickbair/.rvm/gems/ruby-2.6.5/gems/nylas-4.6.2/lib/nylas/http_client.rb:166:in `handle_anticipated_failure_mode': Invalid id: {u'display_name': u'Junk Email', u'id': u'a8cquo7scqx8qpzd5hslmbeqz', u'name': u'spam'} (Nylas::InvalidRequest)
```

## The fix
If a folder is present when updating a message, store the folder's `id` in `folder_id` and remove `folder` from the request payload that is sent to the Nylas API.

<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.