### PR TITLE
[73525] Metadata Support for Calendars, Accounts, and Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for event notifications
+* Add metadata support for `Calendar`, `Message` and `Account`
 * Modify `exchange_code_for_token` to allow returning a full body
 
 ### 5.5.0 / 2021-10-28

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -7,15 +7,17 @@ module Nylas
     include Model
     self.listable = true
     self.showable = true
+    self.updatable = true
 
-    attribute :id, :string
-    attribute :account_id, :string
-    attribute :billing_state, :string
-    attribute :sync_state, :string
-    attribute :provider, :string
+    attribute :id, :string, read_only: true
+    attribute :account_id, :string, read_only: true
+    attribute :billing_state, :string, read_only: true
+    attribute :sync_state, :string, read_only: true
+    attribute :provider, :string, read_only: true
 
-    attribute :email, :string
-    attribute :trial, :boolean
+    attribute :email, :string, read_only: true
+    attribute :trial, :boolean, read_only: true
+    attribute :metadata, :hash
 
     def upgrade
       response = execute(method: :post, path: "#{resource_path}/upgrade")

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -6,7 +6,8 @@ module Nylas
   class Calendar
     include Model
     self.resources_path = "/calendars"
-    allows_operations(listable: true, filterable: true, showable: true)
+    allows_operations(creatable: true, listable: true, filterable: true, showable: true, updatable: true,
+                      destroyable: true)
 
     attribute :id, :string
     attribute :account_id, :string
@@ -20,6 +21,7 @@ module Nylas
     attribute :timezone, :string
 
     attribute :read_only, :boolean
+    attribute :metadata, :hash
 
     def read_only?
       read_only == true

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -75,13 +75,13 @@ module Nylas
       execute(method: :delete, path: resource_path, payload: attributes.serialize_for_api(keys: [:version]))
     end
 
-    private
-
-    def save_call
+    def save
       extract_file_ids!
 
       super
     end
+
+    private
 
     def extract_file_ids!
       files = self.files || []

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -73,14 +73,10 @@ module Nylas
       self
     end
 
-    def save_call
+    def save
       handle_folder
 
-      execute(
-        method: :put,
-        payload: attributes.serialize_for_api,
-        path: resource_path
-      )
+      super
     end
 
     def handle_folder

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -8,7 +8,7 @@ module Nylas
     self.raw_mime_type = "message/rfc822"
     self.resources_path = "/messages"
     allows_operations(showable: true, listable: true, filterable: true, searchable: true, updatable: true)
-    UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread].freeze
+    UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread metadata].freeze
 
     attribute :id, :string
     attribute :object, :string
@@ -36,6 +36,7 @@ module Nylas
     has_n_of_attribute :files, :file
     attribute :folder, :folder
     attribute :folder_id, :string
+    attribute :metadata, :hash
 
     has_n_of_attribute :labels, :label, read_only: true
     has_n_of_attribute :label_ids, :string

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -28,7 +28,7 @@ module Nylas
       result = if persisted?
                  raise ModelNotUpdatableError, self unless updatable?
 
-                 save_call
+                 update_call(attributes.serialize_for_api)
                else
                  create
                end
@@ -119,14 +119,6 @@ module Nylas
     end
 
     private
-
-    def save_call
-      execute(
-        method: :put,
-        payload: attributes.serialize_for_api,
-        path: resource_path
-      )
-    end
 
     def update_call(payload)
       result = execute(

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -9,10 +9,6 @@ describe Nylas::Account do
     expect(described_class).not_to be_creatable
   end
 
-  it "is not updatable" do
-    expect(described_class).not_to be_updatable
-  end
-
   it "is not destroyable" do
     expect(described_class).not_to be_destroyable
   end
@@ -29,7 +25,10 @@ describe Nylas::Account do
       id: "30zipv27dtrsnkleg59mprw5p",
       sync_state: "running",
       trial: false,
-      provider: "gmail"
+      provider: "gmail",
+      metadata: {
+        key: "value"
+      }
     )
     account = described_class.from_json(json, api: nil)
     expect(account.account_id).to eql "30zipv27dtrsnkleg59mprw5p"
@@ -39,6 +38,28 @@ describe Nylas::Account do
     expect(account.sync_state).to eql "running"
     expect(account.trial).to be false
     expect(account.provider).to eq("gmail")
+    expect(account.metadata).to include(key: "value")
+  end
+
+  it "can update metadata" do
+    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    account = described_class.from_json('{ "id": "acc-1234" }', api: api)
+
+    account.metadata = {
+      key: "value"
+    }
+    account.save
+
+    expect(api).to have_received(:execute).with(
+      method: :put,
+      path: "/a/app-987/accounts/acc-1234",
+      payload: JSON.dump(
+        metadata: {
+          key: "value"
+        }
+      ),
+      query: {}
+    )
   end
 
   it "can be downgraded" do

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -30,7 +30,8 @@ describe Nylas::Message do
                          size: 1264 }],
                folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
                labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
-                        { display_name: "All Mail", id: "label-all", name: "all" }] }
+                        { display_name: "All Mail", id: "label-all", name: "all" }],
+               metadata: { key: "value" } }
 
       message = described_class.from_json(JSON.dump(data), api: api)
       expect(message.id).to eql "mess-8766"
@@ -119,6 +120,8 @@ describe Nylas::Message do
       expect(message.labels[1].id).to eql "label-all"
       expect(message.labels[1].name).to eql "all"
       expect(message.labels[1].api).to be api
+
+      expect(message.metadata).to include(key: "value")
     end
   end
 


### PR DESCRIPTION
# Description
The metadata feature first introduced for events has expended to `Calendar`, `Message` and `Account`. This PR adds support for this change. More information on the expansion of the metadata can be found here: https://developer.nylas.com/docs/developer-tools/api/metadata

# Usage

### Adding Metadata to Calendar
```ruby
api.calendars.create(
  name: "My New Calendar",
  description: "Description of my new calendar",
  location: "Location description",
  timezone: "America/Los_Angeles",
  metadata: {
    event_type: "gathering"
  }
)

# Or you can update a calendar with metadata

calendar = api.calendars.last

calendar.update(metadata: {
  test: "true",
}};
```

### Query Calendars by Metadata
```ruby
calendars = api.calendars.where(metadata_pair: {event_type: "gathering"})
```

### Adding Metadata to Message
```ruby
message = api.messages.last

message.update(metadata: {
  test: "true",
}};
```

### Query Messages by Metadata
```ruby
messages = api.messages.where({metadata_key: "test"});
```

### Adding Metadata to Account
```ruby
account = api.current_account

account.update(metadata: {
  test: "true",
}};
```

### Query Account by Metadata
```ruby
accounts = api.accounts.where({metadata_key: "test"});
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.