### PR TITLE
Add messages attribute to Thread.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix issue where `Delta` did not have a header attribute for expanded headers
 * Fix ArgumentError when calling `Nylas::API#send!` due to missing double splat (**)
 * Fix issue where server errors are not reported if HTML is returned
+* Fix issue where expanded `Thread` objects were not returning messages
 
 ### 5.2.0 / 2021-06-07
 * Add support for `Room Resource`

--- a/lib/nylas/thread.rb
+++ b/lib/nylas/thread.rb
@@ -23,6 +23,7 @@ module Nylas
     has_n_of_attribute :labels, :label
     has_n_of_attribute :folders, :folder
     has_n_of_attribute :message_ids, :string
+    has_n_of_attribute :messages, :message
     has_n_of_attribute :participants, :participant
     attribute :snippet, :string
     attribute :starred, :boolean

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -25,6 +25,12 @@ describe Nylas::Thread do
                                { display_name: "Inbox", id: "folder-inbox", name: "inbox" }],
                      last_message_received_timestamp: 1_510_080_143, last_message_sent_timestamp: nil,
                      last_message_timestamp: 1_510_080_143, message_ids: ["mess-0987"],
+                     messages: [{ account_id: "acc-1234", bcc: [], cc: [], date: 1_510_080_788, files: [],
+                                  from: [{ email: "andy-noreply@google.com", name: "Andy" }],
+                                  id: "message-123", labels: [], object: "message", reply_to: [],
+                                  snippet: "One", starred: false, subject: "Thread Test",
+                                  thread_id: "thread-2345", to: [{ email: "hellocohere@gmail.com",
+                                                                   name: "John Smith" }], unread: false }],
                      object: "thread", participants: [{ email: "hellocohere@gmail.com", name: "" },
                                                       { email: "andy-noreply@google.com",
                                                         name: "Andy from Google" }],
@@ -49,6 +55,13 @@ describe Nylas::Thread do
 
     expect(thread.last_message_received_timestamp).to eql Time.at(1_510_080_143)
     expect(thread.last_message_timestamp).to eql Time.at(1_510_080_143)
+
+    expect(thread.messages[0].account_id).to eql "acc-1234"
+    expect(thread.messages[0].thread_id).to eql "thread-2345"
+    expect(thread.messages[0].object).to eql "message"
+    expect(thread.messages[0].subject).to eql "Thread Test"
+    expect(thread.messages[0].from[0].email).to eql "andy-noreply@google.com"
+    expect(thread.messages[0].to[0].email).to eql "hellocohere@gmail.com"
 
     expect(thread.message_ids).to eql(["mess-0987"])
     expect(thread.object).to eql "thread"


### PR DESCRIPTION
This will help deserialize messages for GET requests sent to /threads/{{id}}?view=expanded.

<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Issue is that when tries to get thread with view=expanded, it doesn't deserialize messages.