### PR TITLE
Add provider attribute to Account model

### DIFF
--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -12,6 +12,7 @@ module Nylas
     attribute :account_id, :string
     attribute :billing_state, :string
     attribute :sync_state, :string
+    attribute :provider, :string
 
     attribute :email, :string
     attribute :trial, :boolean

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -22,9 +22,15 @@ describe Nylas::Account do
   end
 
   it "can be deserialized from JSON" do
-    json = JSON.dump(account_id: "30zipv27dtrsnkleg59mprw5p", billing_state: "paid",
-                     email: "test@example.com", id: "30zipv27dtrsnkleg59mprw5p", sync_state: "running",
-                     trial: false)
+    json = JSON.dump(
+      account_id: "30zipv27dtrsnkleg59mprw5p",
+      billing_state: "paid",
+      email: "test@example.com",
+      id: "30zipv27dtrsnkleg59mprw5p",
+      sync_state: "running",
+      trial: false,
+      provider: "gmail"
+    )
     account = described_class.from_json(json, api: nil)
     expect(account.account_id).to eql "30zipv27dtrsnkleg59mprw5p"
     expect(account.billing_state).to eql "paid"
@@ -32,6 +38,7 @@ describe Nylas::Account do
     expect(account.id).to eql "30zipv27dtrsnkleg59mprw5p"
     expect(account.sync_state).to eql "running"
     expect(account.trial).to be false
+    expect(account.provider).to eq("gmail")
   end
 
   it "can be downgraded" do


### PR DESCRIPTION
We are getting `provider` attribute when fetching account details
and it's good to have it available to read via SDK.
This PR adds `provider` attribute to `Nylas::Account` so it
can be populated when fetched via API.
This was also requested in #256

Changes:
- Update `Nylas::Account` to add `provider` attribute.