### PR TITLE
[61539] Draft version not updating after `update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add `save_all_attributes` and `update_all_attributes` methods to support
   nullifying attributes. #299
 * Fix issue where files couldn't be attached to drafts #302
+* Fix exception raise when content-type is not JSON #303
+* Fix issue where draft version wouldn't update after `update` or `save` #304
 
 ### 5.0.0 / 2021-05-07
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -42,10 +42,7 @@ module Nylas
       extract_file_ids!
       data[:file_ids] = file_ids
 
-      response = super
-      return unless response[:version]
-
-      self.version = response[:version]
+      super
     end
 
     def create

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -39,6 +39,7 @@ module Nylas
     transfer :api, to: %i[events files folder labels]
 
     def update(**data)
+      self.files = data[:files] if data[:files]
       extract_file_ids!
       data[:file_ids] = file_ids
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -42,7 +42,10 @@ module Nylas
       extract_file_ids!
       data[:file_ids] = file_ids
 
-      super
+      response = super
+      return unless response[:version]
+
+      self.version = response[:version]
     end
 
     def create

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -58,12 +58,14 @@ module Nylas
       raise ModelNotUpdatableError, model_class unless updatable?
 
       attributes.merge(**data)
-      execute(
+      result = execute(
         method: :put,
         payload: attributes.serialize_for_api(keys: data.keys),
         path: resource_path,
         query: query_params
       )
+      attributes.merge(result) if result
+      true
     rescue Registry::MissingKeyError => e
       raise ModelMissingFieldError.new(e.key, self)
     end
@@ -88,12 +90,13 @@ module Nylas
       raise ModelNotUpdatableError, model_class unless updatable?
 
       attributes.merge(**data)
-      execute(
+      result = execute(
         method: :put,
         payload: attributes.serialize_all_for_api(keys: data.keys),
         path: resource_path,
         query: query_params
       )
+      attributes.merge(result) if result
       true
     rescue Registry::MissingKeyError => e
       raise ModelMissingFieldError.new(e.key, self)

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -64,7 +64,6 @@ module Nylas
         path: resource_path,
         query: query_params
       )
-      true
     rescue Registry::MissingKeyError => e
       raise ModelMissingFieldError.new(e.key, self)
     end

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -28,26 +28,25 @@ describe Nylas::Draft do
   end
 
   describe "update" do
-    context "when `files` key exists" do
-      it "removes `files` from the payload and sets the proper file_ids key" do
+    context "with `files` key" do
+      it "if `files` present, remove from the payload and sets the proper file_ids key" do
         api = instance_double(Nylas::API, execute: JSON.parse("{}"))
         file = Nylas::File.new(id: "abc-123")
         data = {
-          id: "draft-1234",
-          files: [file]
+          id: "draft-1234"
         }
         draft = described_class.from_json(
           JSON.dump(data),
           api: api
         )
 
-        draft.update(**data)
+        draft.update(subject: "Updated subject", files: [file])
 
         expect(api).to have_received(:execute).with(
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
-            id: "draft-1234",
+            subject: "Updated subject",
             file_ids: ["abc-123"]
           ),
           query: {}
@@ -56,7 +55,7 @@ describe Nylas::Draft do
     end
 
     context "when `files` key does not exists" do
-      it "does nothing" do
+      it "does not set the file_ids key or make any further changes to the payload" do
         api = instance_double(Nylas::API, execute: JSON.parse("{}"))
         data = {
           id: "draft-1234"
@@ -66,13 +65,13 @@ describe Nylas::Draft do
           api: api
         )
 
-        draft.update(**data)
+        draft.update(subject: "Updated subject")
 
         expect(api).to have_received(:execute).with(
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
-            id: "draft-1234"
+            subject: "Updated subject"
           ),
           query: {}
         )

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -79,26 +79,24 @@ describe Nylas::Draft do
       end
     end
 
-    context "when update is successful" do
-      it "updates the local draft object version number" do
-        expected_response = {
-          id: "draft-1234",
-          version: 1
-        }
-        api = instance_double(Nylas::API, execute: expected_response)
-        data = {
-          id: "draft-1234",
-          version: 0
-        }
-        draft = described_class.from_json(
-          JSON.dump(data),
-          api: api
-        )
+    it "updates the local draft object version number on update" do
+      expected_response = {
+        id: "draft-1234",
+        version: 1
+      }
+      api = instance_double(Nylas::API, execute: expected_response)
+      data = {
+        id: "draft-1234",
+        version: 0
+      }
+      draft = described_class.from_json(
+        JSON.dump(data),
+        api: api
+      )
 
-        draft.update(**data)
+      draft.update(**data)
 
-        expect(draft.version).to eq(1)
-      end
+      expect(draft.version).to eq(1)
     end
   end
 
@@ -207,25 +205,23 @@ describe Nylas::Draft do
       end
     end
 
-    context "when save is successful" do
-      it "updates the local draft object version number" do
-        expected_response = {
-          id: "draft-1234",
-          version: 1
-        }
-        api = instance_double(Nylas::API, execute: expected_response)
-        data = {
-          id: "draft-1234"
-        }
-        draft = described_class.from_json(
-          JSON.dump(data),
-          api: api
-        )
+    it "updates the local draft object version number on save" do
+      expected_response = {
+        id: "draft-1234",
+        version: 1
+      }
+      api = instance_double(Nylas::API, execute: expected_response)
+      data = {
+        id: "draft-1234"
+      }
+      draft = described_class.from_json(
+        JSON.dump(data),
+        api: api
+      )
 
-        draft.save
+      draft.save
 
-        expect(draft.version).to eq(1)
-      end
+      expect(draft.version).to eq(1)
     end
   end
 
@@ -236,7 +232,7 @@ describe Nylas::Draft do
       update_json = draft.to_json
       allow(api).to receive(:execute).and_return({})
       allow(api).to receive(:execute).with(method: :put, path: "/drafts/draft-1234", payload: update_json)
-                                     .and_return(id: "draft-1234", version: "6")
+        .and_return(id: "draft-1234", version: "6")
 
       draft.send!
 
@@ -290,10 +286,10 @@ describe Nylas::Draft do
                files: [{ content_type: "text/calendar", filename: nil, id: "file-abc35", size: 1264 },
                        { content_type: "application/ics", filename: "invite.ics", id: "file-xyz-9234",
                          size: 1264 }],
-               folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
-               labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
-                        { display_name: "All Mail", id: "label-all", name: "all" }],
-               tracking: { opens: true, links: true, thread_replies: true, payload: "this is a payload" } }
+                         folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+                         labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
+                                  { display_name: "All Mail", id: "label-all", name: "all" }],
+      tracking: { opens: true, links: true, thread_replies: true, payload: "this is a payload" } }
 
       draft = described_class.from_json(JSON.dump(data), api: api)
       expect(draft.id).to eql "drft-592"

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -78,6 +78,28 @@ describe Nylas::Draft do
         )
       end
     end
+
+    context "when update is successful" do
+      it "updates the local draft object version number" do
+        expected_response = {
+          id: "draft-1234",
+          version: 1
+        }
+        api = instance_double(Nylas::API, execute: expected_response)
+        data = {
+          id: "draft-1234",
+          version: 0
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.update(**data)
+
+        expect(draft.version).to eq(1)
+      end
+    end
   end
 
   describe "#create" do
@@ -182,6 +204,27 @@ describe Nylas::Draft do
           ),
           query: {}
         )
+      end
+    end
+
+    context "when save is successful" do
+      it "updates the local draft object version number" do
+        expected_response = {
+          id: "draft-1234",
+          version: 1
+        }
+        api = instance_double(Nylas::API, execute: expected_response)
+        data = {
+          id: "draft-1234"
+        }
+        draft = described_class.from_json(
+          JSON.dump(data),
+          api: api
+        )
+
+        draft.save
+
+        expect(draft.version).to eq(1)
       end
     end
   end

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -232,7 +232,7 @@ describe Nylas::Draft do
       update_json = draft.to_json
       allow(api).to receive(:execute).and_return({})
       allow(api).to receive(:execute).with(method: :put, path: "/drafts/draft-1234", payload: update_json)
-        .and_return(id: "draft-1234", version: "6")
+                                     .and_return(id: "draft-1234", version: "6")
 
       draft.send!
 
@@ -286,10 +286,10 @@ describe Nylas::Draft do
                files: [{ content_type: "text/calendar", filename: nil, id: "file-abc35", size: 1264 },
                        { content_type: "application/ics", filename: "invite.ics", id: "file-xyz-9234",
                          size: 1264 }],
-                         folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
-                         labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
-                                  { display_name: "All Mail", id: "label-all", name: "all" }],
-      tracking: { opens: true, links: true, thread_replies: true, payload: "this is a payload" } }
+               folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
+               labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
+                        { display_name: "All Mail", id: "label-all", name: "all" }],
+               tracking: { opens: true, links: true, thread_replies: true, payload: "this is a payload" } }
 
       draft = described_class.from_json(JSON.dump(data), api: api)
       expect(draft.id).to eql "drft-592"

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -83,7 +83,7 @@ describe Nylas::Thread do
 
   describe "#update" do
     it "let's you set the starred, unread, folder, and label ids" do
-      api =  instance_double(Nylas::API, execute: "{}")
+      api =  instance_double(Nylas::API, execute: {})
       thread = described_class.from_json('{ "id": "thread-1234" }', api: api)
 
       thread.update(


### PR DESCRIPTION
# Description
When making updates to the draft object on the server side (via `.update`) the version number is incremented upon successful update. However, the local object does not update the value when it's returned from the server. This causes an issue when, the user attempts to re-update the draft a second time and the version number has not been incremented. Now, when calling `.update` the version is updated with the value returned from the payload.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.