### PR TITLE
[64639] Return API error regardless if response is JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix issue where `Delta` did not have a header attribute for expanded headers
+* Fix issue where server errors are not reported if HTML is returned
 
 ### 5.2.0 / 2021-06-07
 * Add support for `Room Resource`

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -92,7 +92,12 @@ module Nylas
           content_type = response.headers[:content_type].downcase
         end
 
-        response = parse_response(response) if content_type == "application/json"
+        begin
+          response = parse_response(response) if content_type == "application/json"
+        rescue Nylas::JsonParseError
+          handle_failed_response(result: result, response: response)
+          raise
+        end
 
         handle_failed_response(result: result, response: response)
         response

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -179,12 +179,11 @@ module Nylas
       return if HTTP_SUCCESS_CODES.include?(http_code)
 
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
-      parsed_response = parse_response(response)
-
+      raise exception.new(http_code, response) unless response.is_a?(Hash)
       raise exception.new(
-        parsed_response[:type],
-        parsed_response[:message],
-        parsed_response.fetch(:server_error, nil)
+        response[:type],
+        response[:message],
+        response.fetch(:server_error, nil)
       )
     end
 

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -185,6 +185,7 @@ module Nylas
 
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       raise exception.new(http_code, response) unless response.is_a?(Hash)
+      
       raise exception.new(
         response[:type],
         response[:message],

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -185,7 +185,7 @@ module Nylas
 
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       raise exception.new(http_code, response) unless response.is_a?(Hash)
-      
+
       raise exception.new(
         response[:type],
         response[:message],


### PR DESCRIPTION
# Description
In the rare case, the API server might return a server error but with a HTML body instead of a JSON type. This causes the parser to throw a parse error, but it does not return that the server ran into an error. Now, if parsing fails we also check if we encountered an error and if we did, we should propagate the error back to the user for better information. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.