### PR TITLE
Fix issue where download a file fetch via `find`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Fix issue where download a file fetch via `find` failed #258, #287
+
 ### 4.6.6 / 2021-04-06
 
 * Add support for `notify_participants` when creating events

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -127,8 +127,13 @@ module Nylas
     end
 
     def find_model(id)
-      instance = model.from_hash({ id: id }, api: api)
-      instance.reload
+      response = api.execute(
+        **to_be_executed.merge(
+          path: "#{resources_path}/#{id}",
+          query: {}
+        )
+      )
+      instance = model.from_hash(response, api: api)
       instance
     end
 

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -133,8 +133,7 @@ module Nylas
           query: {}
         )
       )
-      instance = model.from_hash(response, api: api)
-      instance
+      model.from_hash(response, api: api)
     end
 
     # @return [Hash] Specification for request to be passed to {API#execute}

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -128,7 +128,7 @@ module Nylas
 
     def find_model(id)
       response = api.execute(
-        to_be_executed.merge(
+        **to_be_executed.merge(
           path: "#{resources_path}/#{id}",
           query: {}
         )

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -128,7 +128,7 @@ module Nylas
 
     def find_model(id)
       response = api.execute(
-        **to_be_executed.merge(
+        to_be_executed.merge(
           path: "#{resources_path}/#{id}",
           query: {}
         )

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -71,6 +71,28 @@ describe Nylas::Collection do
       instance = collection.find(1234)
 
       expect(instance.id).to eql "1234"
+      expect(instance.api).to eq(api)
+    end
+
+    it "allows `api` to be sent to the related attributes" do
+      collection = described_class.new(model: FullModel, api: api)
+      expected_response = example_instance_hash.merge(
+        files: [
+          {
+            id: 'file-id'
+          }
+        ]
+      )
+      allow(api).to receive(:execute).with(
+        method: :get,
+        path: "/collection/1234",
+        query: {},
+        headers: {}
+      ).and_return(expected_response)
+
+      instance = collection.find(1234)
+
+      expect(instance.files.first.api).to eq(api)
     end
   end
 

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -61,8 +61,12 @@ describe Nylas::Collection do
   describe "#find" do
     it "retrieves a single object, without filtering based upon `where` clauses earlier in the chain" do
       collection = described_class.new(model: FullModel, api: api)
-      allow(api).to receive(:execute).with(method: :get, path: "/collection/1234", payload: nil, query: {})
-                                     .and_return(example_instance_hash)
+      allow(api).to receive(:execute).with(
+        method: :get,
+        path: "/collection/1234",
+        query: {},
+        headers: {}
+      ).and_return(example_instance_hash)
 
       instance = collection.find(1234)
 

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -79,7 +79,7 @@ describe Nylas::Collection do
       expected_response = example_instance_hash.merge(
         files: [
           {
-            id: 'file-id'
+            id: "file-id"
           }
         ]
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,11 @@ class FullModel
   attribute :web_page, :web_page
 
   has_n_of_attribute :web_pages, :web_page
+  has_n_of_attribute :files, :file
+
+  attr_accessor :api
+
+  transfer :api, to: %i[files]
 end
 
 class NotCreatableModel


### PR DESCRIPTION
This PR fixes issue where downloading a file for the
message which is fetched via `find_model` method.
This PR updates `find_model` to fetch from API and then use
`from_hash` to initialize object instead of just using `reload`
which was internally using `assign` method to assign values.
By doing this way `file` object properly gets `api` attribute
assigned and `download` method works.
This issue was reported in #258

Changes:
- Update `Nylas::Collection` to update `find_model` method
  to fetch again fron API and use `from_hash` method.