### PR TITLE
[61632] Add `Room Resource` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Add support for `Room Resource`  #307
+
 ### 5.1.0 / 2021-06-07
 * Add support for read only attributes #298
 * Add `save_all_attributes` and `update_all_attributes` methods to support

--- a/examples/plain-ruby/room_resource.rb
+++ b/examples/plain-ruby/room_resource.rb
@@ -1,0 +1,9 @@
+require_relative '../helpers'
+
+# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
+# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
+api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+                     access_token: ENV['NYLAS_ACCESS_TOKEN'])
+
+# Retrieving a list of room resources
+demonstrate { api.room_resources.map(&:to_h) }

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -69,6 +69,7 @@ require_relative "nylas/deltas"
 require_relative "nylas/delta"
 require_relative "nylas/draft"
 require_relative "nylas/message"
+require_relative "nylas/room_resource"
 require_relative "nylas/new_message"
 require_relative "nylas/raw_message"
 require_relative "nylas/thread"
@@ -94,6 +95,7 @@ module Nylas
   Types.registry[:folder] = Types::ModelType.new(model: Folder)
   Types.registry[:im_address] = Types::ModelType.new(model: IMAddress)
   Types.registry[:label] = Types::ModelType.new(model: Label)
+  Types.registry[:room_resource] = Types::ModelType.new(model: RoomResource)
   Types.registry[:message] = Types::ModelType.new(model: Message)
   Types.registry[:message_headers] = MessageHeadersType.new
   Types.registry[:message_tracking] = Types::ModelType.new(model: MessageTracking)

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -123,6 +123,11 @@ module Nylas
       @messages ||= Collection.new(model: Message, api: self)
     end
 
+    # @return[Collection<RoomResource>] A queryable collection of {RoomResource} objects
+    def room_resources
+      @room_resources ||= Collection.new(model: RoomResource, api: self)
+    end
+
     # Revokes access to the Nylas API for the given access token
     # @return [Boolean]
     def revoke(access_token)

--- a/lib/nylas/room_resource.rb
+++ b/lib/nylas/room_resource.rb
@@ -6,7 +6,7 @@ module Nylas
   class RoomResource
     include Model
     self.resources_path = "/resources"
-    allows_operations(listable: true, showable: true)
+    allows_operations(listable: true)
 
     attribute :object, :string, read_only: true
     attribute :email, :string, read_only: true

--- a/lib/nylas/room_resource.rb
+++ b/lib/nylas/room_resource.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Ruby representation of a Nylas Room Resource object
+  # @see https://developer.nylas.com/docs/api/#tag--Room-Resources
+  class RoomResource
+    include Model
+    self.resources_path = "/resources"
+    allows_operations(listable: true, showable: true)
+
+    attribute :object, :string, read_only: true
+    attribute :email, :string, read_only: true
+    attribute :name, :string, read_only: true
+    attribute :capacity, :string, read_only: true
+    attribute :building, :string, read_only: true
+    attribute :floor_name, :string, read_only: true
+    attribute :floor_number, :string, read_only: true
+  end
+end

--- a/spec/nylas/room_resource_spec.rb
+++ b/spec/nylas/room_resource_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe Nylas::RoomResource do
+  it "is not creatable" do
+    expect(described_class).not_to be_creatable
+  end
+
+  it "is not filterable" do
+    expect(described_class).not_to be_filterable
+  end
+
+  it "is not be_updatable" do
+    expect(described_class).not_to be_updatable
+  end
+
+  it "is not destroyable" do
+    expect(described_class).not_to be_destroyable
+  end
+
+  it "is listable" do
+    expect(described_class).to be_listable
+  end
+
+  describe "#from_json" do
+    it "deserializes all the attributes successfully" do
+      json = JSON.dump("object": "room_resource",
+                       "email": "training-room@outlook.com",
+                       "name": "Microsoft Training Room",
+                       "building": "Seattle",
+                       "capacity": "5",
+                       "floor_name": "Office",
+                       "floor_number": "2")
+
+      label = described_class.from_json(json, api: nil)
+
+      expect(label.object).to eql "room_resource"
+      expect(label.email).to eql "training-room@outlook.com"
+      expect(label.name).to eql "Microsoft Training Room"
+      expect(label.building).to eql "Seattle"
+      expect(label.capacity).to eql "5"
+      expect(label.floor_name).to eql "Office"
+      expect(label.floor_number).to eql "2"
+    end
+  end
+end

--- a/spec/nylas/room_resource_spec.rb
+++ b/spec/nylas/room_resource_spec.rb
@@ -17,6 +17,10 @@ describe Nylas::RoomResource do
     expect(described_class).not_to be_destroyable
   end
 
+  it "is not showable" do
+    expect(described_class).not_to be_showable
+  end
+
   it "is listable" do
     expect(described_class).to be_listable
   end
@@ -31,15 +35,15 @@ describe Nylas::RoomResource do
                        "floor_name": "Office",
                        "floor_number": "2")
 
-      label = described_class.from_json(json, api: nil)
+      resource = described_class.from_json(json, api: nil)
 
-      expect(label.object).to eql "room_resource"
-      expect(label.email).to eql "training-room@outlook.com"
-      expect(label.name).to eql "Microsoft Training Room"
-      expect(label.building).to eql "Seattle"
-      expect(label.capacity).to eql "5"
-      expect(label.floor_name).to eql "Office"
-      expect(label.floor_number).to eql "2"
+      expect(resource.object).to eql "room_resource"
+      expect(resource.email).to eql "training-room@outlook.com"
+      expect(resource.name).to eql "Microsoft Training Room"
+      expect(resource.building).to eql "Seattle"
+      expect(resource.capacity).to eql "5"
+      expect(resource.floor_name).to eql "Office"
+      expect(resource.floor_number).to eql "2"
     end
   end
 

--- a/spec/nylas/room_resource_spec.rb
+++ b/spec/nylas/room_resource_spec.rb
@@ -42,4 +42,20 @@ describe Nylas::RoomResource do
       expect(label.floor_number).to eql "2"
     end
   end
+
+  context "when getting" do
+    it "makes a call to the /resources endpoint" do
+      api = instance_double(Nylas::API, execute: "{}")
+      resource = Nylas::Collection.new(model: described_class, api: api)
+
+      api.execute(resource.to_be_executed)
+
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/resources",
+        headers: {},
+        query: { limit: 100, offset: 0 }
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Description
This adds support for the `/resource` endpoint and the Nylas `Room Resource` object. More information can be found [in the docs](https://developer.nylas.com/docs/api/#tag--Room-Resources).

# Usage
Currently, the `/resource` endpoint only supports the `GET` operation without any extra functionality like filtering. To get a list of all room resource objects attached to your account,  you can do the following:

```
#!/usr/bin/env ruby
require 'nylas'

# Initialize and connect to the Nylas client
nylas = Nylas::API.new(
  app_id: CLIENT_ID,
  app_secret: CLIENT_SECRET,
  access_token: ACCESS_TOKEN
)

resources = nylas.room_resources
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.