### PR TITLE
Add support for authentication_url for hosted authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 4.6.7 / 2021-04-22
+### Unreleased
+
+* Add support for hosted authentication #292
+
+### 4.6.7 / 2021-04-22
 
 * Support for Ruby 3.
 * Add support for `/free-busy` endpoint #288

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -38,16 +38,14 @@ module Nylas
     end
 
     def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil)
-      scopes = scopes.join(",") if scopes
-
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,
         response_type: response_type,
-        scopes: scopes,
         login_hint: login_hint
       }
       params[:state] = state if state
+      params[:scopes] = scopes.join(",") if scopes
 
       "#{api_server}/oauth/authorize?#{URI.encode_www_form(params)}"
     end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -49,7 +49,7 @@ module Nylas
       }
       params[:state] = state if state
 
-      api_server + "/oauth/authorize?" + URI.encode_www_form(params)
+      "#{api_server}/oauth/authorize?#{URI.encode_www_form(params)}"
     end
 
     def exchange_code_for_token(code)

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -6,7 +6,7 @@ module Nylas
     attr_accessor :client
 
     extend Forwardable
-    def_delegators :client, :execute, :get, :post, :put, :delete, :app_id
+    def_delegators :client, :execute, :get, :post, :put, :delete, :app_id, :api_server
 
     include Logging
 
@@ -35,6 +35,21 @@ module Nylas
         reauth_account_id: reauth_account_id,
         scopes: scopes
       )
+    end
+
+    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil)
+      scopes = scopes.join(",") if scopes
+
+      params = {
+        client_id: app_id,
+        redirect_uri: redirect_uri,
+        response_type: response_type,
+        scopes: scopes,
+        login_hint: login_hint
+      }
+      params[:state] = state if state
+
+      api_server + "/oauth/authorize?" + URI.encode_www_form(params)
     end
 
     def exchange_code_for_token(code)

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -26,11 +26,20 @@ describe Nylas::API do
       it "returns url for hosted_authentication" do
         api = described_class.new(app_id: "2454354")
 
-        hosted_auth_url = api.authentication_url(redirect_uri: "http://example.com", scopes: ["email"])
+        hosted_auth_url = api.authentication_url(
+          redirect_uri: "http://example.com",
+          scopes: %w[email calendar],
+          login_hint: "email@example.com",
+          state: "some-state"
+        )
 
-        expected_url = "https://api.nylas.com/oauth/authorize?"\
-        "client_id=2454354&redirect_uri=http%3A%2F%2Fexample.com&response_type=code"\
-        "&scopes=email&login_hint"
+        expected_url = "https://api.nylas.com/oauth/authorize"\
+        "?client_id=2454354"\
+        "&redirect_uri=http%3A%2F%2Fexample.com"\
+        "&response_type=code"\
+        "&login_hint=email%40example.com"\
+        "&state=some-state"\
+        "&scopes=email%2Ccalendar"
         expect(hosted_auth_url).to eq expected_url
       end
     end
@@ -50,6 +59,22 @@ describe Nylas::API do
         expect do
           api.authentication_url(redirect_uri: "http://example.com")
         end.to raise_error(ArgumentError, /scopes/)
+      end
+
+      it "generates wrong url if scopes and redirect_uri is nil" do
+        api = described_class.new(app_id: "2454354")
+
+        hosted_auth_url = api.authentication_url(
+          redirect_uri: nil,
+          scopes: nil
+        )
+
+        expected_url = "https://api.nylas.com/oauth/authorize"\
+        "?client_id=2454354"\
+        "&redirect_uri"\
+        "&response_type=code"\
+        "&login_hint"
+        expect(hosted_auth_url).to eq(expected_url)
       end
     end
   end

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -21,6 +21,39 @@ describe Nylas::API do
     end
   end
 
+  describe "#authentication_url" do
+    context "with required parameters" do
+      it "returns url for hosted_authentication" do
+        api = described_class.new(app_id: "2454354")
+
+        hosted_auth_url = api.authentication_url(redirect_uri: "http://example.com", scopes: ["email"])
+
+        expected_url = "https://api.nylas.com/oauth/authorize?"\
+        "client_id=2454354&redirect_uri=http%3A%2F%2Fexample.com&response_type=code"\
+        "&scopes=email&login_hint"
+        expect(hosted_auth_url).to eq expected_url
+      end
+    end
+
+    context "when required parameter are missing" do
+      it "throws argument error if redirect uri is mising" do
+        api = described_class.new(app_id: "2454354")
+
+        expect do
+          api.authentication_url(scopes: ["email"])
+        end.to raise_error(ArgumentError, /redirect_uri/)
+      end
+
+      it "throws argument error if scopes is mising" do
+        api = described_class.new(app_id: "2454354")
+
+        expect do
+          api.authentication_url(redirect_uri: "http://example.com")
+        end.to raise_error(ArgumentError, /scopes/)
+      end
+    end
+  end
+
   describe "#contact_groups" do
     it "returns Nylas::Collection for contact groups" do
       client = instance_double("Nylas::HttpClient")


### PR DESCRIPTION
This PR adds `authentication_url` method to generate a URL to redirect
to login through Nylas hosted authentication flow.

Mode information can be found here about how authentication flow works
https://docs.nylas.com/reference#oauth

These changes also requested in #223 and also worked on a bit in #227

Changes:
- Update `Nylas::API` to add `authentication_url` method.