### PR TITLE
[73532] Support remaining Scheduler endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,9 +41,7 @@ Naming/FileName:
     - "lib/nylas-streaming.rb"
 
 Naming/AccessorMethodName:
-  Exclude:
-    - "lib/nylas/scheduler.rb"
-    - "lib/nylas/scheduler_collection.rb"
+  Enabled: false
 
 Style/NumericLiterals:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Naming/FileName:
 Naming/AccessorMethodName:
   Exclude:
     - "lib/nylas/scheduler.rb"
+    - "lib/nylas/scheduler_collection.rb"
 
 Style/NumericLiterals:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for event notifications
+* Add more Scheduler support
 * Modify `exchange_code_for_token` to allow returning a full body
 
 ### 5.5.0 / 2021-10-28

--- a/examples/plain-ruby/scheduler.rb
+++ b/examples/plain-ruby/scheduler.rb
@@ -29,5 +29,50 @@ demonstrate { example_scheduler.get_available_calendars }
 # Upload an image
 demonstrate { example_scheduler.upload_image(content_type: "image/png", object_name: "test.png") }
 
+# Get Google Availability
+begin
+  demonstrate { nylas.scheduler.get_google_availability }
+rescue Nylas::Error => e
+  puts "#{e.class}: #{e.message}"
+end
+
+# Get Office 365 Availability
+begin
+  demonstrate { nylas.scheduler.get_office_365_availability }
+rescue Nylas::Error => e
+  puts "#{e.class}: #{e.message}"
+end
+
+# Get a Scheduler page by Slug
+demonstrate { nylas.scheduler.get_page_slug(example_scheduler.slug) }
+
+# Get all available time slots
+available_timeslots = nylas.scheduler.get_available_time_slots(example_scheduler.slug)
+demonstrate { available_timeslots.inspect }
+
+# Book a timeslot
+booking_request = Nylas::SchedulerBookingRequest.new(
+  additional_values: {
+    important: "true"
+  },
+  email: "recipient@example.com",
+  locale: "en_US",
+  name: "John Doe",
+  timezone: "America/New_York",
+  slot: available_timeslots[0]
+)
+booking_confirmation = nylas.scheduler.book_time_slot(example_scheduler.slug, booking_request)
+demonstrate { booking_confirmation.inspect }
+
+# Cancel a booking
+demonstrate { nylas.scheduler.cancel_booking(example_scheduler.slug, booking_confirmation.edit_hash, "Was just a test.") }
+
+# Confirm a booking (Expect an error because we already cancelled this meeting)
+begin
+  demonstrate { nylas.scheduler.confirm_booking(example_scheduler.slug, booking_confirmation.edit_hash) }
+rescue Nylas::Error => e
+  puts "#{e.class}: #{e.message}"
+end
+
 # Delete a scheduler page
 demonstrate { example_scheduler.destroy }

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -97,6 +97,9 @@ require_relative "nylas/neural_signature_extraction"
 require_relative "nylas/neural_message_options"
 require_relative "nylas/categorize"
 require_relative "nylas/scheduler_config"
+require_relative "nylas/scheduler_time_slot"
+require_relative "nylas/scheduler_booking_request"
+require_relative "nylas/scheduler_booking_confirmation"
 
 require_relative "nylas/native_authentication"
 
@@ -143,4 +146,5 @@ module Nylas
   Types.registry[:neural_contact_link] = Types::ModelType.new(model: NeuralContactLink)
   Types.registry[:neural_contact_name] = Types::ModelType.new(model: NeuralContactName)
   Types.registry[:scheduler_config] = Types::ModelType.new(model: SchedulerConfig)
+  Types.registry[:scheduler_time_slot] = Types::ModelType.new(model: SchedulerTimeSlot)
 end

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -66,6 +66,7 @@ require_relative "nylas/deltas_collection"
 require_relative "nylas/free_busy_collection"
 require_relative "nylas/calendar_collection"
 require_relative "nylas/component_collection"
+require_relative "nylas/scheduler_collection"
 
 # Models supported by the API
 require_relative "nylas/account"

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -85,7 +85,7 @@ module Nylas
       @accounts ||= Collection.new(model: Account, api: as(client.app_secret))
     end
 
-    # @return [Collection<Calendar>] A queryable collection of {Calendar}s
+    # @return [CalendarCollection<Calendar>] A queryable collection of {Calendar}s
     def calendars
       @calendars ||= CalendarCollection.new(model: Calendar, api: self)
     end
@@ -100,7 +100,7 @@ module Nylas
       @drafts ||= Collection.new(model: Draft, api: self)
     end
 
-    # @return [Collection<Event>] A queryable collection of {Event}s
+    # @return [EventCollection<Event>] A queryable collection of {Event}s
     def events
       @events ||= EventCollection.new(model: Event, api: self)
     end
@@ -130,12 +130,12 @@ module Nylas
       @room_resources ||= Collection.new(model: RoomResource, api: self)
     end
 
-    # @return[Collection<Scheduler>] A queryable collection of {Scheduler} objects
+    # @return[SchedulerCollection<Scheduler>] A queryable collection of {Scheduler} objects
     def scheduler
       # Make a deep copy of the API as the scheduler API uses a different base URL
       scheduler_api = Marshal.load(Marshal.dump(self))
       scheduler_api.client.api_server = "https://api.schedule.nylas.com"
-      @scheduler ||= Collection.new(model: Scheduler, api: scheduler_api)
+      @scheduler ||= SchedulerCollection.new(model: Scheduler, api: scheduler_api)
     end
 
     # @return[Neural] A {Neural} object that provides

--- a/lib/nylas/scheduler_booking_confirmation.rb
+++ b/lib/nylas/scheduler_booking_confirmation.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the booking response returned from the Scheduler API
+  class SchedulerBookingConfirmation
+    include Model::Attributable
+    attribute :id, :integer
+    attribute :account_id, :string
+    attribute :calendar_event_id, :string
+    attribute :calendar_id, :string
+    attribute :edit_hash, :string
+    attribute :location, :string
+    attribute :title, :string
+    attribute :recipient_email, :string
+    attribute :recipient_locale, :string
+    attribute :recipient_name, :string
+    attribute :recipient_tz, :string
+    attribute :additional_field_values, :hash
+    attribute :is_confirmed, :boolean
+    attribute :start_time, :unix_timestamp
+    attribute :end_time, :unix_timestamp
+    has_n_of_attribute :additional_emails, :string
+  end
+end

--- a/lib/nylas/scheduler_booking_request.rb
+++ b/lib/nylas/scheduler_booking_request.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the booking request used for the Scheduler API
+  class SchedulerBookingRequest
+    include Model::Attributable
+    attribute :additional_values, :hash
+    attribute :email, :string
+    attribute :locale, :string
+    attribute :name, :string
+    attribute :page_hostname, :string
+    attribute :replaces_booking_hash, :string
+    attribute :timezone, :string
+    attribute :slot, :scheduler_time_slot
+    has_n_of_attribute :additional_emails, :string
+  end
+end

--- a/lib/nylas/scheduler_collection.rb
+++ b/lib/nylas/scheduler_collection.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Additional methods for some of Scheduler's other functionality
+  # @see https://developer.nylas.com/docs/api/scheduler#overview
+  class SchedulerCollection < Collection
+    # Retrieve Google availability
+    # @return [Hash] Returns the availability
+    def get_google_availability
+      execute_provider_availability("google")
+    end
+
+    # Retrieve Office 365 availability
+    # @return [Hash] Returns the availability
+    def get_office_365_availability
+      execute_provider_availability("o365")
+    end
+
+    # Retrieve public config for a scheduling page
+    # @param slug [String] The Scheduler page slug
+    # @return [Scheduler] Returns the Scheduler object representing the page configuration
+    def get_page_slug(slug)
+      page_response = api.execute(
+        method: :get,
+        path: "/schedule/#{slug}/info"
+      )
+
+      Scheduler.new(**page_response.merge(api: api))
+    end
+
+    # Retrieve available time slots
+    # @param slug [String] The Scheduler page slug
+    # @return [Array<SchedulerTimeSlot>] Returns the list of available timeslots
+    def get_available_time_slots(slug)
+      response = api.execute(
+        method: :get,
+        path: "/schedule/#{slug}/timeslots"
+      )
+
+      timeslots = []
+      response.each do |available_slot|
+        timeslots.push(SchedulerTimeSlot.new(**available_slot.merge(api: api)))
+      end
+      timeslots
+    end
+
+    # Book a time slot
+    # @param slug [String] The Scheduler page slug
+    # @param timeslot [SchedulerBookingRequest] The time slot booking request
+    # @return [SchedulerBookingConfirmation] Returns the booking confirmation
+    def book_time_slot(slug, timeslot)
+      booking_response = api.execute(
+        method: :post,
+        path: "/schedule/#{slug}/timeslots",
+        payload: JSON.dump(timeslot)
+      )
+
+      SchedulerBookingConfirmation.new(**booking_response.merge(api: api))
+    end
+
+    # Cancel a booking
+    # @param slug [String] The Scheduler page slug
+    # @param edit_hash [String] The token used for editing the booked time slot
+    # @param reason [String] The reason for cancelling the booking
+    # @return [Hash] Returns a hash of a boolean representing success of cancellation
+    def cancel_booking(slug, edit_hash, reason)
+      api.execute(
+        method: :post,
+        path: "/schedule/#{slug}/#{edit_hash}/cancel",
+        payload: JSON.dump(reason: reason)
+      )
+    end
+
+    # Confirm a booking
+    # @param slug [String] The Scheduler page slug
+    # @param edit_hash [String] The token used for editing the booked time slot
+    # @return [SchedulerBookingConfirmation] Returns the confirmed booking confirmation
+    def confirm_booking(slug, edit_hash)
+      booking_response = api.execute(
+        method: :post,
+        path: "/schedule/#{slug}/#{edit_hash}/confirm",
+        payload: {}
+      )
+
+      SchedulerBookingConfirmation.new(**booking_response.merge(api: api))
+    end
+
+    private
+
+    # Retrieve provider availability
+    # @return [Hash] Returns the availability
+    def execute_provider_availability(provider)
+      api.execute(
+        method: :get,
+        path: "/schedule/availability/#{provider}"
+      )
+    end
+  end
+end

--- a/lib/nylas/scheduler_collection.rb
+++ b/lib/nylas/scheduler_collection.rb
@@ -49,10 +49,15 @@ module Nylas
     # @param timeslot [SchedulerBookingRequest] The time slot booking request
     # @return [SchedulerBookingConfirmation] Returns the booking confirmation
     def book_time_slot(slug, timeslot)
+      payload = timeslot.to_h
+      # The booking endpoint requires additional_values and additional_emails
+      # to exist regardless if they are empty or not
+      payload[:additional_values] = {} unless payload[:additional_values]
+      payload[:additional_emails] = [] unless payload[:additional_emails]
       booking_response = api.execute(
         method: :post,
         path: "/schedule/#{slug}/timeslots",
-        payload: JSON.dump(timeslot.to_h)
+        payload: JSON.dump(payload)
       )
 
       SchedulerBookingConfirmation.new(**booking_response.merge(api: api))

--- a/lib/nylas/scheduler_collection.rb
+++ b/lib/nylas/scheduler_collection.rb
@@ -52,7 +52,7 @@ module Nylas
       booking_response = api.execute(
         method: :post,
         path: "/schedule/#{slug}/timeslots",
-        payload: JSON.dump(timeslot)
+        payload: JSON.dump(timeslot.to_h)
       )
 
       SchedulerBookingConfirmation.new(**booking_response.merge(api: api))

--- a/lib/nylas/scheduler_time_slot.rb
+++ b/lib/nylas/scheduler_time_slot.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent the time slot object from the Scheduler API
+  class SchedulerTimeSlot
+    include Model::Attributable
+    attribute :account_id, :string
+    attribute :calendar_id, :string
+    attribute :host_name, :string
+    attribute :start, :unix_timestamp
+    attribute :end, :unix_timestamp
+    has_n_of_attribute :emails, :string
+  end
+end

--- a/spec/nylas/scheduler_collection_spec.rb
+++ b/spec/nylas/scheduler_collection_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Nylas::SchedulerCollection do
+  describe "ProviderAvailability" do
+    it "(getGoogleAvailability) should call the correct endpoint" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+      scheduler_collection.get_google_availability
+
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/schedule/availability/google"
+      )
+    end
+
+    it "(getOffice365Availability) should call the correct endpoint" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+      scheduler_collection.get_office_365_availability
+
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/schedule/availability/o365"
+      )
+    end
+  end
+
+  describe "Public Booking API" do
+    it "(getPageBySlug) should return a Scheduler type" do
+      scheduler_json = {
+        app_client_id: "test-client-id",
+        app_organization_id: 0,
+        config: {
+          timezone: "America/Los_Angeles",
+        },
+        edit_token: "token",
+        name: "Test",
+        slug: "test-slug",
+        created_at: "2021-06-24",
+        modified_at: "2021-06-24"
+      }
+      api = instance_double(Nylas::API, execute: scheduler_json)
+      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+      scheduler = scheduler_collection.get_page_slug("test-slug")
+
+      expect(scheduler.app_client_id).to eql("test-client-id")
+      expect(scheduler.app_organization_id).to be(0)
+      expect(scheduler.config.timezone).to eql("America/Los_Angeles")
+      expect(scheduler.edit_token).to eql("token")
+      expect(scheduler.name).to eql("Test")
+      expect(scheduler.slug).to eql("test-slug")
+      expect(scheduler.created_at).to eql(Date.parse("2021-06-24"))
+      expect(scheduler.modified_at).to eql(Date.parse("2021-06-24"))
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/schedule/test-slug/info"
+      )
+    end
+
+    it "(getAvailableTimeSlots) should return an array of SchedulerTimeSlot" do
+      scheduler_time_slots = [
+        {
+          account_id: "test-account-id",
+          calendar_id: "test-calendar-id",
+          emails: ["test@example.com"],
+          end: 1636731958,
+          host_name: "www.hostname.com",
+          start: 1636728347
+        }
+      ]
+      api = instance_double(Nylas::API, execute: scheduler_time_slots)
+      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+      timeslots = scheduler_collection.get_available_time_slots("test-slug")
+
+      expect(timeslots.length).to be(1)
+      expect(timeslots[0].account_id).to eql("test-account-id")
+      expect(timeslots[0].calendar_id).to eql("test-calendar-id")
+      expect(timeslots[0].emails[0]).to eql("test@example.com")
+      expect(timeslots[0].host_name).to eql("www.hostname.com")
+      expect(timeslots[0].end).to eql(Time.at(1636731958))
+      expect(timeslots[0].start).to eql(Time.at(1636728347))
+      expect(api).to have_received(:execute).with(
+        method: :get,
+        path: "/schedule/test-slug/timeslots"
+      )
+    end
+
+    it "cancel booking" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+      scheduler_collection.cancel_booking("test-slug", "test-edit-hash", "test")
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/schedule/test-slug/test-edit-hash/cancel",
+        payload: JSON.dump(reason: "test")
+      )
+    end
+
+    describe "SchedulerBookingConfirmation" do
+      it "(bookTimeSlot) should return a SchedulerBookingConfirmation type" do
+        booking_confirmation = {
+          account_id: "test-account-id",
+          additional_field_values: {
+            test: "yes"
+          },
+          calendar_event_id: "test-event-id",
+          calendar_id: "test-calendar-id",
+          edit_hash: "test-edit-hash",
+          end_time: 1636731958,
+          id: 123,
+          is_confirmed: false,
+          location: "Earth",
+          recipient_email: "recipient@example.com",
+          recipient_locale: "en_US",
+          recipient_name: "Recipient Doe",
+          recipient_tz: "America/New_York",
+          start_time: 1636728347,
+          title: "Test Booking"
+        }
+        api = instance_double(Nylas::API, execute: booking_confirmation)
+        scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+        slot = Nylas::SchedulerTimeSlot.new(
+          account_id: "test-account-id",
+          calendar_id: "test-calendar-id",
+          emails: ["recipient@example.com"],
+          start: Time.at(1636728347),
+          end: Time.at(1636731958)
+        )
+        timeslot_to_book = Nylas::SchedulerBookingRequest.new(
+          additional_values: {
+            test: "yes"
+          },
+          email: "recipient@example.com",
+          locale: "en_US",
+          name: "Recipient Doe",
+          timezone: "America/New_York",
+          slot: slot
+        )
+        booking_confirmation = scheduler_collection.book_time_slot("test-slug", timeslot_to_book)
+
+        expect(booking_confirmation.account_id).to eql("test-account-id")
+        expect(booking_confirmation.calendar_id).to eql("test-calendar-id")
+        expect(booking_confirmation.additional_field_values).to eql(test: "yes")
+        expect(booking_confirmation.calendar_event_id).to eql("test-event-id")
+        expect(booking_confirmation.calendar_id).to eql("test-calendar-id")
+        expect(booking_confirmation.calendar_event_id).to eql("test-event-id")
+        expect(booking_confirmation.edit_hash).to eql("test-edit-hash")
+        expect(booking_confirmation.id).to be(123)
+        expect(booking_confirmation.is_confirmed).to be(false)
+        expect(booking_confirmation.location).to eql("Earth")
+        expect(booking_confirmation.title).to eql("Test Booking")
+        expect(booking_confirmation.recipient_email).to eql("recipient@example.com")
+        expect(booking_confirmation.recipient_locale).to eql("en_US")
+        expect(booking_confirmation.recipient_name).to eql("Recipient Doe")
+        expect(booking_confirmation.recipient_tz).to eql("America/New_York")
+        expect(booking_confirmation.end_time).to eql(Time.at(1636731958))
+        expect(booking_confirmation.start_time).to eql(Time.at(1636728347))
+        expect(api).to have_received(:execute).with(
+          method: :post,
+          path: "/schedule/test-slug/timeslots",
+          payload: JSON.dump(
+            additional_values: {
+              test: "yes"
+            },
+            email: "recipient@example.com",
+            locale: "en_US",
+            name: "Recipient Doe",
+            timezone: "America/New_York",
+            slot: {
+              account_id: "test-account-id",
+              calendar_id: "test-calendar-id",
+              start: 1636728347,
+              end: 1636731958,
+              emails: ["recipient@example.com"]
+            }
+          )
+        )
+      end
+
+      it "(confirmBooking) should return a SchedulerBookingConfirmation type" do
+        booking_confirmation = {
+          account_id: "test-account-id",
+          additional_field_values: {
+            test: "yes"
+          },
+          calendar_event_id: "test-event-id",
+          calendar_id: "test-calendar-id",
+          edit_hash: "test-edit-hash",
+          end_time: 1636731958,
+          id: 123,
+          is_confirmed: true,
+          location: "Earth",
+          recipient_email: "recipient@example.com",
+          recipient_locale: "en_US",
+          recipient_name: "Recipient Doe",
+          recipient_tz: "America/New_York",
+          start_time: 1636728347,
+          title: "Test Booking"
+        }
+        api = instance_double(Nylas::API, execute: booking_confirmation)
+        scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+
+        booking_confirmation = scheduler_collection.confirm_booking("test-slug", "test-edit-hash")
+
+        expect(booking_confirmation.account_id).to eql("test-account-id")
+        expect(booking_confirmation.calendar_id).to eql("test-calendar-id")
+        expect(booking_confirmation.additional_field_values).to eql(test: "yes")
+        expect(booking_confirmation.calendar_event_id).to eql("test-event-id")
+        expect(booking_confirmation.calendar_id).to eql("test-calendar-id")
+        expect(booking_confirmation.calendar_event_id).to eql("test-event-id")
+        expect(booking_confirmation.edit_hash).to eql("test-edit-hash")
+        expect(booking_confirmation.id).to be(123)
+        expect(booking_confirmation.is_confirmed).to be(true)
+        expect(booking_confirmation.location).to eql("Earth")
+        expect(booking_confirmation.title).to eql("Test Booking")
+        expect(booking_confirmation.recipient_email).to eql("recipient@example.com")
+        expect(booking_confirmation.recipient_locale).to eql("en_US")
+        expect(booking_confirmation.recipient_name).to eql("Recipient Doe")
+        expect(booking_confirmation.recipient_tz).to eql("America/New_York")
+        expect(booking_confirmation.end_time).to eql(Time.at(1636731958))
+        expect(booking_confirmation.start_time).to eql(Time.at(1636728347))
+        expect(api).to have_received(:execute).with(
+          method: :post,
+          path: "/schedule/test-slug/test-edit-hash/confirm",
+          payload: {}
+        )
+      end
+    end
+  end
+end

--- a/spec/nylas/scheduler_collection_spec.rb
+++ b/spec/nylas/scheduler_collection_spec.rb
@@ -35,7 +35,7 @@ describe Nylas::SchedulerCollection do
         app_client_id: "test-client-id",
         app_organization_id: 0,
         config: {
-          timezone: "America/Los_Angeles",
+          timezone: "America/Los_Angeles"
         },
         edit_token: "token",
         name: "Test",
@@ -181,7 +181,8 @@ describe Nylas::SchedulerCollection do
               start: 1636728347,
               end: 1636731958,
               emails: ["recipient@example.com"]
-            }
+            },
+            additional_emails: []
           )
         )
       end


### PR DESCRIPTION
# Description
This PR adds the remaining Scheduler endpoints

# Usage
### Checking Provider Availability
```ruby
# Google Availability
google_availability = nylas.scheduler.get_google_availability

# Office 365 Availability
o365_availability = nylas.scheduler.get_office_365_availability
```

### Retrieve available time slots
```ruby
availabile_timeslots = nylas.scheduler.get_available_time_slots('slug')
```

### Book a time slot
```ruby
slot = Nylas::SchedulerTimeSlot.new(
  account_id: "test-account-id",
  calendar_id: "test-calendar-id",
  emails: ["recipient@example.com"],
  start: Time.at(1636728347),
  end: Time.at(1636731958)
)
timeslot_to_book = Nylas::SchedulerBookingRequest.new(
  additional_values: {
    test: "yes"
  },
  email: "recipient@example.com",
  locale: "en_US",
  name: "Recipient Doe",
  timezone: "America/New_York",
  slot: slot
)
booking_confirmation = nylas.scheduler.book_time_slot("slug", timeslot_to_book)
```

### Confirm a booking
```ruby
booking_confirmation = nylas.scheduler.confirm_booking('slug', 'edit-hash');
```

### Cancel a booking
```ruby
nylas.scheduler.cancel_booking('slug', 'edit-hash', 'reason');
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.