### PR TITLE
[63670] Fix `api` value resetting after `message.expanded` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 * Add support for `Room Resource`  #307
 * Fix issue where "302 Redirect" response codes were treated as errors #306
+* Fix issue where `api` value was overriden when calling `message.expanded` #311
 
 ### 5.1.0 / 2021-06-07
 * Add support for read only attributes #298

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -67,6 +67,8 @@ module Nylas
       return self unless headers.nil?
 
       assign(**api.execute(method: :get, path: resource_path, query: { view: "expanded" }))
+      # Transfer reference to the API to attributes that need it
+      transfer_attributes
       self
     end
 


### PR DESCRIPTION
# Description
When calling `message.expanded`, the attributes of the message that have an `api` value (such as `files`) do not retain the API value after the object's values were updated. The reason for this is that the `transfer_attributes` method is never called, thus the message object never passes the `api` value to the newly parsed data. Now we manually invoke the method call to ensure all of the attributes that need an `api` value get initialized with it.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.