### PR TITLE
[61552] 5.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-### Unreleased
-* Add `metadata` field in the Event model to support new Event metadata feature #300
-* Add support for filtering `metadata` using `metadata_key`, `metadata_value`, and `metadata_pair` #300
+### 5.1.0 / 2021-06-07
+* Add support for read only attributes #298
 * Add `save_all_attributes` and `update_all_attributes` methods to support
   nullifying attributes. #299
+* Add support new `Event` metadata feature #300  
+* Fix attributes assignment for `Delta` #297  
 * Fix issue where files couldn't be attached to drafts #302
 * Fix exception raise when content-type is not JSON #303
 * Fix issue where draft version wouldn't update after `update` or `save` #304

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "4.6.5"
+  VERSION = "5.1.0"
 end


### PR DESCRIPTION
# Description
New `nylas` v5.1.0 release bringing in the following new features:
* Add support for read only attributes (#298)
* Add `save_all_attributes` and `update_all_attributes` methods to support nullifying attributes. (#299)
* Add support new `Event` metadata feature (#300)

The new release also fixes the following:
* Fix attributes assignment for `Delta` (#297)  
* Fix issue where files couldn't be attached to drafts (#302)
* Fix exception raise when content-type is not JSON (#303)
* Fix issue where draft version wouldn't update after `update` or `save` (#304)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.