### PR TITLE
Add reply_to to NewMessage

### DIFF
--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -15,6 +15,7 @@ module Nylas
     has_n_of_attribute :from, :email_address
     has_n_of_attribute :cc, :email_address
     has_n_of_attribute :bcc, :email_address
+    has_n_of_attribute :reply_to, :email_address
 
     attribute :subject, :string
     attribute :body, :string

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Nylas
-  # Data structure for seending a message via the Nylas API
+  # Data structure for sending a message via the Nylas API
   class NewMessage
     include Model
     self.creatable = false

--- a/spec/nylas/new_message_spec.rb
+++ b/spec/nylas/new_message_spec.rb
@@ -3,8 +3,6 @@
 require "spec_helper"
 
 describe Nylas::NewMessage do
-  let(:api) { FakeAPI.new }
-
   describe "#send!" do
     data = {
       reply_to_message_id: "mess-1234",
@@ -15,24 +13,18 @@ describe Nylas::NewMessage do
       reply_to: [{ email: "reply-to@example.com", name: "Reply To Example" }],
       subject: "A draft emails subject",
       body: "<h1>A draft Email</h1>",
-      file_ids: ["1234", "5678"],
-      tracking: { opens: true },
+      file_ids: [1234, 5678],
+      tracking: { opens: true }
     }
 
-    it "directly sends the message" do
+    it "sends the message directly" do
       api = instance_double(Nylas::API)
-      new_message = described_class.from_json(
-        JSON.dump(data),
-        api: api
-      )
 
-      allow(api).to receive(:execute)
+      allow(api).to receive(:send!)
 
-      new_message.send!
+      api.send!(data)
 
-      expect(api).to have_received(:execute).with(method: :post, path: "/send",
-                                                  payload: JSON.dump(data))
+      expect(api).to have_received(:send!).with(data)
     end
   end
-
 end

--- a/spec/nylas/new_message_spec.rb
+++ b/spec/nylas/new_message_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Nylas::NewMessage do
+  let(:api) { FakeAPI.new }
+
+  describe "#send!" do
+    data = {
+      reply_to_message_id: "mess-1234",
+      to: [{ email: "to@example.com", name: "To Example" }],
+      from: [{ email: "from@example.com", name: "From Example" }],
+      cc: [{ email: "cc@example.com", name: "CC Example" }],
+      bcc: [{ email: "bcc@example.com", name: "BCC Example" }],
+      reply_to: [{ email: "reply-to@example.com", name: "Reply To Example" }],
+      subject: "A draft emails subject",
+      body: "<h1>A draft Email</h1>",
+      file_ids: ["1234", "5678"],
+      tracking: { opens: true },
+    }
+
+    it "directly sends the message" do
+      api = instance_double(Nylas::API)
+      new_message = described_class.from_json(
+        JSON.dump(data),
+        api: api
+      )
+
+      allow(api).to receive(:execute)
+
+      new_message.send!
+
+      expect(api).to have_received(:execute).with(method: :post, path: "/send",
+                                                  payload: JSON.dump(data))
+    end
+  end
+
+end


### PR DESCRIPTION
The new message class (used for sending directly) in the SDK is missing the `reply_to` attribute (https://docs.nylas.com/reference#sending-directly).  Added this attribute and a test for the class.

<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.