### PR TITLE
[75450] Fix bug where updating an Event results in an API error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix bug where updating an Event results in an API error
+
 ### 5.6.0 / 2021-11-22
 * Add support for event notifications
 * Add more Scheduler support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.6.0 / 2021-11-22
 * Add support for event notifications
 * Add more Scheduler support
 * Add metadata support for `Calendar`, `Message` and `Account`

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -17,8 +17,8 @@ module Nylas
       end
 
       # @return [Hash] Representation of the model with values serialized into primitives based on their Type
-      def to_h
-        attributes.to_h
+      def to_h(enforce_read_only: false)
+        attributes.to_h(enforce_read_only: enforce_read_only)
       end
 
       protected

--- a/lib/nylas/model/attribute_definition.rb
+++ b/lib/nylas/model/attribute_definition.rb
@@ -5,7 +5,7 @@ module Nylas
     # Define a particular attribute for a given model
     class AttributeDefinition
       extend Forwardable
-      def_delegators :type, :cast, :serialize
+      def_delegators :type, :cast, :serialize, :serialize_for_api
       attr_accessor :type_name, :read_only, :default
 
       def initialize(type_name:, read_only:, default:)

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -43,14 +43,19 @@ module Nylas
         casted_data
       end
 
-      def serialize(keys: attribute_definitions.keys)
-        JSON.dump(to_h(keys: keys))
+      # Serialize the object
+      # @param keys [Array<String>] The keys included
+      # @param enforce_read_only [Boolean] Whether to enforce read_only property (serializing for API)
+      # @return [String] The serialized object as a JSON string
+      def serialize(keys: attribute_definitions.keys, enforce_read_only: false)
+        JSON.dump(to_h(keys: keys, enforce_read_only: enforce_read_only))
       end
 
+      # Serialize the object to an API-compatible JSON string
+      # @param keys [Array<String>] The keys included
+      # @return [String] The serialized object as a JSON string
       def serialize_for_api(keys: attribute_definitions.keys)
-        api_keys = keys.delete_if { |key| attribute_definitions[key].read_only == true }
-
-        serialize(keys: api_keys)
+        serialize(keys: keys, enforce_read_only: true)
       end
 
       def serialize_all_for_api(keys: attribute_definitions.keys)

--- a/lib/nylas/model/list_attribute_definition.rb
+++ b/lib/nylas/model/list_attribute_definition.rb
@@ -18,9 +18,17 @@ module Nylas
         list.map { |item| type.cast(item) }
       end
 
-      def serialize(list)
+      def serialize(list, enforce_read_only: false)
         list = default if list.nil? || list.empty?
-        list.map { |item| type.serialize(item) }
+        if enforce_read_only
+          list.map { |item| type.serialize_for_api(item) }
+        else
+          list.map { |item| type.serialize(item) }
+        end
+      end
+
+      def serialize_for_api(list)
+        serialize(list, enforce_read_only: true)
       end
 
       def type

--- a/lib/nylas/participant.rb
+++ b/lib/nylas/participant.rb
@@ -7,6 +7,6 @@ module Nylas
     attribute :name, :string
     attribute :email, :string
     attribute :comment, :string
-    attribute :status, :string
+    attribute :status, :string, read_only: true
   end
 end

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -45,6 +45,7 @@ module Nylas
       attr_accessor :model
 
       def initialize(model:)
+        super()
         self.model = model
       end
 
@@ -53,7 +54,7 @@ module Nylas
       end
 
       def serialize_for_api(object)
-        object.to_h(enforce_read_only: true) unless object.nil?
+        object&.to_h(enforce_read_only: true)
       end
 
       def cast(value)

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -20,6 +20,9 @@ module Nylas
       def deseralize(object)
         object
       end
+
+      def serialize_for_api(object)
+        serialize(object)
       end
     end
 
@@ -47,6 +50,10 @@ module Nylas
 
       def serialize(object)
         object.to_h
+      end
+
+      def serialize_for_api(object)
+        object.to_h(enforce_read_only: true) unless object.nil?
       end
 
       def cast(value)

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -7,8 +7,24 @@ module Nylas
       @registry ||= Registry.new
     end
 
+    # Base type for attributes
+    class ValueType
+      def cast(object)
+        object
+      end
+
+      def serialize(object)
+        object
+      end
+
+      def deseralize(object)
+        object
+      end
+      end
+    end
+
     # Casts/Serializes data that is persisted and used natively as a Hash
-    class HashType
+    class HashType < ValueType
       def serialize(object)
         object.to_h
       end
@@ -22,7 +38,7 @@ module Nylas
 
     # Type for attributes that are persisted in the API as a hash but exposed in ruby as a particular
     # {Model} or Model-like thing.
-    class ModelType
+    class ModelType < ValueType
       attr_accessor :model
 
       def initialize(model:)
@@ -56,23 +72,8 @@ module Nylas
       end
     end
 
-    # Type for attributes that do not require casting/serializing/deserializing.
-    class ValueType
-      def cast(object)
-        object
-      end
-
-      def serialize(object)
-        object
-      end
-
-      def deseralize(object)
-        object
-      end
-    end
-
     # Type for attributes represented as a unix timestamp in the API and Time in Ruby
-    class UnixTimestampType
+    class UnixTimestampType < ValueType
       def cast(object)
         return object if object.is_a?(Time) || object.nil?
         return Time.at(object.to_i) if object.is_a?(String)

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.5.0"
+  VERSION = "5.6.0"
 end


### PR DESCRIPTION
# Description
A recent API update caused updating an event using the SDK to return an error because the SDK sends a Participant's status as well as an object key within the Event.when object. This PR also modifies how we serialize child objects for API calls, and ensure if we don't want to include read_only values that we enforce it throughout the child objects.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.