### PR TITLE
Add content_disposition to file attrs.

### DIFF
--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -18,6 +18,7 @@ module Nylas
     attribute :content_type, :string
     attribute :filename, :string
     attribute :size, :integer
+    attribute :content_disposition, :string
 
     attr_accessor :file
     # Downloads and caches a local copy of the file.


### PR DESCRIPTION
Adds `content_disposition` attribute to files.  Content disposition is included by the API when fetching messages with attachments:

```
{
...
"files":
  [{"content_disposition": "attachment", ...}]
}
```

<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.