### PR TITLE
v5.4.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.4.0 / 2021-09-23
 * Add support for Event Conferencing
 * Fix update draft failing if version is not explicitly set
 * Fix draft `.send` logic

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.3.0"
+  VERSION = "5.4.0"
 end


### PR DESCRIPTION
# Description
New `nylas` v5.4.0 release bringing in the following new features:
* Add support for Event Conferencing (#320)

The new release also fixes the following:
* Fix update draft failing if version is not explicitly set (#324)
* Fix draft `.send` logic (#323)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.