### PR TITLE
added list of successful http codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Fix issue where "302 Redirect" response codes were treated as errors #306
+
 ### 5.1.0 / 2021-06-07
 * Add support for read only attributes #298
 * Add `save_all_attributes` and `update_all_attributes` methods to support

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -5,6 +5,8 @@ module Nylas
 
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient # rubocop:disable Metrics/ClassLength
+    HTTP_SUCCESS_CODES = [200, 302].freeze
+
     HTTP_CODE_TO_EXCEPTIONS = {
       400 => InvalidRequest,
       401 => UnauthorizedRequest,
@@ -177,7 +179,7 @@ module Nylas
     end
 
     def handle_anticipated_failure_mode(http_code:, response:)
-      return if http_code == 200
+      return if HTTP_SUCCESS_CODES.include?(http_code)
 
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       parsed_response = parse_response(response)

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -59,6 +59,16 @@ describe Nylas::HttpClient do
         url: "https://token:@api.nylas.com/contacts/1234/picture"
       )
     end
+
+    it "handles redirect correctly" do
+      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+
+      stub_request(:get, "https://api.nylas.com/oauth/authorize")
+        .to_return(status: 302, body: "")
+
+      response = nylas.execute(method: :get, path: "/oauth/authorize")
+      expect(response).to eq("")
+    end
   end
 
   describe "HTTP errors" do


### PR DESCRIPTION
**Issue**
API response from nylas GET `/oauth/authorize` returns HTTP=302 with empty body that causes call raise of exception (due it is not 200 code), but fails to do it due the empty body.

**Solution**
I have added list of successful HTTP codes (add more if your API responds with another non-error codes) to the check in `#handle_anticipated_failure_mode` method.

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.