### PR TITLE
Fix issue where files couldn't be attached to drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Gemfile.lock
 gemfiles/*.lock
 InstalledFiles
 .idea/
+*.iml
 _yardoc
 coverage
 doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair` #300
 * Add `save_all_attributes` and `update_all_attributes` methods to support
   nullifying attributes. #299
+* Fix issue where files couldn't be attached to drafts #302
 
 ### 5.0.0 / 2021-05-07
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -40,8 +40,24 @@ module Nylas
 
     def create
       unless files.nil? || files.empty?
-        f = files.map(&:id)
-        self.file_ids = f
+        extract_file_ids
+      end
+
+      super
+    end
+
+    def save_call
+      unless files.nil? || files.empty?
+        extract_file_ids
+      end
+
+      super
+    end
+
+    def update(**data)
+      unless files.nil? || files.empty?
+        extract_file_ids
+        data[:file_ids] = self.file_ids;
       end
 
       super
@@ -64,6 +80,13 @@ module Nylas
 
     def destroy
       execute(method: :delete, path: resource_path, payload: attributes.serialize_for_api(keys: [:version]))
+    end
+
+    private
+
+    def extract_file_ids
+      f = files.map(&:id)
+      self.file_ids = f
     end
   end
 end

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -38,15 +38,7 @@ module Nylas
 
     transfer :api, to: %i[events files folder labels]
 
-    def create
-      extract_file_ids unless files.nil? || files.empty?
-      super
-    end
 
-    def save_call
-      extract_file_ids unless files.nil? || files.empty?
-      super
-    end
 
     def update(**data)
       unless files.nil? || files.empty?
@@ -78,9 +70,21 @@ module Nylas
 
     private
 
+    def create
+      extract_file_ids
+      super
+    end
+
+    def save_call
+      extract_file_ids
+      super
+    end
+
     def extract_file_ids
-      f = files.map(&:id)
-      self.file_ids = f
+      unless files.nil? || files.empty?
+        f = files.map(&:id)
+        self.file_ids = f
+      end
     end
   end
 end

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -29,7 +29,7 @@ module Nylas
     attribute :unread, :boolean
 
     has_n_of_attribute :events, :event
-    has_n_of_attribute :files, :file
+    has_n_of_attribute :files, :file, read_only: true
     has_n_of_attribute :file_ids, :string
     attribute :folder, :folder
     has_n_of_attribute :labels, :label

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -40,8 +40,9 @@ module Nylas
 
     def update(**data)
       extract_file_ids!
+      data[:file_ids] = file_ids
 
-      super(**data.merge(file_ids: file_ids))
+      super
     end
 
     def create

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -80,6 +80,7 @@ module Nylas
 
     def extract_file_ids
       return if files.nil? || files.empty?
+
       f = files.map(&:id)
       self.file_ids = f
     end

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -30,12 +30,22 @@ module Nylas
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file
+    has_n_of_attribute :file_ids, :string
     attribute :folder, :folder
     has_n_of_attribute :labels, :label
 
     attribute :tracking, :message_tracking
 
     transfer :api, to: %i[events files folder labels]
+
+    def create
+      unless files.nil? || files.empty?
+        f = files.map(&:id)
+        self.file_ids = f
+      end
+
+      super
+    end
 
     def send!
       return execute(method: :post, path: "/send", payload: to_json) if tracking

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -39,10 +39,13 @@ module Nylas
     transfer :api, to: %i[events files folder labels]
 
     def update(**data)
-      unless files.nil? || files.empty?
-        extract_file_ids
-        data[:file_ids] = file_ids
-      end
+      extract_file_ids!
+
+      super(**data.merge(file_ids: file_ids))
+    end
+
+    def create
+      extract_file_ids!
 
       super
     end
@@ -68,21 +71,16 @@ module Nylas
 
     private
 
-    def create
-      extract_file_ids
-      super
-    end
-
     def save_call
-      extract_file_ids
+      extract_file_ids!
+
       super
     end
 
-    def extract_file_ids
-      return if files.nil? || files.empty?
+    def extract_file_ids!
+      files = self.files || []
 
-      f = files.map(&:id)
-      self.file_ids = f
+      self.file_ids = files.map(&:id)
     end
   end
 end

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -39,25 +39,19 @@ module Nylas
     transfer :api, to: %i[events files folder labels]
 
     def create
-      unless files.nil? || files.empty?
-        extract_file_ids
-      end
-
+      extract_file_ids unless files.nil? || files.empty?
       super
     end
 
     def save_call
-      unless files.nil? || files.empty?
-        extract_file_ids
-      end
-
+      extract_file_ids unless files.nil? || files.empty?
       super
     end
 
     def update(**data)
       unless files.nil? || files.empty?
         extract_file_ids
-        data[:file_ids] = self.file_ids;
+        data[:file_ids] = file_ids
       end
 
       super

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -38,8 +38,6 @@ module Nylas
 
     transfer :api, to: %i[events files folder labels]
 
-
-
     def update(**data)
       unless files.nil? || files.empty?
         extract_file_ids
@@ -81,10 +79,9 @@ module Nylas
     end
 
     def extract_file_ids
-      unless files.nil? || files.empty?
-        f = files.map(&:id)
-        self.file_ids = f
-      end
+      return if files.nil? || files.empty?
+      f = files.map(&:id)
+      self.file_ids = f
     end
   end
 end

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -27,6 +27,112 @@ describe Nylas::Draft do
     expect(described_class).to be_destroyable
   end
 
+  describe "update" do
+    context "when `files` key exists" do
+      it "removes `files` from the payload and sets the proper file_ids key" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        file = Nylas::File.new(id: "abc-123")
+        data = {
+          id: "draft-1234",
+          files: [file]
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.update(**data)
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/drafts/draft-1234",
+          payload: JSON.dump(
+            id: "draft-1234",
+            file_ids: ["abc-123"]
+          ),
+          query: {}
+        )
+      end
+    end
+
+    context "when `files` key does not exists" do
+      it "does nothing" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        data = {
+          id: "draft-1234"
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.update(**data)
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/drafts/draft-1234",
+          payload: JSON.dump(
+            id: "draft-1234"
+          ),
+          query: {}
+        )
+      end
+    end
+  end
+
+  describe "#create" do
+    context "when `files` key exists" do
+      it "removes `files` from the payload and sets the proper file_ids key" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        file = Nylas::File.new(id: "abc-123")
+        data = {
+          id: "draft-1234",
+          files: [file]
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.create
+
+        expect(api).to have_received(:execute).with(
+          method: :post,
+          path: "/drafts",
+          payload: JSON.dump(
+            id: "draft-1234",
+            file_ids: ["abc-123"]
+          ),
+          query: {}
+        )
+      end
+    end
+
+    context "when `files` key does not exists" do
+      it "does nothing" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        data = {
+          id: "draft-1234"
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.create
+
+        expect(api).to have_received(:execute).with(
+          method: :post,
+          path: "/drafts",
+          payload: JSON.dump(
+            id: "draft-1234"
+          ),
+          query: {}
+        )
+      end
+    end
+  end
+
   describe "save" do
     context "when `files` key exists" do
       it "removes `files` from the payload and sets the proper file_ids key" do
@@ -36,7 +142,6 @@ describe Nylas::Draft do
           id: "draft-1234",
           files: [file]
         }
-
         draft = described_class.from_json(
           JSON.dump(data),
           api: api
@@ -50,6 +155,30 @@ describe Nylas::Draft do
           payload: JSON.dump(
             id: "draft-1234",
             file_ids: ["abc-123"]
+          ),
+          query: {}
+        )
+      end
+    end
+
+    context "when `files` key does not exists" do
+      it "does nothing" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        data = {
+          id: "draft-1234"
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.save
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/drafts/draft-1234",
+          payload: JSON.dump(
+            id: "draft-1234"
           ),
           query: {}
         )

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -27,6 +27,36 @@ describe Nylas::Draft do
     expect(described_class).to be_destroyable
   end
 
+  describe "save" do
+    context "when `files` key exists" do
+      it "removes `files` from the payload and sets the proper file_ids key" do
+        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        file = Nylas::File.new(id: "abc-123")
+        data = {
+          id: "draft-1234",
+          files: [file]
+        }
+
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.save
+
+        expect(api).to have_received(:execute).with(
+          method: :put,
+          path: "/drafts/draft-1234",
+          payload: JSON.dump(
+            id: "draft-1234",
+            file_ids: ["abc-123"]
+          ),
+          query: {}
+        )
+      end
+    end
+  end
+
   describe "#send!" do
     it "saves and sends the draft" do
       api = instance_double(Nylas::API)


### PR DESCRIPTION
# Description
When attaching a file, the user would pass in the `File` object after a successful upload, however without extracting the `file_ids` the draft would be created without attachments

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.