### PR TITLE
[72430] Support Event Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for event notifications
+
 ### 5.5.0 / 2021-10-28
 * Add Component CRUD Support
 * Add Scheduler support

--- a/examples/plain-ruby/events.rb
+++ b/examples/plain-ruby/events.rb
@@ -52,7 +52,7 @@ demonstrate { api.events.where(metadata_pair:{"event_type": "gathering"}).last.m
 #   },
 #   notifications: [{
 #     type: "email",
-#     minutes_before_event: "600",
+#     minutes_before_event: 600,
 #     subject: "Test Event Notification",
 #     body: "Reminding you about our meeting."
 #   }]

--- a/examples/plain-ruby/events.rb
+++ b/examples/plain-ruby/events.rb
@@ -38,7 +38,28 @@ demonstrate do  example_event.update(
 )
 end
 demonstrate { api.events.find(example_event.id).location }
-demonstrate { api.events.where(metadata_pair:{"event_type": "gathering"}).metadata[:event_type] }
+demonstrate { api.events.where(metadata_pair:{"event_type": "gathering"}).last.metadata[:event_type] }
+
+# TODO::Uncomment below when job status support is implemented
+#   as we can't delete an event with conferencing/notifications
+#   until the job status is complete.
+#
+# Adding conferencing and notifications
+# demonstrate do  example_event.update(
+#   conferencing:{
+#     provider: "Zoom Meeting",
+#     autocreate:{}
+#   },
+#   notifications: [{
+#     type: "email",
+#     time_before_event: "600",
+#     subject: "Test Event Notification",
+#     body: "Reminding you about our meeting."
+#   }]
+# )
+# end
+#
+# TODO::Add some sort of loop until
 
 # Deleting an event
 demonstrate { example_event.destroy }

--- a/examples/plain-ruby/events.rb
+++ b/examples/plain-ruby/events.rb
@@ -52,7 +52,7 @@ demonstrate { api.events.where(metadata_pair:{"event_type": "gathering"}).last.m
 #   },
 #   notifications: [{
 #     type: "email",
-#     time_before_event: "600",
+#     minutes_before_event: "600",
 #     subject: "Test Event Notification",
 #     body: "Reminding you about our meeting."
 #   }]

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -56,6 +56,7 @@ require_relative "nylas/open_hours"
 require_relative "nylas/event_conferencing"
 require_relative "nylas/event_conferencing_details"
 require_relative "nylas/event_conferencing_autocreate"
+require_relative "nylas/event_notification"
 require_relative "nylas/component"
 
 # Custom collection types
@@ -135,6 +136,7 @@ module Nylas
   Types.registry[:event_conferencing] = Types::ModelType.new(model: EventConferencing)
   Types.registry[:event_conferencing_details] = Types::ModelType.new(model: EventConferencingDetails)
   Types.registry[:event_conferencing_autocreate] = Types::ModelType.new(model: EventConferencingAutocreate)
+  Types.registry[:event_notification] = Types::ModelType.new(model: EventNotification)
   Types.registry[:neural] = Types::ModelType.new(model: Neural)
   Types.registry[:categorize] = Types::ModelType.new(model: Categorize)
   Types.registry[:neural_signature_contact] = Types::ModelType.new(model: NeuralSignatureContact)

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -29,6 +29,7 @@ module Nylas
     attribute :when, :when
     attribute :metadata, :hash
     attribute :conferencing, :event_conferencing
+    has_n_of_attribute :notifications, :event_notification
     attribute :original_start_time, :unix_timestamp
 
     attr_accessor :notify_participants

--- a/lib/nylas/event_notification.rb
+++ b/lib/nylas/event_notification.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the Event Notification object
+  # @see https://developer.nylas.com/docs/connectivity/calendar/event-notifications
+  class EventNotification
+    include Model::Attributable
+
+    attribute :type, :string
+    attribute :minutes_before_event, :integer
+    attribute :url, :string
+    attribute :payload, :string
+    attribute :subject, :string
+    attribute :body, :string
+    attribute :message, :string
+  end
+end
+

--- a/lib/nylas/event_notification.rb
+++ b/lib/nylas/event_notification.rb
@@ -15,4 +15,3 @@ module Nylas
     attribute :message, :string
   end
 end
-

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -36,7 +36,7 @@ describe Nylas::Event do
           start_time: 1_511_303_400
         },
         metadata: {
-          "event_type": "gathering"
+          event_type: "gathering"
         },
         conferencing: {
           provider: "Zoom Meeting",
@@ -48,7 +48,13 @@ describe Nylas::Event do
               "+11234567890"
             ]
           }
-        }
+        },
+        notifications: [{
+          type: "email",
+          minutes_before_event: "60",
+          subject: "Test Event Notification",
+          body: "Reminding you about our meeting."
+        }]
       }
 
       event = described_class.from_json(JSON.dump(data), api: api)
@@ -85,6 +91,10 @@ describe Nylas::Event do
       expect(event.conferencing.details.meeting_code).to eql "213"
       expect(event.conferencing.details.password).to eql "xyz"
       expect(event.conferencing.details.phone).to eql ["+11234567890"]
+      expect(event.notifications[0].type).to eql "email"
+      expect(event.notifications[0].minutes_before_event).to be 60
+      expect(event.notifications[0].subject).to eql "Test Event Notification"
+      expect(event.notifications[0].body).to eql "Reminding you about our meeting."
     end
   end
 


### PR DESCRIPTION
# Description
Add support for [Event notifications](https://developer.nylas.com/docs/connectivity/calendar/event-notifications).

# Usage
To add notifications to an event:

```ruby
api.events.create(
  title: "A fun event!",
  location: "The Party Zone",
  calendar_id: {CALENDAR_ID},
  conferencing: {
    provider: "Zoom Meeting",
    details: {
      url: "https://us02web.zoom.us/j/****************",
      meeting_code: "213",
      password: "xyz",
      phone: ["+11234567890"]
   },
  notifications: [
    {
      body: "Reminding you about our meeting.",
      minutes_before_event: 600,
      subject: "Test Event Notification",
      type: "email"
    },
    {
      type: "webhook",
      minutes_before_event: 600,
      url: "https://hooks.service.com/services/T01A03EEXDE/B01TBNH532R/HubIZu1zog4oYdFqQ8VUcuiW",
      payload: {
        text: "Your reminder goes here!"
      }.to_json
    },
    {
      type: "sms",
      minutes_before_event: "60",
      message: "Test Event Notfication"
    }
  ]
}
```

To retrieve event notification details of an event:
```ruby
event = api.events.find("{EVENT_ID}")

minutes_before_event = event.notifications[0].minutes_before_event
type = event.notifications[0].type
body = event.notifications[0].body
url = event.notifications[0].url
subject = event.notifications[0].subject
payload = event.notifications[0].payload
message = event.notifications[0].message
```

To update an event with a notification:
```ruby
event = api.events.find("{EVENT_ID}")

event.update(
  notifications: [{
      body: "Reminding you about our meeting.",
      minutes_before_event: 600,
      subject: "Test Event Notification",
      type: "email"
  }]
)
```

To delete a notification from an event:
```ruby
event = api.events.find("{EVENT_ID}")

event.update(
  notifications: []
)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.