### PR TITLE
v5.4.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 5.4.1 / 2021-09-27
+* Fix draft send method to send existing draft when tracking is enabled
+
 ### 5.4.0 / 2021-09-23
 * Add support for Event Conferencing
 * Fix update draft failing if version is not explicitly set

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.4.0"
+  VERSION = "5.4.1"
 end


### PR DESCRIPTION
# Description

New `nylas` v5.4.1 release fixes the following:

- Fix draft send method to send existing draft when tracking is enabled (#327)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.