### PR TITLE
Try parsing all responses as JSON and rescue errors to avoid intermittent parsing errors

### DIFF
--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -86,14 +86,12 @@ module Nylas
         timeout: timeout
       )
       rest_client_execute(**request) do |response, _request, result|
-        content_type = nil
-
-        if response.headers && response.headers[:content_type]
-          content_type = response.headers[:content_type].downcase
+        # Try to parse all responses as JSON, since api.nylas.com content-type can be flaky
+        begin
+          response = parse_response(response)
+        rescue Nylas::JsonParseError
         end
-
-        response = parse_response(response) if content_type == "application/json"
-
+        
         handle_failed_response(result: result, response: response)
         response
       end


### PR DESCRIPTION
## Issue
It seems that api.nylas.com fails to include the `application/json` content-type header on some responses. This is causing intermittent parsing errors when assigning values.

## Fixes
Replaced content-type check with logic that always tries parsing a response as JSON, and rescuing if that fails. This should properly parse JSON responses with no content-type header set, and still allow other response types to be passed through un-parsed.

#
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.