### PR TITLE
Truncate the returned filename so it's less than 256 characters

### DIFF
--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -56,7 +56,9 @@ module Nylas
     def retrieve_file
       response = api.get(path: "#{resource_path}/download")
       filename = response.headers.fetch(:content_disposition, "").gsub("attachment; filename=", "")
-      temp_file = Tempfile.new(filename, encoding: "ascii-8bit")
+      # The returned filename can be longer than 256 chars which isn't supported by rb_sysopen.
+      # 128 chars here is more than enough given that TempFile ensure the filename will be unique.
+      temp_file = Tempfile.new(filename[0..127], encoding: "ascii-8bit")
       temp_file.write(response.body)
       temp_file.seek(0)
       temp_file


### PR DESCRIPTION
This ensures the filename will be compatible with rb_sysopen. See the [Clubhouse story](https://app.clubhouse.io/nylas/story/49502) for more details.

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.