### PR TITLE
Fix exception raise when content-type is not JSON

### DIFF
--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -177,13 +177,13 @@ module Nylas
 
     def handle_failed_response(result:, response:)
       http_code = result.code.to_i
-      return if http_code == 200
 
       handle_anticipated_failure_mode(http_code: http_code, response: response)
       raise UnexpectedResponse, result.msg if result.is_a?(Net::HTTPClientError)
     end
 
     def handle_anticipated_failure_mode(http_code:, response:)
+      return if http_code == 200
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       response = parse_response(response)
 

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -178,6 +178,7 @@ module Nylas
 
     def handle_anticipated_failure_mode(http_code:, response:)
       return if http_code == 200
+
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       response = parse_response(response)
 

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -180,12 +180,12 @@ module Nylas
       return if http_code == 200
 
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
-      response = parse_response(response)
+      parsed_response = parse_response(response)
 
       raise exception.new(
-        response[:type],
-        response[:message],
-        response.fetch(:server_error, nil)
+        parsed_response[:type],
+        parsed_response[:message],
+        parsed_response.fetch(:server_error, nil)
       )
     end
 

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -162,14 +162,8 @@ module Nylas
     private
 
     def rest_client_execute(method:, url:, headers:, payload:, timeout:, &block)
-      ::RestClient::Request.execute(
-        method: method,
-        url: url,
-        payload: payload,
-        headers: headers,
-        timeout: timeout,
-        &block
-      )
+      ::RestClient::Request.execute(method: method, url: url, payload: payload,
+                                    headers: headers, timeout: timeout, &block)
     end
 
     inform_on :rest_client_execute, level: :debug,

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -183,30 +183,16 @@ module Nylas
       raise UnexpectedResponse, result.msg if result.is_a?(Net::HTTPClientError)
     end
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Style/GuardClause
     def handle_anticipated_failure_mode(http_code:, response:)
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
+      response = parse_response(response)
 
-      if response.is_a?(Hash)
-        raise exception.new(
-          response[:type],
-          response[:message],
-          response.fetch(:server_error, nil)
-        )
-      end
-
-      if response.is_a?(RestClient::Response)
-        response = parse_response(response)
-        raise exception.new(
-          response[:type],
-          response[:message],
-          response.fetch(:server_error, nil)
-        )
-      end
+      raise exception.new(
+        response[:type],
+        response[:message],
+        response.fetch(:server_error, nil)
+      )
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Style/GuardClause
 
     def add_query_params_to_url(url, query)
       unless query.empty?

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -193,7 +193,7 @@ describe Nylas::Collection do
         allow(model).to receive(:resources_path)
         collection = described_class.new(model: model, api: api)
         stub_request(:get, "https://api.nylas.com/search?limit=100&offset=0&q=%7B%7D")
-          .to_return(status: code, body: {}.to_json, headers: { "Content-Type" => "Application/Json" })
+          .to_return(status: code, body: {}.to_json)
 
         expect do
           collection.search({}).last

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -165,4 +165,40 @@ describe Nylas::Collection do
       expect(collection.where(id: "1234").count).to be 1
     end
   end
+
+  describe "HTTP errors" do
+    http_codes_errors = {
+      400 => Nylas::InvalidRequest,
+      401 => Nylas::UnauthorizedRequest,
+      402 => Nylas::MessageRejected,
+      403 => Nylas::AccessDenied,
+      404 => Nylas::ResourceNotFound,
+      405 => Nylas::MethodNotAllowed,
+      410 => Nylas::ResourceRemoved,
+      418 => Nylas::TeapotError,
+      422 => Nylas::MailProviderError,
+      429 => Nylas::SendingQuotaExceeded,
+      500 => Nylas::InternalError,
+      501 => Nylas::EndpointNotYetImplemented,
+      502 => Nylas::BadGateway,
+      503 => Nylas::ServiceUnavailable,
+      504 => Nylas::RequestTimedOut
+    }
+
+    http_codes_errors.each do |code, error|
+      it "raises error if API returns #{error} with #{code}" do
+        api = Nylas::API.new
+        model = instance_double("Model")
+        allow(model).to receive(:searchable?).and_return(true)
+        allow(model).to receive(:resources_path)
+        collection = described_class.new(model: model, api: api)
+        stub_request(:get, "https://api.nylas.com/search?limit=100&offset=0&q=%7B%7D")
+          .to_return(status: code, body: {}.to_json, headers: { "Content-Type" => "Application/Json" })
+
+        expect do
+          collection.search({}).last
+        end.to raise_error(error)
+      end
+    end
+  end
 end

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -93,9 +93,7 @@ describe Nylas::HttpClient do
 
         expect { nylas.execute(method: :get, path: "/contacts") }.to raise_error(error)
       end
-    end
 
-    http_codes_errors.each do |code, error|
       it "should return #{error} given #{code} status code when content-type is json" do
         error_json = {
           "message": "Invalid datetime value z for start_time",

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -81,10 +81,30 @@ describe Nylas::HttpClient do
     }
 
     http_codes_errors.each do |code, error|
-      it "should return #{error} given #{code} status code" do
+      it "should return #{error} given #{code} status code when no content-type defined" do
+        error_json = {
+          "message": "Invalid datetime value z for start_time",
+          "type": "invalid_request_error"
+        }.to_json
+
         nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
         stub_request(:get, "https://api.nylas.com/contacts")
-          .to_return(status: code, body: full_json, headers: { "Content-Type" => "Application/Json" })
+          .to_return(status: code, body: error_json)
+
+        expect { nylas.execute(method: :get, path: "/contacts") }.to raise_error(error)
+      end
+    end
+
+    http_codes_errors.each do |code, error|
+      it "should return #{error} given #{code} status code when content-type is json" do
+        error_json = {
+          "message": "Invalid datetime value z for start_time",
+          "type": "invalid_request_error"
+        }.to_json
+
+        nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+        stub_request(:get, "https://api.nylas.com/contacts")
+          .to_return(status: code, body: error_json, headers: { "Content-Type" => "Application/Json" })
 
         expect { nylas.execute(method: :get, path: "/contacts") }.to raise_error(error)
       end

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -81,7 +81,7 @@ describe Nylas::HttpClient do
     }
 
     http_codes_errors.each do |code, error|
-      it "should return #{error} given #{code} status code when no content-type defined" do
+      it "should return #{error} given #{code} status code when no content-type present" do
         error_json = {
           "message": "Invalid datetime value z for start_time",
           "type": "invalid_request_error"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ class FullModel
   self.filterable = true
   self.updatable = true
   self.destroyable = true
+  self.searchable = true
 
   self.resources_path = "/collection"
 


### PR DESCRIPTION
Background:
Currently if server returns any error where content-type is not a JSON
is not raising error in `Nylas` namespace and returns
`RestClient::Response` instead. This issue is also raised in #274
and #272. It has been found that it breaks after #268 where we 
have fixed parsing error if content type is not json.

This PR makes sure that whatever content-type is returned from
API in error response it always raises error in `Nylas`
namespace.

Changes:
- Update `Nylas::HttpClient` to parse error response beforing
  raising exception.