### PR TITLE
Remaining fixes required to work with Ruby3

### DIFF
--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -119,7 +119,7 @@ module Nylas
     end
 
     def find_raw(id)
-      api.execute(to_be_executed.merge(path: "#{resources_path}/#{id}")).to_s
+      api.execute(**to_be_executed.merge(path: "#{resources_path}/#{id}")).to_s
     end
 
     def resources_path

--- a/lib/nylas/deltas_collection.rb
+++ b/lib/nylas/deltas_collection.rb
@@ -34,7 +34,7 @@ module Nylas
     # Retrieves the data from the API for the particular constraints
     # @return [Detlas]
     def execute
-      self.deltas ||= Deltas.new(**api.execute(to_be_executed))
+      self.deltas ||= Deltas.new(**api.execute(**to_be_executed))
     end
   end
 end


### PR DESCRIPTION
We have done some changes in #283 to make this gem works with
Ruby 3 and above but there are few changes left which are covered
in this PR. This PR fixes fetching `deltas` and fixes fetching an
object when content-type is not `json`.

This PR has been verified based on feedback received in #289

More details about this upgrade can be read here:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/