### PR TITLE
Support for `messages.expanded.find(id)` to get expanded message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Metrics/ParameterLists:
 Metrics/ClassLength:
   Exclude:
     - "lib/nylas/api.rb"
+    - "lib/nylas/collection.rb"
 
 Naming/FileName:
   Exclude:

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -130,7 +130,7 @@ module Nylas
       response = api.execute(
         **to_be_executed.merge(
           path: "#{resources_path}/#{id}",
-          query: {}
+          query: view_query
         )
       )
       model.from_hash(response, api: api)
@@ -146,6 +146,16 @@ module Nylas
     # @return [Hash,Array]
     def execute
       api.execute(**to_be_executed)
+    end
+
+    private
+
+    def view_query
+      if constraints.view
+        { view: constraints.view }
+      else
+        {}
+      end
     end
   end
 end

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -74,7 +74,7 @@ describe Nylas::Collection do
       expect(instance.api).to eq(api)
     end
 
-    it "retrieves a single object with `view` argument in query if clauses earlier in the chain" do
+    it "retrieves with `view` argument in query if clauses earlier in the chain" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute).and_return(example_instance_hash)
 
@@ -86,6 +86,22 @@ describe Nylas::Collection do
         method: :get,
         path: "/collection/1234",
         query: { view: "expanded" },
+        headers: {}
+      )
+    end
+
+    it "retrieves without `view` argument in query if not clauses earlier in the chain" do
+      collection = described_class.new(model: FullModel, api: api)
+      allow(api).to receive(:execute).and_return(example_instance_hash)
+
+      instance = collection.find(1234)
+
+      expect(instance.id).to eql "1234"
+      expect(instance.api).to eq(api)
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/collection/1234",
+        query: {},
         headers: {}
       )
     end

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -74,7 +74,7 @@ describe Nylas::Collection do
       expect(instance.api).to eq(api)
     end
 
-    it "retrieves a single object, with `view` argument in query if given" do
+    it "retrieves a single object with `view` argument in query if clauses earlier in the chain" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute).and_return(example_instance_hash)
 

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -74,6 +74,22 @@ describe Nylas::Collection do
       expect(instance.api).to eq(api)
     end
 
+    it "retrieves a single object, with `view` argument in query if given" do
+      collection = described_class.new(model: FullModel, api: api)
+      allow(api).to receive(:execute).and_return(example_instance_hash)
+
+      instance = collection.expanded.find(1234)
+
+      expect(instance.id).to eql "1234"
+      expect(instance.api).to eq(api)
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/collection/1234",
+        query: { view: "expanded" },
+        headers: {}
+      )
+    end
+
     it "allows `api` to be sent to the related attributes" do
       collection = described_class.new(model: FullModel, api: api)
       expected_response = example_instance_hash.merge(


### PR DESCRIPTION
Currently sending `view` in the query param is not supported when
fetching a single record and we want to support it as it's already
supported in API. This PR allows to chain `view` related methods before
`find` so that `view` is send to API.

This PR fixes #189 where it has been requested that expanded message
should be fetched in single call by sending `view=expanded` in query param.


Changes:
- Update `Nylas::Collection` to send `view` in query params when a view
related method is chained.