### PR TITLE
Support for read only attributes

### DIFF
--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -13,9 +13,9 @@ module Nylas
     self.updatable = true
     self.destroyable = true
 
-    attribute :id, :string, exclude_when: %i[creating updating]
+    attribute :id, :string, read_only: true
     attribute :object, :string, default: "contact"
-    attribute :account_id, :string, exclude_when: %i[creating updating]
+    attribute :account_id, :string, read_only: true
 
     attribute :given_name, :string
     attribute :middle_name, :string

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -53,7 +53,7 @@ module Nylas
     end
 
     def destroy
-      execute(method: :delete, path: resource_path, payload: attributes.serialize(keys: [:version]))
+      execute(method: :delete, path: resource_path, payload: attributes.serialize_for_api(keys: [:version]))
     end
   end
 end

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -9,9 +9,9 @@ module Nylas
     allows_operations(creatable: true, listable: true, filterable: true, showable: true, updatable: true,
                       destroyable: true)
 
-    attribute :id, :string, exclude_when: %i[saving]
-    attribute :object, :string, exclude_when: %i[saving]
-    attribute :account_id, :string, exclude_when: %i[saving]
+    attribute :id, :string, read_only: true
+    attribute :object, :string, read_only: true
+    attribute :account_id, :string, read_only: true
     attribute :calendar_id, :string
     attribute :master_event_id, :string
     attribute :message_id, :string

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -37,7 +37,7 @@ module Nylas
     attribute :folder, :folder
     attribute :folder_id, :string
 
-    has_n_of_attribute :labels, :label, exclude_when: [:saving]
+    has_n_of_attribute :labels, :label, read_only: true
     has_n_of_attribute :label_ids, :string
 
     transfer :api, to: %i[events files folder labels]
@@ -75,7 +75,7 @@ module Nylas
 
       execute(
         method: :put,
-        payload: attributes.serialize(keys: allowed_keys_for_save),
+        payload: attributes.serialize,
         path: resource_path
       )
     end

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -75,7 +75,7 @@ module Nylas
 
       execute(
         method: :put,
-        payload: attributes.serialize,
+        payload: attributes.serialize_for_api,
         path: resource_path
       )
     end

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -48,7 +48,7 @@ module Nylas
 
       execute(
         method: :post,
-        payload: attributes.serialize,
+        payload: attributes.serialize_for_api,
         path: resources_path,
         query: query_params
       )
@@ -60,7 +60,7 @@ module Nylas
       attributes.merge(**data)
       execute(
         method: :put,
-        payload: attributes.serialize(keys: data.keys),
+        payload: attributes.serialize_for_api(keys: data.keys),
         path: resource_path,
         query: query_params
       )
@@ -98,7 +98,7 @@ module Nylas
     def save_call
       execute(
         method: :put,
-        payload: attributes.serialize,
+        payload: attributes.serialize_for_api,
         path: resource_path
       )
     end

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -95,16 +95,10 @@ module Nylas
 
     private
 
-    def allowed_keys_for_save
-      attributes.attribute_definitions.to_h.reject do |_k, v|
-        v.exclude_when.include?(:saving)
-      end.keys
-    end
-
     def save_call
       execute(
         method: :put,
-        payload: attributes.serialize(keys: allowed_keys_for_save),
+        payload: attributes.serialize,
         path: resource_path
       )
     end

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -34,17 +34,22 @@ module Nylas
       # Methods to call when tweaking Attributable classes
       module ClassMethods
         # rubocop:disable Naming/PredicateName
-        def has_n_of_attribute(name, type_name, exclude_when: [], default: [])
-          attribute_definitions[name] = ListAttributeDefinition.new(type_name: type_name,
-                                                                    exclude_when: exclude_when,
-                                                                    default: default)
+        def has_n_of_attribute(name, type_name, read_only: false, default: [])
+          attribute_definitions[name] = ListAttributeDefinition.new(
+            type_name: type_name,
+            read_only: read_only,
+            default: default
+          )
           define_accessors(name)
         end
         # rubocop:enable Naming/PredicateName
 
-        def attribute(name, type_name, exclude_when: [], default: nil)
-          attribute_definitions[name] = AttributeDefinition.new(type_name: type_name,
-                                                                exclude_when: exclude_when, default: default)
+        def attribute(name, type_name, read_only: false, default: nil)
+          attribute_definitions[name] = AttributeDefinition.new(
+            type_name: type_name,
+            read_only: read_only,
+            default: default
+          )
           define_accessors(name)
         end
 

--- a/lib/nylas/model/attribute_definition.rb
+++ b/lib/nylas/model/attribute_definition.rb
@@ -6,11 +6,11 @@ module Nylas
     class AttributeDefinition
       extend Forwardable
       def_delegators :type, :cast, :serialize
-      attr_accessor :type_name, :exclude_when, :default
+      attr_accessor :type_name, :read_only, :default
 
-      def initialize(type_name:, exclude_when:, default:)
+      def initialize(type_name:, read_only:, default:)
         self.type_name = type_name
-        self.exclude_when = exclude_when
+        self.read_only = read_only
         self.default = default
       end
 

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -30,6 +30,7 @@ module Nylas
 
       def to_h(keys: attribute_definitions.keys)
         keys.each_with_object({}) do |key, casted_data|
+          next if attribute_definitions[key].read_only == true
           value = attribute_definitions[key].serialize(self[key])
           casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
         end

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -30,7 +30,6 @@ module Nylas
 
       def to_h(keys: attribute_definitions.keys)
         keys.each_with_object({}) do |key, casted_data|
-          next if attribute_definitions[key].read_only == true
           value = attribute_definitions[key].serialize(self[key])
           casted_data[key] = value unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
         end
@@ -38,6 +37,12 @@ module Nylas
 
       def serialize(keys: attribute_definitions.keys)
         JSON.dump(to_h(keys: keys))
+      end
+
+      def serialize_for_api(keys: attribute_definitions.keys)
+        api_keys = keys.delete_if { |key| attribute_definitions[key].read_only == true }
+
+        serialize(keys: api_keys)
       end
 
       private

--- a/lib/nylas/model/list_attribute_definition.rb
+++ b/lib/nylas/model/list_attribute_definition.rb
@@ -4,11 +4,11 @@ module Nylas
   module Model
     # Allows models to have an attribute which is a lists of another type of thing
     class ListAttributeDefinition
-      attr_accessor :type_name, :exclude_when, :default
+      attr_accessor :type_name, :read_only, :default
 
-      def initialize(type_name:, exclude_when:, default:)
+      def initialize(type_name:, read_only:, default:)
         self.type_name = type_name
-        self.exclude_when = exclude_when
+        self.read_only = read_only
         self.default = default
       end
 

--- a/lib/nylas/rsvp.rb
+++ b/lib/nylas/rsvp.rb
@@ -13,8 +13,12 @@ module Nylas
     attr_accessor :notify_participants
 
     def save
-      api.execute(method: :post, path: "/send-rsvp", payload: attributes.serialize,
-                  query: { notify_participants: notify_participants })
+      api.execute(
+        method: :post,
+        path: "/send-rsvp",
+        payload: attributes.serialize_for_api,
+        query: { notify_participants: notify_participants }
+      )
     end
   end
 end

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -8,7 +8,7 @@ module Nylas
 
     include Model::Attributable
 
-    attribute :object, :string
+    attribute :object, :string, read_only: true
 
     # when object == 'date'
     attribute :date, :date

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -248,7 +248,6 @@ describe Nylas::Event do
           method: :post,
           path: "/events",
           payload: {
-            account_id: "acc-1234",
             calendar_id: "cal-0987",
             read_only: false
           }.to_json,
@@ -274,7 +273,6 @@ describe Nylas::Event do
           method: :post,
           path: "/events",
           payload: {
-            account_id: "acc-1234",
             calendar_id: "cal-0987",
             read_only: false
           }.to_json,

--- a/spec/nylas/model/attributes_spec.rb
+++ b/spec/nylas/model/attributes_spec.rb
@@ -9,12 +9,12 @@ describe Nylas::Model::Attributes do
         id: 1234,
         string: "a-test-string",
         read_only_attribute: "a read-only-attribute",
-        multiple_read_only_attributes: [
-          "read-only-value-1",
-          "read-only-value-2"
+        multiple_read_only_attributes: %w[
+          read-only-value-1
+          read-only-value-2
         ]
       }.to_json
-      api = double("API")
+      api = instance_double("API")
       instance = FullModel.from_json(test_json, api: api)
 
       result = instance.attributes.serialize_for_api

--- a/spec/nylas/model/attributes_spec.rb
+++ b/spec/nylas/model/attributes_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Nylas::Model::Attributes do
+  describe "#serialize_for_api" do
+    it "rejects keys which are read_only" do
+      test_json = {
+        id: 1234,
+        string: "a-test-string",
+        read_only_attribute: "a read-only-attribute",
+        multiple_read_only_attributes: [
+          "read-only-value-1",
+          "read-only-value-2"
+        ]
+      }.to_json
+      api = double("API")
+      instance = FullModel.from_json(test_json, api: api)
+
+      result = instance.attributes.serialize_for_api
+
+      expect(result).to eq(
+        {
+          id: "1234",
+          string: "a-test-string"
+        }.to_json
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,9 +43,11 @@ class FullModel
   attribute :physical_address, :physical_address
   attribute :string, :string
   attribute :web_page, :web_page
+  attribute :read_only_attribute, :string, read_only: true
 
   has_n_of_attribute :web_pages, :web_page
   has_n_of_attribute :files, :file
+  has_n_of_attribute :multiple_read_only_attributes, :string, read_only: true
 
   attr_accessor :api
 


### PR DESCRIPTION
Background:
Currently in API there are few attributes which should be treated as
read only and we should not send them to API when creating and updating.
We did a solution in #291 but it's not working for the cases where
attributes are nested. This change also suggested in #120.

This PR allows us setting up read only attibute on attribute level
and they will not be sent to the API when creating and updating.

Changes:
- Removed usage of `exclude_when` and using `read_only` to determine
  if attribute is read_only or not.
- Added `serialize_for_api` method in `Nylas::Model::Attributes` to
  be used for create and update calls.