### PR TITLE
[63813] Neural API Support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,10 @@ Naming/FileName:
   Exclude:
     - "lib/nylas-streaming.rb"
 
+Style/NumericLiterals:
+  Exclude:
+    - "spec/nylas/neural_spec.rb"
+
 RSpec/MultipleExpectations:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,8 +39,7 @@ Naming/FileName:
     - "lib/nylas-streaming.rb"
 
 Style/NumericLiterals:
-  Exclude:
-    - "spec/nylas/neural_spec.rb"
+  Enabled: false
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix issue where `Delta` did not have a header attribute for expanded headers
+* Add support for Neural API
 
 ### 5.2.0 / 2021-06-07
 * Add support for `Room Resource`

--- a/examples/plain-ruby/neural.rb
+++ b/examples/plain-ruby/neural.rb
@@ -18,18 +18,24 @@ demonstrate { sentiments[0].to_h }
 # Perform extracting a signature and parsing its contact information
 signatures = api.neural.extract_signature([message_id])
 demonstrate { signatures[0].to_h }
-demonstrate { signatures[0].to_h }
 # Convert the parsed contact to a Nylas contact object
 contact = signatures[0].contacts.to_contact_object
 demonstrate { contact.to_h }
 
 # Perform OCR request on a page (with a page range)
-begin
-  file_id = api.files.first.id
-  ocr = api.neural.ocr_request(file_id, [2,3])
-  demonstrate { ocr.to_h }
-rescue Nylas::Error
-  puts "No file found or file found was not compatible with the OCR endpoint"
+file = api.files.first
+if file.nil?
+  puts "No file was found"
+else
+  begin
+    file_id = api.files.first.id
+    # Optionally you can add a range, like below, of the pages OCR can be performed on
+    # Also just pass in the file ID without a range to perform OCR on all pages
+    ocr = api.neural.ocr_request(file_id, [1])
+    demonstrate { ocr.to_h }
+  rescue Nylas::Error => e
+    puts "#{e.class}: #{e.message}"
+  end
 end
 
 # Perform category analysis on a message

--- a/examples/plain-ruby/neural.rb
+++ b/examples/plain-ruby/neural.rb
@@ -32,7 +32,7 @@ demonstrate { ocr.to_h }
 categorize_list = api.neural.categorize([message_id])
 demonstrate { categorize_list[0].to_h }
 # Re-categorize the message to a different category
-categorize = categorize.recategorize("conversation")
+categorize = categorize_list[0].recategorize("conversation")
 demonstrate { categorize.to_h }
 
 # Clean the conversation of a message

--- a/examples/plain-ruby/neural.rb
+++ b/examples/plain-ruby/neural.rb
@@ -1,0 +1,47 @@
+require_relative '../helpers'
+
+# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
+# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
+api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+                     access_token: ENV['NYLAS_ACCESS_TOKEN'])
+
+message_id = api.messages.first.id
+
+# Perform sentiment analysis on a string
+sentiment = api.neural.sentiment_analysis_text("Hello world")
+demonstrate { sentiment.to_h }
+
+# Perform sentiment analysis on a message
+sentiments = api.neural.sentiment_analysis_message([message_id])
+demonstrate { sentiments[0].to_h }
+
+# Perform extracting a signature and parsing its contact information
+signatures = api.neural.extract_signature([message_id])
+demonstrate { signatures[0].to_h }
+demonstrate { signatures[0].to_h }
+# Convert the parsed contact to a Nylas contact object
+contact = signatures[0].contacts.to_contact_object
+demonstrate { contact.to_h }
+
+# Perform OCR request on a page (with a page range)
+file_id = api.files.first.id
+ocr = api.neural.ocr_request(file_id, [2,3])
+demonstrate { ocr.to_h }
+
+# Perform category analysis on a message
+categorize_list = api.neural.categorize([message_id])
+demonstrate { categorize_list[0].to_h }
+# Re-categorize the message to a different category
+categorize = categorize.recategorize("conversation")
+demonstrate { categorize.to_h }
+
+# Clean the conversation of a message
+conversations = api.neural.clean_conversation([message_id])
+demonstrate { conversations[0].to_h }
+# Provide some options to the endpoint
+options = Nylas::NeuralMessageOptions.new(ignore_images: false)
+conversations = api.neural.clean_conversation([message_id], options)
+demonstrate { conversations[0].to_h }
+# Parse the images from the clean conversation
+extracted_images = conversations[0].extract_images
+demonstrate { extracted_images }

--- a/examples/plain-ruby/neural.rb
+++ b/examples/plain-ruby/neural.rb
@@ -24,9 +24,13 @@ contact = signatures[0].contacts.to_contact_object
 demonstrate { contact.to_h }
 
 # Perform OCR request on a page (with a page range)
-file_id = api.files.first.id
-ocr = api.neural.ocr_request(file_id, [2,3])
-demonstrate { ocr.to_h }
+begin
+  file_id = api.files.first.id
+  ocr = api.neural.ocr_request(file_id, [2,3])
+  demonstrate { ocr.to_h }
+rescue Nylas::Error
+  puts "No file found or file found was not compatible with the OCR endpoint"
+end
 
 # Perform category analysis on a message
 categorize_list = api.neural.categorize([message_id])

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -75,6 +75,19 @@ require_relative "nylas/raw_message"
 require_relative "nylas/thread"
 require_relative "nylas/webhook"
 
+# Neural specific types
+require_relative "nylas/neural"
+require_relative "nylas/neural_sentiment_analysis"
+require_relative "nylas/neural_ocr"
+require_relative "nylas/neural_categorizer"
+require_relative "nylas/neural_clean_conversation"
+require_relative "nylas/neural_contact_link"
+require_relative "nylas/neural_contact_name"
+require_relative "nylas/neural_signature_contact"
+require_relative "nylas/neural_signature_extraction"
+require_relative "nylas/neural_message_options"
+require_relative "nylas/categorize"
+
 require_relative "nylas/native_authentication"
 
 require_relative "nylas/http_client"
@@ -110,4 +123,9 @@ module Nylas
   Types.registry[:contact_group] = Types::ModelType.new(model: ContactGroup)
   Types.registry[:when] = Types::ModelType.new(model: When)
   Types.registry[:time_slot] = Types::ModelType.new(model: TimeSlot)
+  Types.registry[:neural] = Types::ModelType.new(model: Neural)
+  Types.registry[:categorize] = Types::ModelType.new(model: Categorize)
+  Types.registry[:neural_signature_contact] = Types::ModelType.new(model: NeuralSignatureContact)
+  Types.registry[:neural_contact_link] = Types::ModelType.new(model: NeuralContactLink)
+  Types.registry[:neural_contact_name] = Types::ModelType.new(model: NeuralContactName)
 end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -126,6 +126,11 @@ module Nylas
       @room_resources ||= Collection.new(model: RoomResource, api: self)
     end
 
+    # @return[Neural] A {Neural} object that provides
+    def neural
+      @neural ||= Neural.new(api: self)
+    end
+
     # Revokes access to the Nylas API for the given access token
     # @return [Boolean]
     def revoke(access_token)

--- a/lib/nylas/categorize.rb
+++ b/lib/nylas/categorize.rb
@@ -1,0 +1,14 @@
+module Nylas
+  # Structure to represent a the Neural Optical Character Recognition object.
+  # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
+  class Categorize
+    include Model::Attributable
+
+    attribute :category, :string
+    attribute :categorized_at, :unix_timestamp
+    attribute :model_version, :string
+    has_n_of_attribute :subcategories, :string
+  end
+end
+
+

--- a/lib/nylas/categorize.rb
+++ b/lib/nylas/categorize.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Nylas
-  # Structure to represent a the Neural Categorize object.
+  # Structure to represent the Neural Categorize object.
   # @see https://developer.nylas.com/docs/intelligence/categorizer/#categorize-message-response
   class Categorize
     include Model::Attributable

--- a/lib/nylas/categorize.rb
+++ b/lib/nylas/categorize.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Nylas
-  # Structure to represent a the Neural Optical Character Recognition object.
-  # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
+  # Structure to represent a the Neural Categorize object.
+  # @see https://developer.nylas.com/docs/intelligence/categorizer/#categorize-message-response
   class Categorize
     include Model::Attributable
 
@@ -10,5 +12,3 @@ module Nylas
     has_n_of_attribute :subcategories, :string
   end
 end
-
-

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -5,7 +5,7 @@ module Nylas
 
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient # rubocop:disable Metrics/ClassLength
-    HTTP_SUCCESS_CODES = [200, 302].freeze
+    HTTP_SUCCESS_CODES = [200, 201, 302].freeze
 
     HTTP_CODE_TO_EXCEPTIONS = {
       400 => InvalidRequest,

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -139,7 +139,7 @@ module Nylas
         "X-Nylas-Client-Id" => @app_id,
         "Nylas-API-Version" => SUPPORTED_API_VERSION,
         "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
-        "Content-types" => "application/json"
+        "Content-type" => "application/json"
       }
     end
 

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -63,6 +63,19 @@ module Nylas
           end
         end
 
+        # Allows a class to inherit parent's attributes
+        def inherit_attributes
+          return if superclass.nil?
+          parent_attributes = superclass.attribute_definitions
+          parent_attributes.each do |parent_attribute|
+            name = parent_attribute[0]
+            attr = parent_attribute[1]
+            next if attribute_definitions.key?(name)
+            attribute_definitions[name] = attr
+            define_accessors(name)
+          end
+        end
+
         def attribute_definitions
           @attribute_definitions ||= Registry.new
         end

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -66,11 +66,13 @@ module Nylas
         # Allows a class to inherit parent's attributes
         def inherit_attributes
           return if superclass.nil?
+
           parent_attributes = superclass.attribute_definitions
           parent_attributes.each do |parent_attribute|
             name = parent_attribute[0]
             attr = parent_attribute[1]
             next if attribute_definitions.key?(name)
+
             attribute_definitions[name] = attr
             define_accessors(name)
           end

--- a/lib/nylas/neural.rb
+++ b/lib/nylas/neural.rb
@@ -78,6 +78,7 @@ module Nylas
       )
     end
 
+    # For Ruby < 3.0 support, as it doesn't support Hash.except
     def delete_from_hash(hash, to_delete)
       hash.delete(to_delete)
       hash

--- a/lib/nylas/neural.rb
+++ b/lib/nylas/neural.rb
@@ -58,9 +58,9 @@ module Nylas
 
     def clean_conversation(message_ids, options = nil)
       body = { message_id: message_ids }
-      body = body.merge(options.to_hash.except(:parse_contact)) unless options.nil?
-      response = request(NeuralCleanConversation.resources_path, body)
+      body = body.merge(delete_from_hash(options.to_hash, :parse_contact)) unless options.nil?
 
+      response = request(NeuralCleanConversation.resources_path, body)
       collection = []
       response.each do |conversation|
         collection.push(NeuralCleanConversation.new(**conversation.merge(api: api)))
@@ -76,6 +76,11 @@ module Nylas
         path: path,
         payload: JSON.dump(body)
       )
+    end
+
+    def delete_from_hash(hash, to_delete)
+      hash.delete(to_delete)
+      hash
     end
   end
 end

--- a/lib/nylas/neural.rb
+++ b/lib/nylas/neural.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Class containing methods for accessing Neural API features.
+  # @see https://developer.nylas.com/docs/intelligence/
+  class Neural
+    attr_accessor :api
+
+    def initialize(api:)
+      self.api = api
+    end
+
+    def sentiment_analysis_message(message_ids)
+      body = { message_id: message_ids }
+      response = request(NeuralSentimentAnalysis.resources_path, body)
+
+      collection = []
+      response.each do |sentiment|
+        collection.push(NeuralSentimentAnalysis.new(**sentiment.merge(api: api)))
+      end
+      collection
+    end
+
+    def sentiment_analysis_text(text)
+      body = { text: text }
+      NeuralSentimentAnalysis.new(**request(NeuralSentimentAnalysis.resources_path, body).merge(api: api))
+    end
+
+    def extract_signature(message_ids, options = nil)
+      body = { message_id: message_ids }
+      body = body.merge(options) unless options.nil?
+      response = request(NeuralSignatureExtraction.resources_path, body)
+
+      collection = []
+      response.each do |signature|
+        collection.push(NeuralSignatureExtraction.new(**signature.merge(api: api)))
+      end
+      collection
+    end
+
+    def ocr_request(file_id, pages = nil)
+      body = { file_id: file_id }
+      body[:pages] = pages unless pages.nil?
+
+      NeuralOcr.new(**request(NeuralOcr.resources_path, body).merge(api: api))
+    end
+
+    def categorize(message_ids)
+      body = { message_id: message_ids }
+      response = request(NeuralCategorizer.resources_path, body)
+
+      collection = []
+      response.each do |categorize|
+        collection.push(NeuralCategorizer.new(**categorize.merge(api: api)))
+      end
+      collection
+    end
+
+    def clean_conversation(message_ids, options = nil)
+      body = { message_id: message_ids }
+      body = body.merge(options.to_hash.except(:parse_contact)) unless options.nil?
+      response = request(NeuralCleanConversation.resources_path, body)
+
+      collection = []
+      response.each do |conversation|
+        collection.push(NeuralCleanConversation.new(**conversation.merge(api: api)))
+      end
+      collection
+    end
+
+    private
+
+    def request(path, body)
+      api.execute(
+        method: :put,
+        path: path,
+        payload: JSON.dump(body)
+      )
+    end
+  end
+end

--- a/lib/nylas/neural_categorizer.rb
+++ b/lib/nylas/neural_categorizer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent a the Neural Categorizer object.
+  # @see https://developer.nylas.com/docs/intelligence/categorizer/#categorize-message-response
+  class NeuralCategorizer < Message
+    include Model
+    self.resources_path = "/neural/categorize"
+    allows_operations(listable: true)
+
+    attribute :categorizer, :categorize
+    # Overrides Message's label attribute as currently categorize returns
+    # list of strings for labels instead of label object types
+    has_n_of_attribute :labels, :string
+
+    inherit_attributes
+
+    def recategorize(category)
+      body = { message_id: id, category: category }
+      api.execute(
+        method: :post,
+        path: "#{resources_path}/feedback",
+        payload: JSON.dump(body)
+      )
+      list = api.neural.categorize([id])
+      list[0]
+    end
+  end
+end

--- a/lib/nylas/neural_clean_conversation.rb
+++ b/lib/nylas/neural_clean_conversation.rb
@@ -7,7 +7,7 @@ module Nylas
     include Model
     self.resources_path = "/neural/conversation"
     allows_operations(listable: true)
-    IMAGE_REGEX = /[(']cid:(.*?)[)']/
+    IMAGE_REGEX = /[(']cid:(.*?)[)']/.freeze
 
     attribute :conversation, :string
     attribute :model_version, :string

--- a/lib/nylas/neural_clean_conversation.rb
+++ b/lib/nylas/neural_clean_conversation.rb
@@ -1,0 +1,30 @@
+module Nylas
+  # Structure to represent a the Neural Clean Conversations object.
+  # @see https://developer.nylas.com/docs/intelligence/clean-conversations/#clean-conversation-response
+  class NeuralCleanConversation < Message
+    include Model
+    self.resources_path = "/neural/conversation"
+    allows_operations(listable: true)
+    IMAGE_REGEX = /[\(']cid:(.*?)[\)']/
+
+    attribute :conversation, :string
+    attribute :model_version, :string
+
+    inherit_attributes
+
+    # Parses image file IDs found in the clean conversation object and returns
+    # an array of File objects returned from the File API
+    def extract_images
+      return if conversation.nil?
+      files = []
+      matches = conversation.scan(IMAGE_REGEX)
+      matches.each do |match|
+        # After applying the regex, if there are IDs found they would be
+        # in the form of => 'cid:xxxx' (including apostrophes), so we discard
+        # everything before and after the file ID (denoted as xxxx above)
+        files.push(api.files.find(match))
+      end
+      files
+    end
+  end
+end

--- a/lib/nylas/neural_clean_conversation.rb
+++ b/lib/nylas/neural_clean_conversation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Nylas
   # Structure to represent a the Neural Clean Conversations object.
   # @see https://developer.nylas.com/docs/intelligence/clean-conversations/#clean-conversation-response

--- a/lib/nylas/neural_clean_conversation.rb
+++ b/lib/nylas/neural_clean_conversation.rb
@@ -7,7 +7,7 @@ module Nylas
     include Model
     self.resources_path = "/neural/conversation"
     allows_operations(listable: true)
-    IMAGE_REGEX = /[\(']cid:(.*?)[\)']/
+    IMAGE_REGEX = /[(']cid:(.*?)[)']/
 
     attribute :conversation, :string
     attribute :model_version, :string
@@ -18,6 +18,7 @@ module Nylas
     # an array of File objects returned from the File API
     def extract_images
       return if conversation.nil?
+
       files = []
       matches = conversation.scan(IMAGE_REGEX)
       matches.each do |match|

--- a/lib/nylas/neural_contact_link.rb
+++ b/lib/nylas/neural_contact_link.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the "Link" object in the Neural API's Signature Extraction Contact object
+  # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#parse-signature-response
+  class NeuralContactLink
+    include Model::Attributable
+    attribute :description, :string
+    attribute :url, :string
+  end
+end

--- a/lib/nylas/neural_contact_name.rb
+++ b/lib/nylas/neural_contact_name.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the "Name" object in the Neural API's Signature Extraction Contact object
+  # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#parse-signature-response
+  class NeuralContactName
+    include Model::Attributable
+    attribute :first_name, :string
+    attribute :last_name, :string
+  end
+end

--- a/lib/nylas/neural_message_options.rb
+++ b/lib/nylas/neural_message_options.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Nylas
+  # Structure to represent a the Neural Optical Character Recognition object.
+  # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
+  class NeuralMessageOptions
+    attr_accessor :ignore_links, :ignore_images, :ignore_tables, :remove_conclusion_phrases,
+                  :images_as_markdown, :parse_contact
+
+    def initialize(ignore_links: nil,
+                   ignore_images: nil,
+                   ignore_tables: nil,
+                   remove_conclusion_phrases: nil,
+                   images_as_markdown:nil,
+                   parse_contact: nil)
+      @ignore_links = ignore_links
+      @ignore_images = ignore_images
+      @ignore_tables = ignore_tables
+      @remove_conclusion_phrases = remove_conclusion_phrases
+      @images_as_markdown = images_as_markdown
+      @parse_contact = parse_contact
+    end
+
+    def to_hash
+      hash = {}
+      hash[:ignore_links] = @ignore_links unless @ignore_links.nil?
+      hash[:ignore_images] = @ignore_images unless @ignore_images.nil?
+      hash[:ignore_tables] = @ignore_tables unless @ignore_tables.nil?
+      hash[:remove_conclusion_phrases] = @remove_conclusion_phrases unless @remove_conclusion_phrases.nil?
+      hash[:images_as_markdown] = @images_as_markdown unless @images_as_markdown.nil?
+      hash[:parse_contact] = @parse_contact unless @parse_contact.nil?
+      hash
+    end
+  end
+end

--- a/lib/nylas/neural_message_options.rb
+++ b/lib/nylas/neural_message_options.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Nylas
   # Structure to represent a the Neural Optical Character Recognition object.
   # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
@@ -10,7 +11,7 @@ module Nylas
                    ignore_images: nil,
                    ignore_tables: nil,
                    remove_conclusion_phrases: nil,
-                   images_as_markdown:nil,
+                   images_as_markdown: nil,
                    parse_contact: nil)
       @ignore_links = ignore_links
       @ignore_images = ignore_images

--- a/lib/nylas/neural_ocr.rb
+++ b/lib/nylas/neural_ocr.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent a the Neural Optical Character Recognition object.
+  # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
+  class NeuralOcr < File
+    include Model
+    self.resources_path = "/neural/ocr"
+    allows_operations(listable: true)
+
+    has_n_of_attribute :ocr, :string
+    attribute :processed_pages, :integer
+
+    inherit_attributes
+  end
+end

--- a/lib/nylas/neural_sentiment_analysis.rb
+++ b/lib/nylas/neural_sentiment_analysis.rb
@@ -11,7 +11,7 @@ module Nylas
     attribute :account_id, :string
     attribute :sentiment, :string
     attribute :sentiment_score, :float
-    attribute :processed_length, :float
+    attribute :processed_length, :integer
     attribute :text, :string
   end
 end

--- a/lib/nylas/neural_sentiment_analysis.rb
+++ b/lib/nylas/neural_sentiment_analysis.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent a the Neural Sentiment Analysis object.
+  # @see https://developer.nylas.com/docs/intelligence/sentiment-analysis/#sentiment-analysis-response-message
+  class NeuralSentimentAnalysis
+    include Model
+    self.resources_path = "/neural/sentiment"
+    allows_operations(listable: true)
+
+    attribute :account_id, :string
+    attribute :sentiment, :string
+    attribute :sentiment_score, :float
+    attribute :processed_length, :float
+    attribute :text, :string
+  end
+end

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -14,8 +14,7 @@ module Nylas
     attr_accessor :api
 
     def to_contact_object
-      contact = {}
-      contact = contact.merge(convert_names, convert_emails, convert_phone_numbers, convert_links)
+      contact = merge_multiple_hashes([convert_names, convert_emails, convert_phone_numbers, convert_links])
       contact[:job_title] = job_titles[0] unless job_titles.nil?
       Contact.new(**contact.merge(api: api))
     end
@@ -64,6 +63,16 @@ module Nylas
         contact[:web_pages].push(type: type, url: link.url)
       end
       contact
+    end
+
+    # For Ruby 2.5 support as it doesn't support multiple hashes to merge at once
+    def merge_multiple_hashes(hashes_to_merge)
+      hash = {}
+      hashes_to_merge.each do |new_hash|
+        hash = hash.merge(new_hash)
+      end
+
+      hash
     end
   end
 end

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the Neural API's Signature Extraction Contact object
+  # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#parse-signature-response
+  class NeuralSignatureContact
+    include Model::Attributable
+    has_n_of_attribute :job_titles, :string
+    has_n_of_attribute :links, :neural_contact_link
+    has_n_of_attribute :phone_numbers, :string
+    has_n_of_attribute :emails, :string
+    has_n_of_attribute :names, :neural_contact_name
+
+    attr_accessor :api
+
+    def to_contact_object
+      contact = {}
+      contact = contact.merge(convert_names, convert_emails, convert_phone_numbers, convert_links)
+      contact[:job_title] = job_titles[0] unless job_titles.nil?
+      Contact.new(**contact.merge(api: api))
+    end
+
+    private
+
+    def convert_names
+      return if names.nil?
+      contact = {}
+      contact[:given_name] = names[0].first_name
+      contact[:surname] = names[0].last_name
+      contact
+    end
+
+    def convert_emails
+      return if emails.nil?
+      contact = {}
+      contact[:emails] = []
+      emails.each do |e|
+        contact[:emails].push(type: "personal", email: e)
+      end
+      contact
+    end
+
+    def convert_phone_numbers
+      return if phone_numbers.nil?
+      contact = {}
+      contact[:phone_numbers] = []
+      phone_numbers.each do |number|
+        contact[:phone_numbers].push(type: "mobile", number: number)
+      end
+      contact
+    end
+
+    def convert_links
+      return if links.nil?
+      contact = {}
+      contact[:web_pages] = []
+      links.each do |link|
+        type = "homepage"
+        type = link.description unless link.description.empty?
+        contact[:web_pages].push(type: type, url: link.url)
+      end
+      contact
+    end
+  end
+end

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -13,6 +13,9 @@ module Nylas
 
     attr_accessor :api
 
+    # Creates a Nylas contact object compatible with the contact endpoints.
+    # Please note if multiple names or multiple job titles were parsed only
+    # the first set are used.
     def to_contact_object
       contact = merge_multiple_hashes([convert_names, convert_emails, convert_phone_numbers, convert_links])
       contact[:job_title] = job_titles[0] unless job_titles.nil?
@@ -25,8 +28,8 @@ module Nylas
       return if names.nil?
 
       contact = {}
-      contact[:given_name] = names[0].first_name
-      contact[:surname] = names[0].last_name
+      contact[:given_name] = names[0].first_name unless names[0].first_name.to_s.empty?
+      contact[:surname] = names[0].last_name unless names[0].last_name.to_s.empty?
       contact
     end
 

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -25,7 +25,7 @@ module Nylas
     private
 
     def convert_names
-      return if names.nil?
+      return {} if names.empty?
 
       contact = {}
       contact[:given_name] = names[0].first_name if names[0].first_name
@@ -34,7 +34,7 @@ module Nylas
     end
 
     def convert_emails
-      return if emails.nil?
+      return {} if emails.empty?
 
       contact = {}
       contact[:emails] = []
@@ -45,7 +45,7 @@ module Nylas
     end
 
     def convert_phone_numbers
-      return if phone_numbers.nil?
+      return {} if phone_numbers.empty?
 
       contact = {}
       contact[:phone_numbers] = []
@@ -56,7 +56,7 @@ module Nylas
     end
 
     def convert_links
-      return if links.nil?
+      return {} if links.empty?
 
       contact = {}
       contact[:web_pages] = []

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -24,6 +24,7 @@ module Nylas
 
     def convert_names
       return if names.nil?
+
       contact = {}
       contact[:given_name] = names[0].first_name
       contact[:surname] = names[0].last_name
@@ -32,6 +33,7 @@ module Nylas
 
     def convert_emails
       return if emails.nil?
+
       contact = {}
       contact[:emails] = []
       emails.each do |e|
@@ -42,6 +44,7 @@ module Nylas
 
     def convert_phone_numbers
       return if phone_numbers.nil?
+
       contact = {}
       contact[:phone_numbers] = []
       phone_numbers.each do |number|
@@ -52,6 +55,7 @@ module Nylas
 
     def convert_links
       return if links.nil?
+
       contact = {}
       contact[:web_pages] = []
       links.each do |link|

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -28,8 +28,8 @@ module Nylas
       return if names.nil?
 
       contact = {}
-      contact[:given_name] = names[0].first_name unless names[0].first_name.to_s.empty?
-      contact[:surname] = names[0].last_name unless names[0].last_name.to_s.empty?
+      contact[:given_name] = names[0].first_name if names[0].first_name
+      contact[:surname] = names[0].last_name if names[0].last_name
       contact
     end
 

--- a/lib/nylas/neural_signature_extraction.rb
+++ b/lib/nylas/neural_signature_extraction.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent a the Signature Extraction Schema.
+  # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#signature-feedback-response
+  class NeuralSignatureExtraction < Message
+    include Model
+    self.resources_path = "/neural/signature"
+
+    attribute :signature, :string
+    attribute :model_version, :string
+    attribute :contacts, :neural_signature_contact
+
+    inherit_attributes
+
+    transfer :api, to: %i[contacts]
+  end
+end

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -144,5 +144,16 @@ module Nylas
       end
     end
     Types.registry[:boolean] = BooleanType.new
+
+    # Type for attributes represented as floats.
+    class FloatType < ValueType
+      # @param value [Object] Strictly casts the passed in value to a boolean (must be true, not "" or 1)
+      def cast(value)
+        return nil if value.nil?
+
+        value.to_f
+      end
+    end
+    Types.registry[:float] = FloatType.new
   end
 end

--- a/spec/nylas/neural_spec.rb
+++ b/spec/nylas/neural_spec.rb
@@ -1,0 +1,373 @@
+# frozen_string_literal: true
+
+describe Nylas::Neural do
+  describe "Clean Conversation" do
+    let(:data) do
+      [
+        {
+          account_id: "account123",
+          body: "<img src='cid:1781777f666586677621' /> This is the body",
+          conversation:
+            "<img src='cid:1781777f666586677621' /> This is the conversation",
+          date: 1624029503,
+          from: [
+            {
+              email: "swag@nylas.com",
+              name: "Nylas Swag"
+            }
+          ],
+          id: "abc123",
+          model_version: "0.0.1",
+          object: "message",
+          provider_name: "gmail",
+          subject: "Subject",
+          to: [
+            {
+              email: "me@nylas.com",
+              name: "me"
+            }
+          ]
+        }
+      ]
+    end
+
+    it "Deserializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      clean_conversation = neural.clean_conversation(["abc123"])
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/conversation",
+        payload: JSON.dump(
+          message_id: ["abc123"]
+        )
+      )
+
+      expect(clean_conversation.length).to be(1)
+      expect(clean_conversation[0].id).to eql("abc123")
+      expect(clean_conversation[0].body).to eql("<img src='cid:1781777f666586677621' /> This is the body")
+      expect(clean_conversation[0].conversation).to
+      eql("<img src='cid:1781777f666586677621' /> This is the conversation")
+      expect(clean_conversation[0].model_version).to eql("0.0.1")
+    end
+
+    it "Sends the options in the body" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      options = Nylas::NeuralMessageOptions.new(
+        ignore_links: false,
+        ignore_images: false,
+        ignore_tables: false,
+        remove_conclusion_phrases: false,
+        images_as_markdown: false,
+        parse_contact: false
+      )
+      neural.clean_conversation(["abc123"], options)
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/conversation",
+        payload: JSON.dump(
+          message_id: ["abc123"],
+          ignore_links: false,
+          ignore_images: false,
+          ignore_tables: false,
+          remove_conclusion_phrases: false,
+          images_as_markdown: false
+        )
+      )
+    end
+
+    it "Parses the image correctly" do
+      api = instance_double(Nylas::API, execute: data)
+      files = instance_double(Nylas::Collection, find: Nylas::File.new(id: "file123"))
+      allow(api).to receive(:files).and_return(files)
+      neural = described_class.new(api: api)
+      clean_conversation = neural.clean_conversation(["abc123"])
+      clean_conversation[0].extract_images
+
+      expect(files).to have_received(:find).with(
+        ["1781777f666586677621"]
+      )
+    end
+  end
+
+  describe "Sentiment Analysis" do
+    let(:data) do
+      {
+        account_id: "abc123",
+        processed_length: 17,
+        sentiment: "NEUTRAL",
+        sentiment_score: 0.20000000298023224,
+        text: "This is some text"
+      }
+    end
+
+    it "Deserializes the message request into Ruby objects" do
+      api = instance_double(Nylas::API, execute: [data])
+      neural = described_class.new(api: api)
+      sentiment = neural.sentiment_analysis_message(["abc123"])
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/sentiment",
+        payload: JSON.dump(
+          message_id: ["abc123"]
+        )
+      )
+
+      expect(sentiment.length).to be(1)
+      expect(sentiment[0].account_id).to eql("abc123")
+      expect(sentiment[0].processed_length).to be(17)
+      expect(sentiment[0].sentiment).to eql("NEUTRAL")
+      expect(sentiment[0].sentiment_score).to be(0.20000000298023224)
+      expect(sentiment[0].text).to eql("This is some text")
+    end
+
+    it "Deserializes the text request into Ruby objects" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      sentiment = neural.sentiment_analysis_text("This is some text")
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/sentiment",
+        payload: JSON.dump(
+          text: "This is some text"
+        )
+      )
+
+      expect(sentiment.account_id).to eql("abc123")
+      expect(sentiment.processed_length).to be(17)
+      expect(sentiment.sentiment).to eql("NEUTRAL")
+      expect(sentiment.sentiment_score).to be(0.20000000298023224)
+      expect(sentiment.text).to eql("This is some text")
+    end
+  end
+
+  describe "Extract Signature" do
+    let(:data) do
+      [
+        {
+          account_id: "account123",
+          body:
+            "This is the body<div>Nylas Swag</div><div>Software Engineer</div><div>123-456-8901</div>
+            <div>swag@nylas.com</div><img src='https://example.com/logo.png'
+            alt='https://example.com/link.html'></a>",
+          signature:
+            "Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\n\nswag@nylas.com",
+          contacts: {
+            job_titles: ["Software Engineer"],
+            links: [
+              {
+                description: "string",
+                url: "https://example.com/link.html"
+              }
+            ],
+            phone_numbers: ["123-456-8901"],
+            emails: ["swag@nylas.com"],
+            names: [
+              {
+                first_name: "Nylas",
+                last_name: "Swag"
+              }
+            ]
+          },
+          date: 1624029503,
+          from: [
+            {
+              email: "swag@nylas.com",
+              name: "Nylas Swag"
+            }
+          ],
+          id: "abc123",
+          model_version: "0.0.1",
+          object: "message",
+          provider_name: "gmail",
+          subject: "Subject",
+          to: [
+            {
+              email: "me@nylas.com",
+              name: "me"
+            }
+          ]
+        }
+      ]
+    end
+
+    it "Deserializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      signature = neural.extract_signature(["abc123"])
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/signature",
+        payload: JSON.dump(
+          message_id: ["abc123"]
+        )
+      )
+
+      expect(signature.length).to be(1)
+      expect(signature[0].signature).to
+      eql("Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\n\nswag@nylas.com")
+      expect(signature[0].model_version).to eql("0.0.1")
+      expect(signature[0].contacts.job_titles).to eql(["Software Engineer"])
+      expect(signature[0].contacts.phone_numbers).to eql(["123-456-8901"])
+      expect(signature[0].contacts.emails).to eql(["swag@nylas.com"])
+      expect(signature[0].contacts.links.length).to be(1)
+      expect(signature[0].contacts.links[0].description).to eql("string")
+      expect(signature[0].contacts.links[0].url).to eql("https://example.com/link.html")
+      expect(signature[0].contacts.names.length).to be(1)
+      expect(signature[0].contacts.names[0].first_name).to eql("Nylas")
+      expect(signature[0].contacts.names[0].last_name).to eql("Swag")
+    end
+
+    it "Sends the options in the body" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      options = Nylas::NeuralMessageOptions.new(
+        ignore_links: false,
+        ignore_images: false,
+        ignore_tables: false,
+        remove_conclusion_phrases: false,
+        images_as_markdown: false,
+        parse_contact: false
+      )
+      neural.extract_signature(["abc123"], options)
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/signature",
+        payload: JSON.dump(
+          message_id: ["abc123"],
+          ignore_links: false,
+          ignore_images: false,
+          ignore_tables: false,
+          remove_conclusion_phrases: false,
+          images_as_markdown: false,
+          parse_contact: false
+        )
+      )
+    end
+
+    it "Converts signature contact object to a Nylas contact object" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      signature = neural.extract_signature(["abc123"])
+      contact = signature[0].contacts.to_contact_object
+
+      expect(contact.given_name).to eql("Nylas")
+      expect(contact.surname).to eql("Swag")
+      expect(contact.job_title).to eql("Software Engineer")
+      expect(contact.emails.length).to be(1)
+      expect(contact.emails[0].email).to eql("swag@nylas.com")
+      expect(contact.phone_numbers.length).to be(1)
+      expect(contact.phone_numbers[0].number).to eql("123-456-8901")
+      expect(contact.web_pages.length).to be(1)
+      expect(contact.web_pages[0].url).to eql("https://example.com/link.html")
+    end
+  end
+
+  describe "Categorize" do
+    let(:data) do
+      {
+        account_id: "account123",
+        body: "This is a body",
+        categorizer: {
+          categorized_at: 1624570089,
+          category: "feed",
+          model_version: "6194f733",
+          subcategories: ["ooo"]
+        },
+        date: 1624029503,
+        from: [
+          {
+            email: "swag@nylas.com",
+            name: "Nylas Swag"
+          }
+        ],
+        id: "abc123",
+        object: "message",
+        provider_name: "gmail",
+        subject: "Subject",
+        to: [
+          {
+            email: "me@nylas.com",
+            name: "me"
+          }
+        ]
+      }
+    end
+
+    it "Deserializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API, execute: [data])
+      neural = described_class.new(api: api)
+      categorize = neural.categorize(["abc123"])
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/categorize",
+        payload: JSON.dump(
+          message_id: ["abc123"]
+        )
+      )
+
+      expect(categorize.length).to be(1)
+      expect(categorize[0].categorizer.category).to eql("feed")
+      expect(categorize[0].categorizer.categorized_at).to eql(Time.at(1624570089))
+      expect(categorize[0].categorizer.model_version).to eql("6194f733")
+      expect(categorize[0].categorizer.subcategories.length).to be(1)
+      expect(categorize[0].categorizer.subcategories[0]).to eql("ooo")
+    end
+
+    it "Re-categorizes the message" do
+      api = instance_double(Nylas::API, execute: [data])
+      neural = described_class.new(api: api)
+      allow(api).to receive(:neural).and_return(neural)
+      categorize = neural.categorize(["abc123"])
+      new_categorize = categorize[0].recategorize("feed")
+
+      expect(new_categorize.categorizer.category).to eql("feed")
+      expect(new_categorize.categorizer.categorized_at).to eql(Time.at(1624570089))
+      expect(new_categorize.categorizer.model_version).to eql("6194f733")
+      expect(new_categorize.categorizer.subcategories.length).to be(1)
+      expect(new_categorize.categorizer.subcategories[0]).to eql("ooo")
+    end
+  end
+
+  describe "OCR" do
+    let(:data) do
+      {
+        account_id: "account123",
+        content_type: "application/pdf",
+        filename: "sample.pdf",
+        id: "abc123",
+        object: "file",
+        ocr: ["This is page 1", "This is page 2"],
+        processed_pages: 2,
+        size: 20
+      }
+    end
+
+    it "Deserializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API, execute: data)
+      neural = described_class.new(api: api)
+      ocr = neural.ocr_request("abc123")
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/neural/ocr",
+        payload: JSON.dump(
+          file_id: "abc123"
+        )
+      )
+
+      expect(ocr.ocr.length).to be(2)
+      expect(ocr.ocr[0]).to eql("This is page 1")
+      expect(ocr.ocr[1]).to eql("This is page 2")
+      expect(ocr.processed_pages).to be(2)
+    end
+  end
+end

--- a/spec/nylas/neural_spec.rb
+++ b/spec/nylas/neural_spec.rb
@@ -8,7 +8,7 @@ describe Nylas::Neural do
           account_id: "account123",
           body: "<img src='cid:1781777f666586677621' /> This is the body",
           conversation:
-            "<img src='cid:1781777f666586677621' /> This is the conversation",
+            "<img src='cid:1781777f666586677621' /> Conversation",
           date: 1624029503,
           from: [
             {
@@ -47,8 +47,7 @@ describe Nylas::Neural do
       expect(clean_conversation.length).to be(1)
       expect(clean_conversation[0].id).to eql("abc123")
       expect(clean_conversation[0].body).to eql("<img src='cid:1781777f666586677621' /> This is the body")
-      expect(clean_conversation[0].conversation).to
-      eql("<img src='cid:1781777f666586677621' /> This is the conversation")
+      expect(clean_conversation[0].conversation).to eql("<img src='cid:1781777f666586677621' /> Conversation")
       expect(clean_conversation[0].model_version).to eql("0.0.1")
     end
 
@@ -156,7 +155,7 @@ describe Nylas::Neural do
             <div>swag@nylas.com</div><img src='https://example.com/logo.png'
             alt='https://example.com/link.html'></a>",
           signature:
-            "Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\n\nswag@nylas.com",
+            "Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\nswag@nylas.com",
           contacts: {
             job_titles: ["Software Engineer"],
             links: [
@@ -210,8 +209,7 @@ describe Nylas::Neural do
       )
 
       expect(signature.length).to be(1)
-      expect(signature[0].signature).to
-      eql("Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\n\nswag@nylas.com")
+      expect(signature[0].signature).to eql("Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\nswag@nylas.com")
       expect(signature[0].model_version).to eql("0.0.1")
       expect(signature[0].contacts.job_titles).to eql(["Software Engineer"])
       expect(signature[0].contacts.phone_numbers).to eql(["123-456-8901"])


### PR DESCRIPTION
# Description
This PR brings support for the Nylas [Neural API](https://developer.nylas.com/docs/intelligence/). The Neural API exposes endpoints that perform intelligent analysis on items in your Nylas account. This change will enable users to access the features of the Nylas Neural API and provides some utility functions to help improve the user's workflow.

# Usage
To use [Sentiment Analysis](https://developer.nylas.com/docs/intelligence/sentiment-analysis/):
```ruby
# To perform sentiment analysis on a message, pass in the list of message ID:
message_analysis = nylas.neural.sentiment_analysis_message([MESSAGE_ID])

# To perform sentiment analysis on just text, pass in a string:
text_analysis = nylas.neural.sentiment_analysis_text("Hi, thank you so much for reaching out! We can catch up tomorrow.")
```

To use [Signature Extraction](https://developer.nylas.com/docs/intelligence/signature-extraction/):
```ruby
const signature = nylas.neural.extract_signature([MESSAGE_ID])

# The method also accepts an optional parameter options, an object of options
# that can be enabled for the Neural endpoint, of type NeuralMessageOptions:
options = Nylas::NeuralMessageOptions.new(
    ignore_links: false,
    ignore_images: false,
    ignore_tables: false,
    remove_conclusion_phrases: false,
    images_as_markdown: false,
    parse_contact: false
)

signature = nylas.neural.extract_signature([MESSAGE_ID], options)
```
and to parse the contact and convert it to the standard Nylas contact object:
```ruby
contact = signature[0].contacts.to_contact_object
```

To use [Clean Conversations](https://developer.nylas.com/docs/intelligence/clean-conversations/):
```ruby
convo = nylas.neural.clean_conversation([MESSAGE_ID])

# You can also pass in an object of options that can be enabled for the Neural endpoint, of type NeuralMessageOptions
convo = nylas.neural.clean_conversation([MESSAGE_ID], options);
```
and to extract images from the result:
```ruby
convo[0].extract_images
```

To use [Optical Character Recognition](https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/):
```ruby
ocr = nylas.neural.ocr_request(FILE_ID)

# This endpoint also supports a second, optional parameter for an array specifying the pages that the user wants analyzed:
ocr = nylas.neural.ocr_request(FILE_ID, [2, 3])
```


To use [Categorizer](https://developer.nylas.com/docs/intelligence/categorizer/)
```ruby
cat = nylas.neural.categorize([MESSAGE_ID])

# You can also send a request to recategorize the message:
cat = cat[0].recategorize("conversation")
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.