### PR TITLE
Add message tracking to drafts.

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -38,7 +38,7 @@ module Nylas
     transfer :api, to: %i[events files folder labels]
 
     def send!
-      return execute(method: :post, path: "/send", payload: JSON.dump(to_h)) if tracking
+      return execute(method: :post, path: "/send", payload: to_json) if tracking
 
       save
       execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -33,9 +33,13 @@ module Nylas
     attribute :folder, :folder
     has_n_of_attribute :labels, :label
 
+    attribute :tracking, :message_tracking
+
     transfer :api, to: %i[events files folder labels]
 
     def send!
+      return execute(method: :post, path: "/send", payload: JSON.dump(to_h)) if tracking
+
       save
       execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))
     end


### PR DESCRIPTION
Add support for message tracking to the drafts class.  Users who are not adding the tracking attribute to their draft will not hit the new code.

<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.