### PR TITLE
Exclude `id`, `object` and `account_id` when updating an event

### DIFF
--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -9,9 +9,9 @@ module Nylas
     allows_operations(creatable: true, listable: true, filterable: true, showable: true, updatable: true,
                       destroyable: true)
 
-    attribute :id, :string
-    attribute :object, :string
-    attribute :account_id, :string
+    attribute :id, :string, exclude_when: %i[saving]
+    attribute :object, :string, exclude_when: %i[saving]
+    attribute :account_id, :string, exclude_when: %i[saving]
     attribute :calendar_id, :string
     attribute :master_event_id, :string
     attribute :message_id, :string

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -150,8 +150,87 @@ describe Nylas::Event do
     end
   end
 
-  describe "notify_participants" do
+  describe "account_id" do
     context "when saving" do
+      it "is excluded from payload" do
+        api = instance_double(Nylas::API)
+        allow(api).to receive(:execute).and_return({})
+        data = {
+          id: "event-id",
+          account_id: "acc-1234",
+          read_only: false,
+          calendar_id: "cal-0987"
+        }
+        event = described_class.from_json(JSON.dump(data), api: api)
+
+        event.save
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/events/event-id",
+          payload: {
+            calendar_id: "cal-0987",
+            read_only: false
+          }.to_json,
+          query: {}
+        )
+      end
+    end
+  end
+
+  describe "object" do
+    context "when saving" do
+      it "is excluded from payload" do
+        api = instance_double(Nylas::API)
+        allow(api).to receive(:execute).and_return({})
+        data = {
+          id: "event-id",
+          object: "event",
+          calendar_id: "cal-0987"
+        }
+        event = described_class.from_json(JSON.dump(data), api: api)
+
+        event.save
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/events/event-id",
+          payload: {
+            calendar_id: "cal-0987"
+          }.to_json,
+          query: {}
+        )
+      end
+    end
+  end
+
+  describe "id" do
+    context "when saving" do
+      it "is excluded from payload" do
+        api = instance_double(Nylas::API)
+        allow(api).to receive(:execute).and_return({})
+        data = {
+          id: "event-id",
+          calendar_id: "cal-0987"
+        }
+        event = described_class.from_json(JSON.dump(data), api: api)
+
+        event.save
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/events/event-id",
+          payload: {
+            calendar_id: "cal-0987"
+          }.to_json,
+          query: {}
+        )
+      end
+    end
+  end
+
+  describe "notify_participants" do
+    context "when creating" do
       it "sends notify_participants in query params" do
         api = instance_double(Nylas::API)
         allow(api).to receive(:execute).and_return({})


### PR DESCRIPTION
We have identified that few of the event update calls to the API
sends `object` and `account_id` attributes and it should not be
allowed to send.
This PR stops sending `id`, `object` and `account_id` attribute
to the API when we call `.save` on an event object. These are
readonly object on server and we should avoid sending it.