### PR TITLE
[67394] Fix updating `Draft` failing if no version number provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix update draft failing if version is not explicitly set
+
 ### 5.3.0 / 2021-08-18
 * Add support for Neural API
 * Fix issue where `Delta` did not have a header attribute for expanded headers

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -39,9 +39,12 @@ module Nylas
     transfer :api, to: %i[events files folder labels]
 
     def update(**data)
+      # If files are provided, replace files with file IDs
       self.files = data[:files] if data[:files]
       extract_file_ids!
       data[:file_ids] = file_ids
+      # If version is not provided, add version or request will fail
+      data[:version] = version unless data[:version]
 
       super
     end

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -97,6 +97,34 @@ describe Nylas::Draft do
 
       expect(draft.version).to eq(1)
     end
+
+    it "sends the version number if the user does not manually add it" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      data = {
+        id: "draft-1234",
+        subject: "This is a draft",
+        version: 0
+      }
+      draft = described_class.from_json(
+        JSON.dump(data),
+        api: api
+      )
+      updated = {
+        subject: "This is an updated draft"
+      }
+
+      draft.update(**updated)
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/drafts/draft-1234",
+        payload: JSON.dump(
+          subject: "This is an updated draft",
+          version: 0
+        ),
+        query: {}
+      )
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
# Description
The following is the code snippet is found on our Nylas docs for Ruby PUT `/drafts/{id}`: https://developer.nylas.com/docs/api/#put/drafts/id

```ruby
draft_to_change = api.drafts.find("51si***")
draft_to_change.update(display_name: "My Renamed Draft")
```

However in practice this fails. The reason is because the API expects a version number to be passed in with a PUT call. In the Ruby SDK we only pass the updated parameters to the API, so if the user doesn't explicitly send in the `version` number, the SDK doesn't do it for them and triggers the error. To adhere to the documentation and the API's expectation, we should send the version number in the payload if the user never adds it in explicitly.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.