### PR TITLE
Change drafts example so that it works even when a user has no existing drafts

### DIFF
--- a/examples/plain-ruby/drafts.rb
+++ b/examples/plain-ruby/drafts.rb
@@ -5,6 +5,11 @@ require_relative '../helpers'
 api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
+# Creating a draft
+demonstrate do
+  example_draft = api.drafts.create(subject: "A new draft!")
+  example_draft.to_h
+end
 
 # Retrieving a count of drafts
 demonstrate { api.drafts.count }
@@ -15,12 +20,6 @@ example_draft =  api.drafts.first
 
 # Retrieving a particular drafts
 demonstrate { api.drafts.find(example_draft.id) }
-
-# Creating a draft
-demonstrate do
-  example_draft = api.drafts.create(subject: "A new draft!")
-  example_draft.to_h
-end
 
 # Sending a draft
 demonstrate do


### PR DESCRIPTION
Move "Creating a draft" to the top so that subsequent steps (e.g. Retrieving a particular draft) will still work even if a user has no pre-existing drafts

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.