### PR TITLE
Fix attributes assignment for `Delta`

### DIFF
--- a/lib/nylas/delta.rb
+++ b/lib/nylas/delta.rb
@@ -6,6 +6,7 @@ module Nylas
   # @see https://docs.nylas.com/reference#deltas
   class Delta
     include Model::Attributable
+
     attribute :id, :string
     attribute :type, :string
     attribute :object, :string
@@ -42,8 +43,10 @@ module Nylas
              else
                data
              end
+
+      data = data.merge(data[:attributes]) if data[:attributes]
       data[:object_attributes] = data.delete(:attributes)
-      super(data)
+      super(**data)
     end
   end
 end

--- a/lib/nylas/delta.rb
+++ b/lib/nylas/delta.rb
@@ -25,8 +25,6 @@ module Nylas
       @model ||= Types.registry[object.to_sym].cast(object_attributes_with_ids)
     end
 
-    private
-
     def object_attributes_with_ids
       (object_attributes || {}).merge(id: id, account_id: account_id)
     end

--- a/lib/nylas/delta.rb
+++ b/lib/nylas/delta.rb
@@ -25,6 +25,8 @@ module Nylas
       @model ||= Types.registry[object.to_sym].cast(object_attributes_with_ids)
     end
 
+    private
+
     def object_attributes_with_ids
       (object_attributes || {}).merge(id: id, account_id: account_id)
     end

--- a/lib/nylas/deltas.rb
+++ b/lib/nylas/deltas.rb
@@ -14,6 +14,6 @@ module Nylas
     attribute :cursor_end, :string
 
     extend Forwardable
-    def_delegators :deltas, :count, :length, :each, :map, :first, :to_a, :empty?
+    def_delegators :deltas, :count, :length, :each, :map, :first, :last, :to_a, :empty?
   end
 end

--- a/spec/nylas/delta_spec.rb
+++ b/spec/nylas/delta_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe Nylas::Delta do
+  it "initialize data" do
+    data = {
+      object: "message",
+      account_id: "acc-id",
+      id: "message-id",
+      type: "message",
+      event: "created",
+      cursor: "999",
+      namespace_id: "namespace-id",
+      date: 1_609_439_400,
+      metadata: { key: :value },
+      object_attributes: { object: :attributes }
+    }
+
+    delta = described_class.new(**data)
+
+    expect(delta.object).to eq("message")
+    expect(delta.account_id).to eq("acc-id")
+    expect(delta.id).to eq("message-id")
+    expect(delta.type).to eq("message")
+    expect(delta.event).to eq("created")
+    expect(delta.cursor).to eq("999")
+    expect(delta.namespace_id).to eq("namespace-id")
+    expect(delta.date).to eq(Time.at(1_609_439_400))
+    expect(delta.metadata).to eq(key: :value)
+    expect(delta.object_attributes).to eq(object: :attributes)
+  end
+
+  describe "#model" do
+    it "returns model based on given `object`" do
+      data = {
+        object: "message"
+      }
+
+      delta = described_class.new(**data)
+
+      expect(delta.model).to be_a(Nylas::Message)
+    end
+
+    it "returns `nil` if `object` is nil" do
+      data = {
+        type: "message"
+      }
+
+      delta = described_class.new(**data)
+
+      expect(delta.model).to eq(nil)
+    end
+  end
+end

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -108,8 +108,7 @@ describe Nylas::Deltas do
     expect(deltas.count).to eq(2)
     message_delta = deltas.first
     expect(message_delta.object).to eq("message")
-    expect(message_delta.object_attributes).not_to eq(nil)
-    expect(message_delta.object_attributes_with_ids).to include(
+    expect(message_delta.object_attributes).to include(
       account_id: "acc-id",
       object: "message",
       id: "message-id"
@@ -124,8 +123,7 @@ describe Nylas::Deltas do
     expect(message_delta.account_id).to eq("acc-id")
     event_delta = deltas.last
     expect(event_delta.object).to eq("event")
-    expect(event_delta.object_attributes).not_to eq(nil)
-    expect(event_delta.object_attributes_with_ids).to include(
+    expect(event_delta.object_attributes).to include(
       account_id: "acc-id",
       object: "event",
       id: "event-id"

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -137,4 +137,69 @@ describe Nylas::Deltas do
     expect(event_delta.id).to eq("event-id")
     expect(event_delta.account_id).to eq("acc-id")
   end
+
+  it "parses deltas if `attributes` is `nil`" do
+    data = {
+      "deltas": [
+        {
+          object: "message",
+          attributes: nil
+        }
+      ]
+    }
+
+    deltas = described_class.new(**data)
+
+    expect(deltas.count).to eq(1)
+    delta = deltas.last
+    expect(delta.model).to be_a(Nylas::Message)
+    expect(delta.attributes.to_h).to eq(
+      object: "message"
+    )
+  end
+
+  it "parses deltas if `attributes` is not present" do
+    data = {
+      "deltas": [
+        {
+          id: "some-id",
+          object: "event"
+        }
+      ]
+    }
+
+    deltas = described_class.new(**data)
+
+    expect(deltas.count).to eq(1)
+    delta = deltas.last
+    expect(delta.id).to eq("some-id")
+    expect(delta.model).to be_a(Nylas::Event)
+    expect(delta.attributes.to_h).to eq(
+      id: "some-id",
+      object: "event"
+    )
+  end
+
+  it "parses deltas if `attributes` is empty hash" do
+    data = {
+      "deltas": [
+        {
+          id: "some-id",
+          object: "message",
+          attributes: {}
+        }
+      ]
+    }
+
+    deltas = described_class.new(**data)
+
+    expect(deltas.count).to eq(1)
+    delta = deltas.last
+    expect(delta.id).to eq("some-id")
+    expect(delta.model).to be_a(Nylas::Message)
+    expect(delta.attributes.to_h).to eq(
+      id: "some-id",
+      object: "message"
+    )
+  end
 end

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -2,11 +2,26 @@
 
 describe Nylas::Deltas do
   it "safely inflates an account.running event" do
-    data = { "deltas": [{ "date": 1_514_335_663, "object": "account", "type": "account.running",
-                          "object_data": { "namespace_id": "acc-2345", "account_id": "acc-2345",
-                                           "object": "account", "attributes": nil, "id": "dlt-09876",
-                                           "metadata": nil } }] }
+    data = {
+      "deltas": [
+        {
+          "date": 1_514_335_663,
+          "object": "account",
+          "type": "account.running",
+          "object_data": {
+            "namespace_id": "acc-2345",
+            "account_id": "acc-2345",
+            "object": "account",
+            "attributes": nil,
+            "id": "dlt-09876",
+            "metadata": nil
+          }
+        }
+      ]
+    }
+
     deltas = described_class.new(**data)
+
     expect(deltas.length).to be 1
     delta = deltas.first
     expect(delta.date).to eql(Time.at(1_514_335_663))
@@ -21,18 +36,41 @@ describe Nylas::Deltas do
   end
 
   it "savely inflates a message.created event" do
-    data = { "deltas": [{ "date": 1_514_339_684, "object": "message", "type": "message.created",
-                          "object_data": { "namespace_id": "acc-1234", "account_id": "acc-1234",
-                                           "object": "message",
-                                           "attributes": { "thread_id": "thread-098",
-                                                           "received_date": 1_514_339_665 },
-                                           "id": "msg-1234", "metadata": nil } },
-                        { "date": 1_514_339_684, "object": "message", "type": "message.created",
-                          "object_data": { "namespace_id": "acc-1234", "account_id": "acc-1234",
-                                           "object": "message",
-                                           "attributes": { "thread_id": "thread-098",
-                                                           "received_date": 1_514_339_675 },
-                                           "id": "msg-2345", "metadata": nil } }] }
+    data = {
+      "deltas": [
+        {
+          "date": 1_514_339_684,
+          "object": "message",
+          "type": "message.created",
+          "object_data": {
+            "namespace_id": "acc-1234",
+            "account_id": "acc-1234",
+            "object": "message",
+            "attributes": {
+              "thread_id": "thread-098",
+              "received_date": 1_514_339_665
+            },
+            "id": "msg-1234",
+            "metadata": nil
+          }
+        },
+        {
+          "date": 1_514_339_684,
+          "object": "message",
+          "type": "message.created",
+          "object_data": {
+            "namespace_id": "acc-1234",
+            "account_id": "acc-1234",
+            "object": "message",
+            "attributes": {
+              "thread_id": "thread-098",
+              "received_date": 1_514_339_675
+            },
+            "id": "msg-2345", "metadata": nil
+          }
+        }
+      ]
+    }
 
     deltas = described_class.new(**data)
     expect(deltas.length).to be 2
@@ -43,5 +81,52 @@ describe Nylas::Deltas do
     expect(delta.model.id).to eql "msg-1234"
     expect(delta.model.thread_id).to eql "thread-098"
     expect(delta.model.received_date).to eql Time.at(1_514_339_665)
+  end
+
+  it "parse stream data from multiple changes" do
+    data = {
+      "deltas": [
+        {
+          "attributes": {
+            "account_id": "acc-id",
+            "object": "message",
+            "id": "message-id"
+          }
+        },
+        {
+          "attributes": {
+            "account_id": "acc-id",
+            "object": "event",
+            "id": "event-id"
+          }
+        }
+      ]
+    }
+
+    deltas = described_class.new(**data)
+
+    expect(deltas.count).to eq(2)
+    message_delta = deltas.first
+    event_delta = deltas.last
+    expect(message_delta.object).to eq("message")
+    expect(message_delta.object_attributes).not_to eq(nil)
+    expect(message_delta.object_attributes_with_ids).to eq(
+      account_id: "acc-id",
+      object: "message",
+      id: "message-id"
+    )
+    expect(message_delta.model).to be_a(Nylas::Message)
+    expect(message_delta.id).to eq("message-id")
+    expect(message_delta.account_id).to eq("acc-id")
+    # expect(message_delta.model).to eq(Nylas::Message)
+    #
+    # expect(event_delta.object_attributes).not_to eq(nil)
+    # expect(event_delta.object_attributes_with_ids).to eq(
+    # {
+    # account_id: 'acc-id',
+    # object: 'event',
+    # id: 'event-id'
+    # }
+    # )
   end
 end

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -109,7 +109,12 @@ describe Nylas::Deltas do
     message_delta = deltas.first
     expect(message_delta.object).to eq("message")
     expect(message_delta.object_attributes).not_to eq(nil)
-    expect(message_delta.object_attributes_with_ids).to eq(
+    expect(message_delta.object_attributes_with_ids).to include(
+      account_id: "acc-id",
+      object: "message",
+      id: "message-id"
+    )
+    expect(message_delta.model.attributes.to_h).to include(
       account_id: "acc-id",
       object: "message",
       id: "message-id"
@@ -120,12 +125,17 @@ describe Nylas::Deltas do
     event_delta = deltas.last
     expect(event_delta.object).to eq("event")
     expect(event_delta.object_attributes).not_to eq(nil)
-    expect(event_delta.object_attributes_with_ids).to eq(
+    expect(event_delta.object_attributes_with_ids).to include(
       account_id: "acc-id",
       object: "event",
       id: "event-id"
     )
     expect(event_delta.model).to be_a(Nylas::Event)
+    expect(event_delta.model.attributes.to_h).to include(
+      account_id: "acc-id",
+      object: "event",
+      id: "event-id"
+    )
     expect(event_delta.id).to eq("event-id")
     expect(event_delta.account_id).to eq("acc-id")
   end

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -83,7 +83,7 @@ describe Nylas::Deltas do
     expect(delta.model.received_date).to eql Time.at(1_514_339_665)
   end
 
-  it "parse stream data from multiple changes" do
+  it "parses stream data from multiple changes" do
     data = {
       "deltas": [
         {

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -107,7 +107,6 @@ describe Nylas::Deltas do
 
     expect(deltas.count).to eq(2)
     message_delta = deltas.first
-    event_delta = deltas.last
     expect(message_delta.object).to eq("message")
     expect(message_delta.object_attributes).not_to eq(nil)
     expect(message_delta.object_attributes_with_ids).to eq(
@@ -118,6 +117,8 @@ describe Nylas::Deltas do
     expect(message_delta.model).to be_a(Nylas::Message)
     expect(message_delta.id).to eq("message-id")
     expect(message_delta.account_id).to eq("acc-id")
+    event_delta = deltas.last
+    expect(event_delta.object).to eq("event")
     expect(event_delta.object_attributes).not_to eq(nil)
     expect(event_delta.object_attributes_with_ids).to eq(
       account_id: "acc-id",

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -118,15 +118,14 @@ describe Nylas::Deltas do
     expect(message_delta.model).to be_a(Nylas::Message)
     expect(message_delta.id).to eq("message-id")
     expect(message_delta.account_id).to eq("acc-id")
-    # expect(message_delta.model).to eq(Nylas::Message)
-    #
-    # expect(event_delta.object_attributes).not_to eq(nil)
-    # expect(event_delta.object_attributes_with_ids).to eq(
-    # {
-    # account_id: 'acc-id',
-    # object: 'event',
-    # id: 'event-id'
-    # }
-    # )
+    expect(event_delta.object_attributes).not_to eq(nil)
+    expect(event_delta.object_attributes_with_ids).to eq(
+      account_id: "acc-id",
+      object: "event",
+      id: "event-id"
+    )
+    expect(event_delta.model).to be_a(Nylas::Event)
+    expect(event_delta.id).to eq("event-id")
+    expect(event_delta.account_id).to eq("acc-id")
   end
 end


### PR DESCRIPTION
Background:
Currently `Delta` object for changes like `Message` and `Event`
having `account_id` as nil and it was also reported in #266.
This PR fixes the issue where the delta object properly assigning
`account_id` and other attributes to the attached model object
for messages and others.


Changes:
- Update `Delta` class to handle case where changes are inside
  `attributes` key. Also marked `object_attributes_with_ids` as
  private.
- Update `Deltas` class to have `.last` method which useful when
  having multiple objects.