### PR TITLE
Add `Nylas-API-Version` header to be sent to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Unreleased
 
-* Send `Nylas-API-Version` header to API with latest supported version.
+* Send `Nylas-API-Version` header to API with latest supported version. #296
 * Fix issue sending message using raw mime type. #294
 * Support for `messages.expanded.find(id)` to return expanded message. #293
 * Add support for hosted authentication #292

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Send `Nylas-API-Version` header to API with latest supported version.
 * Fix issue sending message using raw mime type. #294
 * Support for `messages.expanded.find(id)` to return expanded message. #293
 * Add support for hosted authentication #292

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -31,6 +31,7 @@ module Nylas
       "/delta/longpoll" => 3650,
       "/delta/streaming" => 3650
     }.freeze
+    SUPPORTED_API_VERSION = "2.2"
 
     include Logging
     attr_accessor :api_server, :service_domain
@@ -137,6 +138,7 @@ module Nylas
       @default_headers ||= {
         "X-Nylas-API-Wrapper" => "ruby",
         "X-Nylas-Client-Id" => @app_id,
+        "Nylas-API-Version" => SUPPORTED_API_VERSION,
         "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
         "Content-types" => "application/json"
       }

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -45,13 +45,14 @@ describe Nylas::HttpClient do
 
   describe "#execute" do
     it "includes Nylas API Version in headers" do
+      supported_api_version = "2.2"
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       allow(RestClient::Request).to receive(:execute)
 
       nylas.execute(method: :get, path: "/contacts/1234/picture")
 
       expect(RestClient::Request).to have_received(:execute).with(
-        headers: hash_including("Nylas-API-Version" => "2.2"),
+        headers: hash_including("Nylas-API-Version" => supported_api_version),
         method: :get,
         payload: nil,
         timeout: 230,

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -43,6 +43,23 @@ describe Nylas::HttpClient do
     end
   end
 
+  describe "#execute" do
+    it "includes Nylas API Version in headers" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      allow(RestClient::Request).to receive(:execute)
+
+      nylas.execute(method: :get, path: "/contacts/1234/picture")
+
+      expect(RestClient::Request).to have_received(:execute).with(
+        headers: hash_including("Nylas-API-Version" => "2.2"),
+        method: :get,
+        payload: nil,
+        timeout: 230,
+        url: "https://token:@api.nylas.com/contacts/1234/picture"
+      )
+    end
+  end
+
   describe "HTTP errors" do
     http_codes_errors = {
       400 => Nylas::InvalidRequest,


### PR DESCRIPTION
Based on versioning docs https://developer.nylas.com/docs/developer-tools/api/versioning/
we should be sending `Nylas-API-Version` header with supprted version
number to the API. This PR impements it and also set it to 2.2 which is
latest version of API

Changes:
- Update `Nylas::HttpClient` to send `Nylas-API-Version` header.