### PR TITLE
[69622] Allow `exchange_code_for_token` to return a full body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for event notifications
+* Modify `exchange_code_for_token` to allow returning a full body
 
 ### 5.5.0 / 2021-10-28
 * Add Component CRUD Support

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -48,7 +48,11 @@ module Nylas
       "#{api_server}/oauth/authorize?#{URI.encode_www_form(params)}"
     end
 
-    def exchange_code_for_token(code)
+    # Exchanges an authorization code for an access token
+    # @param code [String] The authorization code to exchange
+    # @param return_full_response [Boolean] If true, returns the full response body instead of just the token
+    # @return [String | Hash] Returns just the access token as a string, or the full response as a hash
+    def exchange_code_for_token(code, return_full_response = false)
       data = {
         "client_id" => app_id,
         "client_secret" => client.app_secret,
@@ -56,8 +60,8 @@ module Nylas
         "code" => code
       }
 
-      response_json = execute(method: :post, path: "/oauth/token", payload: data)
-      response_json[:access_token]
+      response = execute(method: :post, path: "/oauth/token", payload: data)
+      return_full_response ? response : response[:access_token]
     end
 
     # @return [Collection<Contact>] A queryable collection of Contacts

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -52,7 +52,7 @@ module Nylas
     # @param code [String] The authorization code to exchange
     # @param return_full_response [Boolean] If true, returns the full response body instead of just the token
     # @return [String | Hash] Returns just the access token as a string, or the full response as a hash
-    def exchange_code_for_token(code, return_full_response = false)
+    def exchange_code_for_token(code, return_full_response: false)
       data = {
         "client_id" => app_id,
         "client_secret" => client.app_secret,

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -45,7 +45,7 @@ describe Nylas::API do
       allow(client).to receive(:execute).with(method: :post, path: "/oauth/token", payload: data)
                                         .and_return(response)
       api = described_class.new(client: client)
-      expect(api.exchange_code_for_token("fake-code", true)).to eql(response)
+      expect(api.exchange_code_for_token("fake-code", return_full_response: true)).to eql(response)
     end
   end
 

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -14,10 +14,38 @@ describe Nylas::API do
         "grant_type" => "authorization_code",
         "code" => "fake-code"
       }
+      response = {
+        account_id: "account-id",
+        email_address: "fake@email.com",
+        provider: "yahoo",
+        token_type: "barer",
+        access_token: "fake-token"
+      }
       allow(client).to receive(:execute).with(method: :post, path: "/oauth/token", payload: data)
-                                        .and_return(access_token: "fake-token")
+                                        .and_return(response)
       api = described_class.new(client: client)
       expect(api.exchange_code_for_token("fake-code")).to eql("fake-token")
+    end
+
+    it "retrieves full response from the server" do
+      client = Nylas::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
+      data = {
+        "client_id" => "fake-app",
+        "client_secret" => "fake-secret",
+        "grant_type" => "authorization_code",
+        "code" => "fake-code"
+      }
+      response = {
+        account_id: "account-id",
+        email_address: "fake@email.com",
+        provider: "yahoo",
+        token_type: "barer",
+        access_token: "fake-token"
+      }
+      allow(client).to receive(:execute).with(method: :post, path: "/oauth/token", payload: data)
+                                        .and_return(response)
+      api = described_class.new(client: client)
+      expect(api.exchange_code_for_token("fake-code", true)).to eql(response)
     end
   end
 


### PR DESCRIPTION
# Description
The `exchange_code_for_token` method strips the response body from the server and returns just the `access_token`. Now, it allows the user to pass in a boolean to dictate whether or not to return the full server response. To preserve backwards compatibility, the default behaviour of the method will still return an `access_token`.

# Usage
To return the entire full response body, pass in `return_full_response: true` with the `code`:
```ruby
response_body = api.exchange_code_for_token("code", return_full_response: true)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.