### PR TITLE
[58503] Ruby SDK support for metadata for Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+* Add `metadata` field in the Event model to support new Event metadata feature
+* Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair`
+
 ### 5.0.0 / 2021-05-07
 
 * Send `Nylas-API-Version` header to API with latest supported version. #296

--- a/examples/plain-ruby/events.rb
+++ b/examples/plain-ruby/events.rb
@@ -30,8 +30,15 @@ demonstrate { api.events.create(title: "A fun event!", location: "The Party Zone
 example_event = api.events.where(location: "The Party Zone").last
 
 # Updating an event
-demonstrate { example_event.update(location: "Somewhere else!") }
+demonstrate do  example_event.update(
+  location: "Somewhere else!",
+  metadata: {
+    event_type: "gathering"
+  }
+)
+end
 demonstrate { api.events.find(example_event.id).location }
+demonstrate { api.events.where(metadata_pair:{"event_type": "gathering"}).metadata[:event_type] }
 
 # Deleting an event
 demonstrate { example_event.destroy }

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -27,6 +27,7 @@ module Nylas
     attribute :status, :string
     attribute :title, :string
     attribute :when, :when
+    attribute :metadata, :hash
     attribute :original_start_time, :unix_timestamp
 
     attr_accessor :notify_participants

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -104,8 +104,14 @@ module Nylas
                         also_log: { result: true, values: %i[method url path headers query payload] }
 
     def build_request(method:, path: nil, headers: {}, query: {}, payload: nil, timeout: nil)
-      headers[:params] = query
       url ||= url_for_path(path)
+
+      # Add parameters using the uri module as it allows us to make custom rules
+      uri = URI.parse(url)
+      params = URI.decode_www_form(uri.query || '') + query.to_a
+      uri.query = URI.encode_www_form(params)
+      url = uri.to_s
+
       resulting_headers = default_headers.merge(headers)
       { method: method, url: url, payload: payload, headers: resulting_headers, timeout: timeout }
     end

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -184,7 +184,6 @@ module Nylas
       raise exception.new(response[:type], response[:message], response.fetch(:server_error, nil))
     end
 
-    # Add parameters using the uri module as it allows us to handle special cases
     def add_query_params_to_url(url, query)
       unless query.empty?
         uri = URI.parse(url)
@@ -197,15 +196,15 @@ module Nylas
       url
     end
 
-    # Process any URL parameter that requires a special case
     def custom_params(query)
+      # Convert hash to "<key>:<value>" form for metadata_pair query
       if query.key?(:metadata_pair)
-        pairs = []
-        query[:metadata_pair].each do |key, value|
-          pairs.append("#{key}:#{value}")
+        pairs = query[:metadata_pair].map do |key, value|
+          "#{key}:#{value}"
         end
         query[:metadata_pair] = pairs
       end
+
       query
     end
   end

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -107,18 +107,19 @@ module Nylas
       url ||= url_for_path(path)
 
       # Add parameters using the uri module as it allows us to make custom rules
-      uri = URI.parse(url)
-      if query.has_key?(:metadata_pair)
-        pairs = []
-        query[:metadata_pair].each do |key, value|
-          puts "Here's the #{key} and it's value is: #{value}"
-          pairs.append("#{key}:#{value}")
+      unless query.empty?
+        uri = URI.parse(url)
+        if query.has_key?(:metadata_pair)
+          pairs = []
+          query[:metadata_pair].each do |key, value|
+            pairs.append("#{key}:#{value}")
+          end
+          query[:metadata_pair] = pairs
         end
-        query[:metadata_pair] = pairs
+        params = URI.decode_www_form(uri.query || '') + query.to_a
+        uri.query = URI.encode_www_form(params)
+        url = uri.to_s
       end
-      params = URI.decode_www_form(uri.query || '') + query.to_a
-      uri.query = URI.encode_www_form(params)
-      url = uri.to_s
 
       resulting_headers = default_headers.merge(headers)
       { method: method, url: url, payload: payload, headers: resulting_headers, timeout: timeout }

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -108,6 +108,14 @@ module Nylas
 
       # Add parameters using the uri module as it allows us to make custom rules
       uri = URI.parse(url)
+      if query.has_key?(:metadata_pair)
+        pairs = []
+        query[:metadata_pair].each do |key, value|
+          puts "Here's the #{key} and it's value is: #{value}"
+          pairs.append("#{key}:#{value}")
+        end
+        query[:metadata_pair] = pairs
+      end
       params = URI.decode_www_form(uri.query || '') + query.to_a
       uri.query = URI.encode_www_form(params)
       url = uri.to_s

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -109,14 +109,8 @@ module Nylas
       # Add parameters using the uri module as it allows us to make custom rules
       unless query.empty?
         uri = URI.parse(url)
-        if query.has_key?(:metadata_pair)
-          pairs = []
-          query[:metadata_pair].each do |key, value|
-            pairs.append("#{key}:#{value}")
-          end
-          query[:metadata_pair] = pairs
-        end
-        params = URI.decode_www_form(uri.query || '') + query.to_a
+        query = custom_params(query)
+        params = URI.decode_www_form(uri.query || "") + query.to_a
         uri.query = URI.encode_www_form(params)
         url = uri.to_s
       end
@@ -197,6 +191,18 @@ module Nylas
 
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       raise exception.new(response[:type], response[:message], response.fetch(:server_error, nil))
+    end
+
+    # Process any URL parameter that requires a special case
+    def custom_params(query)
+      if query.key?(:metadata_pair)
+        pairs = []
+        query[:metadata_pair].each do |key, value|
+          pairs.append("#{key}:#{value}")
+        end
+        query[:metadata_pair] = pairs
+      end
+      query
     end
   end
 end

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -34,6 +34,9 @@ describe Nylas::Event do
           end_time: 1_511_306_400,
           object: "timespan",
           start_time: 1_511_303_400
+        },
+        metadata: {
+          "event_type": "gathering"
         }
       }
 
@@ -65,6 +68,7 @@ describe Nylas::Event do
       expect(event.when.end_time).to eql Time.at(1_511_306_400)
       expect(event.when).to cover(Time.at(1_511_306_400))
       expect(event.when).not_to cover(Time.at(1_511_306_401))
+      expect(event.metadata[:event_type]).to eql "gathering"
     end
   end
 

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -98,12 +98,14 @@ describe Nylas::HttpClient do
     it "no query parameters" do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: {})
+
       expect(CGI.unescape(request[:url])).to eql(url + path)
     end
 
     it "one query parameter" do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: { param: "value" })
+
       expected_params = "?param=value"
       expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end
@@ -112,6 +114,7 @@ describe Nylas::HttpClient do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       params = { id: "1234", limit: 100, offset: 0, view: "count" }
       request = nylas.build_request(method: :get, path: path, query: params)
+
       expected_params = "?id=1234&limit=100&offset=0&view=count"
       expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end
@@ -119,6 +122,7 @@ describe Nylas::HttpClient do
     it "array of query parameter values" do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: { metadata_key: %w[key1 key2 key3] })
+
       expected_params = "?metadata_key=key1&metadata_key=key2&metadata_key=key3"
       expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end
@@ -127,6 +131,7 @@ describe Nylas::HttpClient do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       metadata_pair = { key1: "value1", key2: "value2", key3: "value3" }
       request = nylas.build_request(method: :get, path: path, query: { metadata_pair: metadata_pair })
+      
       expected_params = "?metadata_pair=key1:value1&metadata_pair=key2:value2&metadata_pair=key3:value3"
       expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -104,14 +104,16 @@ describe Nylas::HttpClient do
     it "one query parameter" do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: { param: "value" })
-      expect(CGI.unescape(request[:url])).to eql(url + path + "?param=value")
+      expected_params = "?param=value"
+      expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end
 
     it "multiple query parameters" do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       params = { id: "1234", limit: 100, offset: 0, view: "count" }
       request = nylas.build_request(method: :get, path: path, query: params)
-      expect(CGI.unescape(request[:url])).to eql(url + path + "?id=1234&limit=100&offset=0&view=count")
+      expected_params = "?id=1234&limit=100&offset=0&view=count"
+      expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end
 
     it "array of query parameter values" do

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -90,4 +90,43 @@ describe Nylas::HttpClient do
       end
     end
   end
+
+  describe "building URL with query params" do
+    url = "https://token:@api.nylas.com"
+    path = "/contacts/1234/picture"
+
+    it "no query parameters" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      request = nylas.build_request(method: :get, path: path, query: {})
+      expect(CGI.unescape(request[:url])).to eql(url + path)
+    end
+
+    it "one query parameter" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      request = nylas.build_request(method: :get, path: path, query: { param: "value" })
+      expect(CGI.unescape(request[:url])).to eql(url + path + "?param=value")
+    end
+
+    it "multiple query parameters" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      params = { id: "1234", limit: 100, offset: 0, view: "count" }
+      request = nylas.build_request(method: :get, path: path, query: params)
+      expect(CGI.unescape(request[:url])).to eql(url + path + "?id=1234&limit=100&offset=0&view=count")
+    end
+
+    it "array of query parameter values" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      request = nylas.build_request(method: :get, path: path, query: { metadata_key: %w[key1 key2 key3] })
+      expected_params = "?metadata_key=key1&metadata_key=key2&metadata_key=key3"
+      expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
+    end
+
+    it "setting metadata_pair query param (set hash of key-value pairs)" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      metadata_pair = { key1: "value1", key2: "value2", key3: "value3" }
+      request = nylas.build_request(method: :get, path: path, query: { metadata_pair: metadata_pair })
+      expected_params = "?metadata_pair=key1:value1&metadata_pair=key2:value2&metadata_pair=key3:value3"
+      expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
+    end
+  end
 end

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -131,7 +131,7 @@ describe Nylas::HttpClient do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       metadata_pair = { key1: "value1", key2: "value2", key3: "value3" }
       request = nylas.build_request(method: :get, path: path, query: { metadata_pair: metadata_pair })
-      
+
       expected_params = "?metadata_pair=key1:value1&metadata_pair=key2:value2&metadata_pair=key3:value3"
       expect(CGI.unescape(request[:url])).to eql(url + path + expected_params)
     end


### PR DESCRIPTION
# Description
The Nylas Calendar API has a new beta feature of adding a new [metadata field to calendar events](https://www.nylas.com/blog/event-metadata). This PR makes the feature available via the Nylas Ruby SDK. 

# Usage
To create a new event with event metadata, you can create a `Hash` object with a mapping of key-value pairs for the metadata:
```
api.events.create(
  title: "A fun event!",
  ...
  metadata: {
    event_type: "gathering"
  }
).to_h
```

To query events based on metadata, you can filter on three different parameters:
- `metadata_key` (string or array) to filter based on the keys within the metadata object
- `metadata_value` (string or array) to filter based on the value within the metadata object
- `metadata_pair` (hash) to filter based on the key-value pairs within the metadata object

These filters can be passed in as parameters, like so:
- `events = calendar.events.where(metadata_key: "event_type")`
- `events = calendar.events.where(metadata_value: ["gathering", "meeting"])`
- `events = calendar.events.where(metadata_pair: {event_type: "gathering"})`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.