### PR TITLE
Fix thread-safety issue in HTTP::CookieJar loading

### DIFF
--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -3,6 +3,21 @@
 require "json"
 require "rest-client"
 
+# BUGFIX
+#   See https://github.com/sparklemotion/http-cookie/issues/27
+#   and https://github.com/sparklemotion/http-cookie/issues/6
+#
+# CookieJar uses unsafe class caching for dynamically loading cookie jars
+# If 2 rest-client instances are instantiated at the same time, (in threads)
+# non-deterministic behaviour can occur whereby the Hash cookie jar isn't
+# properly loaded and cached.
+# Forcing an instantiation of the jar onload will force the CookieJar to load
+# before the system has a chance to spawn any threads.
+# Note this should technically be fixed in rest-client itself however that
+# library appears to be stagnant so we're forced to fix it here
+# This object should get GC'd as it's not referenced by anything
+HTTP::CookieJar.new
+
 require "ostruct"
 require "forwardable"
 


### PR DESCRIPTION
HTTP::CookieJar uses unsafe class caching for dynamically loading cookie jar implementations. If 2 rest-client instances are instantiated at the same time, (for instance if you spawn 2 threads), then non-deterministic behaviour can occur whereby the Hash cookie jar isn't entirely loaded and cached. This _sometimes_ [raises an exception](https://github.com/sparklemotion/http-cookie/blob/master/lib/http/cookie_jar/abstract_store.rb#L21) because the Hash CookieJar can't be found (it's a race condition)

See:
- https://github.com/sparklemotion/http-cookie/issues/27
- https://github.com/sparklemotion/http-cookie/issues/6

Forcing an instantiation of the jar onload will force the Hash CookieJar to load before the system has a chance to spawn any threads.

Note this should technically be fixed in rest-client itself however that library appears to be stagnant so we're forced to fix it here. This object should get GC'd as it's not referenced by anything

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.