### PR TITLE
[63799] Fix ArgumentError when sending email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix issue where `Delta` did not have a header attribute for expanded headers
+* Fix ArgumentError when calling `Nylas::API#send!` due to missing double splat (**)
 
 ### 5.2.0 / 2021-06-07
 * Add support for `Room Resource`

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -26,7 +26,7 @@ module Nylas
     attribute :tracking, :message_tracking
 
     def send!
-      Message.new(api.execute(method: :post, path: "/send", payload: to_json).merge(api: api))
+      Message.new(**api.execute(method: :post, path: "/send", payload: to_json).merge(api: api))
     end
   end
 end


### PR DESCRIPTION
# Description
The double splat operator was missing causing a ArgumentError when calling `Nylas::API#send!`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.