### PR TITLE
Update draft send method to send existing draft when tracking is enabled

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -56,9 +56,11 @@ module Nylas
     end
 
     def send!
-      return execute(method: :post, path: "/send", payload: to_json) if tracking || !id
+      return execute(method: :post, path: "/send", payload: to_json) unless id
 
-      execute(method: :post, path: "/send", payload: JSON.dump(draft_id: id, version: version))
+      data = { draft_id: id, version: version }
+      data[:tracking] = tracking.to_h if tracking
+      execute(method: :post, path: "/send", payload: JSON.dump(data))
     end
 
     def starred?

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -277,7 +277,6 @@ describe Nylas::Draft do
       api = instance_double(Nylas::API)
       draft = described_class.from_hash({ id: "draft-1234", "version": 5 }, api: api)
       draft.tracking = { opens: true, links: true, thread_replies: true, payload: "this is a payload" }
-      update_json = draft.to_json
       allow(api).to receive(:execute)
 
       draft.send!
@@ -285,7 +284,11 @@ describe Nylas::Draft do
       expect(api).to have_received(:execute).with(
         method: :post,
         path: "/send",
-        payload: update_json,
+        payload: JSON.dump(
+          draft_id: "draft-1234",
+          version: 5,
+          tracking: draft.tracking.to_h
+        ),
         query: {}
       )
     end


### PR DESCRIPTION
## Description
This fixes a bug where if tracking information is enabled on a draft it sends directly rather than sending the existing draft. If a draft has already been saved this means the actual draft message never gets sent and a new message is created. The message should instead only be sent directly if it hasn't been saved and otherwise conditionally add the tracking information to the draft message.

I've also updated the draft spec to reflect this change. Previously it was expecting:
`{\"id\":\"draft-1234\",\"version\":5,\"tracking\":{\"links\":true,\"opens\":true,\"thread_replies\":true,\"payload\":\"this is a payload\"}}`

It should instead expect `draft_id` rather than `id`:
`{\"draft_id\":\"draft-1234\",\"version\":5,\"tracking\":{\"links\":true,\"opens\":true,\"thread_replies\":true,\"payload\":\"this is a payload\"}}`

## License
<!-- Your PR comment must contain the following line for us to merge the PR. -->
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.