### PR TITLE
v5.3.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.3.0 / 2021-08-18
 * Add support for Neural API
 * Fix issue where `Delta` did not have a header attribute for expanded headers
 * Fix ArgumentError when calling `Nylas::API#send!` due to missing double splat (**)

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.2.0"
+  VERSION = "5.3.0"
 end


### PR DESCRIPTION
# Description
New `nylas` v5.3.0 release bringing in the following new features:
* Add support for the Neural API (#318)

The new release also fixes the following:
* Fix issue where `Delta` did not have a header attribute for expanded headers (#315, #314)
* Fix ArgumentError when calling `Nylas::API#send!` due to missing double splat (**) (#317, #310)
* Fix issue where server errors are not reported if HTML is returned (#316, #313)
* Fix issue where expanded `Thread` objects were not returning messages (#319, #321)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.