### PR TITLE
[75895] Enable metadata support for new Messages and Drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Unreleased
-* Enabled support for adding metadata to a new `Message`/`Draft`
+* Enabled support for adding metadata to a `NewMessage`/`Draft`
 
 ### 5.6.0 / 2021-11-22
 * Add support for event notifications

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Enabled support for adding metadata to a new `Message`/`Draft`
+
 ### 5.6.0 / 2021-11-22
 * Add support for event notifications
 * Add more Scheduler support

--- a/examples/plain-ruby/drafts.rb
+++ b/examples/plain-ruby/drafts.rb
@@ -24,7 +24,8 @@ demonstrate { api.drafts.find(example_draft.id) }
 # Sending a draft
 demonstrate do
   draft = api.drafts.create(to: [{ email: ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-a-real-email@example.com')}],
-                            subject: "A new draft!")
+                            subject: "A new draft!",
+                            metadata: {test: "yes"})
   draft.send!
 end
 

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -27,6 +27,7 @@ module Nylas
     attribute :body, :string
     attribute :starred, :boolean
     attribute :unread, :boolean
+    attribute :metadata, :hash
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file, read_only: true

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -20,6 +20,7 @@ module Nylas
     attribute :subject, :string
     attribute :body, :string
     attribute :reply_to_message_id, :string
+    attribute :metadata, :hash
 
     has_n_of_attribute :file_ids, :string
 

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -315,6 +315,7 @@ describe Nylas::Draft do
                folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
                labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
                         { display_name: "All Mail", id: "label-all", name: "all" }],
+               metadata: { test: "yes" },
                tracking: { opens: true, links: true, thread_replies: true, payload: "this is a payload" } }
 
       draft = described_class.from_json(JSON.dump(data), api: api)
@@ -373,6 +374,8 @@ describe Nylas::Draft do
       expect(draft.labels[1].id).to eql "label-all"
       expect(draft.labels[1].name).to eql "all"
       expect(draft.labels[1].api).to be api
+
+      expect(draft.metadata).to eq(test: "yes")
 
       expect(draft.tracking.opens).to be true
       expect(draft.tracking.links).to be true


### PR DESCRIPTION
# Description
This PR builds on #337, the API also supports adding metadata to a message either via adding to a Draft or sending directly through `/send`. Now both the `NewMessage` and `Draft` objects support metadata.

# Usage
Add metadata to Draft:
```ruby
draft = api.drafts.create(to: [{ email: "not-a-real-email@example.com"}],
                          subject: "A new draft!",
                          metadata: {test: "yes"})
draft.send!
```

You can also add metadata directly to a new message being sent:
```ruby
message = api.send!(to: [{ email: "not-a-real-email@example.com"}],
                          subject: "A new message!",
                          metadata: {test: "yes"})
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.