### PR TITLE
Fixed issue when sending message raw mime type

### DIFF
--- a/lib/nylas/raw_message.rb
+++ b/lib/nylas/raw_message.rb
@@ -11,8 +11,12 @@ module Nylas
     end
 
     def send!
-      Message.new(api.execute(method: :post, path: "/send", payload: mime_compatible_string,
-                              headers: { "Content-type" => "message/rfc822" }).merge(api: api))
+      Message.new(**api.execute(
+        method: :post,
+        path: "/send",
+        payload: mime_compatible_string,
+        headers: { "Content-type" => "message/rfc822" }
+      ).merge(api: api))
     end
   end
 end

--- a/lib/nylas/raw_message.rb
+++ b/lib/nylas/raw_message.rb
@@ -15,8 +15,11 @@ module Nylas
         method: :post,
         path: "/send",
         payload: mime_compatible_string,
-        headers: { "Content-type" => "message/rfc822" }
+        headers: HEADERS
       ).merge(api: api))
     end
+
+    HEADERS = { "Content-type" => "message/rfc822" }.freeze
+    private_constant :HEADERS
   end
 end

--- a/spec/nylas/raw_message_spec.rb
+++ b/spec/nylas/raw_message_spec.rb
@@ -9,7 +9,6 @@ describe Nylas::RawMessage do
         "To: You <#{ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-real@example.com')}>\n\n" \
         "This is the body of the message sent as a raw mime!"
       api = FakeAPI.new
-      # collection = Nylas::Message.new(model: FullModel, api: api)
       example_instance_hash = { id: "1234" }
       allow(api).to receive(:execute).and_return(example_instance_hash)
       message = described_class.new(message_string, api: api)

--- a/spec/nylas/raw_message_spec.rb
+++ b/spec/nylas/raw_message_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Nylas::RawMessage do
+  describe ".#send!" do
+    it "calls execute on api with params" do
+      message_string = "MIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\n" \
+        "Subject: A mime email\n" \
+        "From: You <your-email@example.com>\n" \
+        "To: You <#{ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-real@example.com')}>\n\n" \
+        "This is the body of the message sent as a raw mime!"
+      api = FakeAPI.new
+      # collection = Nylas::Message.new(model: FullModel, api: api)
+      example_instance_hash = { id: "1234" }
+      allow(api).to receive(:execute).and_return(example_instance_hash)
+      message = described_class.new(message_string, api: api)
+
+      message.send!
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/send",
+        payload: message_string,
+        headers: { "Content-type" => "message/rfc822" }
+      )
+    end
+  end
+end


### PR DESCRIPTION
We added support for sending raw mime type message in #169
and it stopped working after an upgrade. This PR fixes that.

This PR also fixes #122

Changes:
- Fix `Nylas::RawMessage#send!` to send raw mime type.