### PR TITLE
Add `#headers` to `Nylas::Delta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix issue where `Delta` did not have a header attribute for expanded headers
+
 ### 5.2.0 / 2021-06-07
 * Add support for `Room Resource`
 * Fix issue where "302 Redirect" response codes were treated as errors

--- a/lib/nylas/delta.rb
+++ b/lib/nylas/delta.rb
@@ -15,6 +15,8 @@ module Nylas
     attribute :namespace_id, :string
     attribute :account_id, :string
 
+    attribute :headers, :message_headers
+
     attribute :date, :unix_timestamp
     attribute :metadata, :hash
     attribute :object_attributes, :hash

--- a/spec/nylas/delta_spec.rb
+++ b/spec/nylas/delta_spec.rb
@@ -12,7 +12,17 @@ describe Nylas::Delta do
       namespace_id: "namespace-id",
       date: 1_609_439_400,
       metadata: { key: :value },
-      object_attributes: { object: :attributes }
+      headers: { "In-Reply-To": "In-Reply-To", "Message-Id": "Message-Id", References: ["References-01", "References-02"] },
+      object_attributes:
+      {
+        headers:
+        {
+          "In-Reply-To": "In-Reply-To",
+          "Message-Id": "Message-Id",
+          References: ["References-01", "References-02"]
+        },
+        object: :attributes
+      }
     }
 
     delta = described_class.new(**data)
@@ -26,7 +36,18 @@ describe Nylas::Delta do
     expect(delta.namespace_id).to eq("namespace-id")
     expect(delta.date).to eq(Time.at(1_609_439_400))
     expect(delta.metadata).to eq(key: :value)
-    expect(delta.object_attributes).to eq(object: :attributes)
+    expect(delta.headers.in_reply_to).to eq("In-Reply-To")
+    expect(delta.headers.message_id).to eq("Message-Id")
+    expect(delta.headers.references).to eq(["References-01", "References-02"])
+    expect(delta.object_attributes).to eq(
+      headers:
+      {
+        "In-Reply-To": "In-Reply-To",
+        "Message-Id": "Message-Id",
+        References: ["References-01", "References-02"]
+      },
+      object: :attributes
+    )
   end
 
   describe "#model" do

--- a/spec/nylas/delta_spec.rb
+++ b/spec/nylas/delta_spec.rb
@@ -15,7 +15,7 @@ describe Nylas::Delta do
       headers: {
         "In-Reply-To": "In-Reply-To",
         "Message-Id": "Message-Id",
-        References: ["References-01", "References-02"]
+        References: %w[References-01 References-02]
       },
       object_attributes:
       {
@@ -23,7 +23,7 @@ describe Nylas::Delta do
         {
           "In-Reply-To": "In-Reply-To",
           "Message-Id": "Message-Id",
-          References: ["References-01", "References-02"]
+          References: %w[References-01 References-02]
         },
         object: :attributes
       }
@@ -42,13 +42,13 @@ describe Nylas::Delta do
     expect(delta.metadata).to eq(key: :value)
     expect(delta.headers.in_reply_to).to eq("In-Reply-To")
     expect(delta.headers.message_id).to eq("Message-Id")
-    expect(delta.headers.references).to eq(["References-01", "References-02"])
+    expect(delta.headers.references).to eq(%w[References-01 References-02])
     expect(delta.object_attributes).to eq(
       headers:
       {
         "In-Reply-To": "In-Reply-To",
         "Message-Id": "Message-Id",
-        References: ["References-01", "References-02"]
+        References: %w[References-01 References-02]
       },
       object: :attributes
     )

--- a/spec/nylas/delta_spec.rb
+++ b/spec/nylas/delta_spec.rb
@@ -12,7 +12,11 @@ describe Nylas::Delta do
       namespace_id: "namespace-id",
       date: 1_609_439_400,
       metadata: { key: :value },
-      headers: { "In-Reply-To": "In-Reply-To", "Message-Id": "Message-Id", References: ["References-01", "References-02"] },
+      headers: {
+        "In-Reply-To": "In-Reply-To",
+        "Message-Id": "Message-Id",
+        References: ["References-01", "References-02"]
+      },
       object_attributes:
       {
         headers:

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -118,13 +118,21 @@ describe Nylas::Deltas do
       account_id: "acc-id",
       object: "message",
       id: "message-id",
-      headers: { "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>", "Message-Id": "<84umizq7c4jtrew491brpa6iu-0@example.com>", References: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"] }
+      headers: {
+        "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>",
+        "Message-Id": "<84umizq7c4jtrew491brpa6iu-0@example.com>",
+        References: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"]
+      }
     )
     expect(message_delta.model.attributes.to_h).to include(
       account_id: "acc-id",
       object: "message",
       id: "message-id",
-      headers: { in_reply_to: "<evh5uy0shhpm5d0le89goor17-0@example.com>", message_id: "<84umizq7c4jtrew491brpa6iu-0@example.com>", references: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"] }
+      headers: {
+        in_reply_to: "<evh5uy0shhpm5d0le89goor17-0@example.com>",
+        message_id: "<84umizq7c4jtrew491brpa6iu-0@example.com>",
+        references: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"]
+      }
     )
     expect(message_delta.model).to be_a(Nylas::Message)
     expect(message_delta.id).to eq("message-id")

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -90,7 +90,13 @@ describe Nylas::Deltas do
           "attributes": {
             "account_id": "acc-id",
             "object": "message",
-            "id": "message-id"
+            "id": "message-id",
+            headers:
+            {
+              "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>",
+              "Message-Id": "<84umizq7c4jtrew491brpa6iu-0@example.com>",
+              References: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"]
+            }
           }
         },
         {
@@ -111,16 +117,22 @@ describe Nylas::Deltas do
     expect(message_delta.object_attributes).to include(
       account_id: "acc-id",
       object: "message",
-      id: "message-id"
+      id: "message-id",
+      headers: { "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>", "Message-Id": "<84umizq7c4jtrew491brpa6iu-0@example.com>", References: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"] }
     )
     expect(message_delta.model.attributes.to_h).to include(
       account_id: "acc-id",
       object: "message",
-      id: "message-id"
+      id: "message-id",
+      headers: { in_reply_to: "<evh5uy0shhpm5d0le89goor17-0@example.com>", message_id: "<84umizq7c4jtrew491brpa6iu-0@example.com>", references: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"] }
     )
     expect(message_delta.model).to be_a(Nylas::Message)
     expect(message_delta.id).to eq("message-id")
     expect(message_delta.account_id).to eq("acc-id")
+    expect(message_delta.headers.in_reply_to).to eq("<evh5uy0shhpm5d0le89goor17-0@example.com>")
+    expect(message_delta.headers.message_id).to eq("<84umizq7c4jtrew491brpa6iu-0@example.com>")
+    expect(message_delta.headers.references).to eq(["<evh5uy0shhpm5d0le89goor17-0@example.com>"])
+
     event_delta = deltas.last
     expect(event_delta.object).to eq("event")
     expect(event_delta.object_attributes).to include(


### PR DESCRIPTION
Fixes Bug #314 

`/deltas` endpoint has the option to respond to the _expanded_ option however, the object `Nylas::Delta` doesn't have the `#headers` attribute; Field responsible for the _expanded_ information.

This commit aims to add the `#headers` attribute to be filled with the _expanded_ response when available.

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.