### PR TITLE
Fix JSON parsing behavior

### DIFF
--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Nylas
-  require 'yajl'
+  require "yajl"
 
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient # rubocop:disable Metrics/ClassLength
@@ -135,7 +135,7 @@ module Nylas
       return response if response.is_a?(Enumerable)
 
       json = StringIO.new(response)
-      Yajl::Parser.new(:symbolize_names => true).parse(json)
+      Yajl::Parser.new(symbolize_names: true).parse(json)
     end
     inform_on :parse_response, level: :debug, also_log: { result: true }
 

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Nylas
+  require 'yajl'
+
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient # rubocop:disable Metrics/ClassLength
     HTTP_CODE_TO_EXCEPTIONS = {
@@ -130,9 +132,10 @@ module Nylas
     end
 
     def parse_response(response)
-      response.is_a?(Enumerable) ? response : JSON.parse(response, symbolize_names: true)
-    rescue JSON::ParserError
-      response
+      return response if response.is_a?(Enumerable)
+
+      json = StringIO.new(response)
+      Yajl::Parser.new(:symbolize_names => true).parse(json)
     end
     inform_on :parse_response, level: :debug, also_log: { result: true }
 

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -7,4 +7,5 @@ Gem::Specification.new do |gem|
   gem.summary = %(Gem for interacting with the Nylas API)
   gem.description = %(Gem for interacting with the Nylas API.)
   gem.add_runtime_dependency "rest-client", ">= 1.6", "< 3.0"
+  gem.add_runtime_dependency "yajl-ruby", "~> 1.2", ">= 1.2.1"
 end

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -1,30 +1,24 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require 'yajl'
+require "yajl"
 
 describe Nylas::HttpClient do
   let(:full_json) do
-    '{"account_id":"1234","bcc":[],"body":"","cc":[],"date":1607313827,"events":[],"files":[],"folder":{"display_name":"Deleted Messages","id":"1234","name":"trash"},"from":[{"email":"hello@nylas.com","name":"Book Updates"}],"id":"1234","object":"message","reply_to":[],"snippet":"\u26a1\ufe0f Some text \ud83d","starred":false,"subject":"Updates","thread_id":"1234","to":[{"email":"hello@nylas.com","name":"Hello Nylas"}],"unread":false}'
+    '{"snippet":"\u26a1\ufe0f Some text \ud83d","starred":false,"subject":"Updates"}'
   end
   let(:api) { FakeAPI.new }
 
   describe "#parse_response" do
     it "deserializes JSON with unicode characters" do
-      nylas = Nylas::HttpClient.new(app_id: 'id', app_secret: 'secret', access_token: 'token')
-
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       response = nylas.parse_response(full_json)
-
       expect(response).not_to be_a_kind_of(String)
     end
 
     it "raises if the JSON is unable to be deserialized" do
-      nylas = Nylas::HttpClient.new(app_id: 'id', app_secret: 'secret', access_token: 'token')
-
-      expect {
-        nylas.parse_response("{{")
-      }.to raise_error(Yajl::ParseError)
-
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      expect { nylas.parse_response("{{") }.to raise_error(Yajl::ParseError)
     end
   end
 

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require 'yajl'
+
+describe Nylas::HttpClient do
+  let(:full_json) do
+    '{"account_id":"1234","bcc":[],"body":"","cc":[],"date":1607313827,"events":[],"files":[],"folder":{"display_name":"Deleted Messages","id":"1234","name":"trash"},"from":[{"email":"hello@nylas.com","name":"Book Updates"}],"id":"1234","object":"message","reply_to":[],"snippet":"\u26a1\ufe0f Some text \ud83d","starred":false,"subject":"Updates","thread_id":"1234","to":[{"email":"hello@nylas.com","name":"Hello Nylas"}],"unread":false}'
+  end
+  let(:api) { FakeAPI.new }
+
+  describe "#parse_response" do
+    it "deserializes JSON with unicode characters" do
+      nylas = Nylas::HttpClient.new(app_id: 'id', app_secret: 'secret', access_token: 'token')
+
+      response = nylas.parse_response(full_json)
+
+      expect(response).not_to be_a_kind_of(String)
+    end
+
+    it "raises if the JSON is unable to be deserialized" do
+      nylas = Nylas::HttpClient.new(app_id: 'id', app_secret: 'secret', access_token: 'token')
+
+      expect {
+        nylas.parse_response("{{")
+      }.to raise_error(Yajl::ParseError)
+
+    end
+  end
+
+end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -143,7 +143,7 @@ describe Nylas::Message do
         expect(api).to have_received(:execute).with(
           method: :put, path: "/messages/message-1234",
           payload: JSON.dump(
-            id: "message-1234",
+            id: "message-1234"
           )
         )
       end


### PR DESCRIPTION
## Issue
In `http_client.rb` when parsing the response from an API call, if `JSON.parse` raises an error, the error is rescued and the raw response returned.  This causes an error downstream in `attributable.rb` and returns a non-specific error `wrong number of arguments (given 1, expected 0)`.

The one instance of a consistently reproducible parse error I was able to find using the Nylas API was an email with the unicode character `\ud83d`, thus is was used as the primary test case.  Technically speaking, `\ud83d` is not valid, but IMO, instead of raising an error, replacing the offending character or returning the string literal value is a better approach.

## Fix / Changes
1. Given an error when parsing JSON, no longer rescue the error.
2. Replace JSON with Yajl for parsing responses (also used in the Nylas streaming gem), instead of raising an error when parsing JSON that contains `\ud83d` it is replaced with a `?`.

<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.