### PR TITLE
[68888] Modify Draft Sending logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Fix update draft failing if version is not explicitly set
+* Fix draft `.send` logic
 
 ### 5.3.0 / 2021-08-18
 * Add support for Neural API

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -56,9 +56,8 @@ module Nylas
     end
 
     def send!
-      return execute(method: :post, path: "/send", payload: to_json) if tracking
+      return execute(method: :post, path: "/send", payload: to_json) if tracking || !id
 
-      save
       execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))
     end
 

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -253,26 +253,22 @@ describe Nylas::Draft do
   end
 
   describe "#send!" do
-    it "saves and sends the draft" do
+    it "sends the payload if the draft was not created on the server" do
       api = instance_double(Nylas::API)
-      draft = described_class.from_hash({ id: "draft-1234", "version": 5 }, api: api)
+      draft = described_class.from_hash({ reply_to_message_id: "mess-1234",
+                                          to: [{ email: "to@example.com", name: "To Example" }],
+                                          from: [{ email: "from@example.com", name: "From Example" }],
+                                          subject: "A draft emails subject", body: "<h1>A draft Email</h1>" },
+                                        api: api)
       update_json = draft.to_json
-      allow(api).to receive(:execute).and_return({})
-      allow(api).to receive(:execute).with(method: :put, path: "/drafts/draft-1234", payload: update_json)
-                                     .and_return(id: "draft-1234", version: "6")
+      allow(api).to receive(:execute)
 
       draft.send!
 
       expect(api).to have_received(:execute).with(
-        method: :put,
-        path: "/drafts/#{draft.id}",
-        payload: update_json,
-        query: {}
-      )
-      expect(api).to have_received(:execute).with(
         method: :post,
         path: "/send",
-        payload: JSON.dump(draft_id: draft.id, version: draft.version),
+        payload: update_json,
         query: {}
       )
     end


### PR DESCRIPTION
# Description
We shouldn't be updating a draft every time the user tries to to send a draft. This causes an unnecessary PUT call, and potentially causes a delay in the syncing process for the end user. So now, calling `.send` on a draft will not trigger an update/PUT call. Also to make up for this change, if a user wants to send a draft that they haven't saved (have not triggered a POST `/drafts` call), the SDK will send the full body in the POST call to `/send` allowing the user to send a message directly without having to create and save a draft object first.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.