### PR TITLE
[75827] Add job status support

### DIFF
--- a/examples/plain-ruby/job_status.rb
+++ b/examples/plain-ruby/job_status.rb
@@ -1,0 +1,18 @@
+require_relative '../helpers'
+
+# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# Drafts API. See https://docs.nylas.com/reference#drafts for API documentation
+api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+                     access_token: ENV['NYLAS_ACCESS_TOKEN'])
+
+# Getting all job statuses
+demonstrate { api.job_statuses }
+
+# Get a specific job status
+demonstrate do
+  job_status = api.job_statuses.first
+  api.job_statuses.find(job_status.job_status_id).to_h
+end
+
+# Get a boolean value representing status
+demonstrate { api.job_statuses.first.successful? }

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -84,6 +84,7 @@ require_relative "nylas/raw_message"
 require_relative "nylas/thread"
 require_relative "nylas/webhook"
 require_relative "nylas/scheduler"
+require_relative "nylas/job_status"
 
 # Neural specific types
 require_relative "nylas/neural"
@@ -148,4 +149,5 @@ module Nylas
   Types.registry[:neural_contact_name] = Types::ModelType.new(model: NeuralContactName)
   Types.registry[:scheduler_config] = Types::ModelType.new(model: SchedulerConfig)
   Types.registry[:scheduler_time_slot] = Types::ModelType.new(model: SchedulerTimeSlot)
+  Types.registry[:job_status] = Types::ModelType.new(model: JobStatus)
 end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -130,6 +130,11 @@ module Nylas
       @room_resources ||= Collection.new(model: RoomResource, api: self)
     end
 
+    # @return[Collection<JobStatus>] A queryable collection of {JobStatus} objects
+    def job_statuses
+      @job_statuses ||= Collection.new(model: JobStatus, api: self)
+    end
+
     # @return[SchedulerCollection<Scheduler>] A queryable collection of {Scheduler} objects
     def scheduler
       # Make a deep copy of the API as the scheduler API uses a different base URL

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -22,6 +22,7 @@ module Nylas
 
     attribute :read_only, :boolean
     attribute :metadata, :hash
+    attribute :job_status_id, :string, read_only: true
 
     def read_only?
       read_only == true

--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -30,6 +30,7 @@ module Nylas
     attribute :office_location, :string
     attribute :notes, :string
     attribute :source, :string
+    attribute :job_status_id, :string, read_only: true
 
     has_n_of_attribute :groups, :contact_group
     has_n_of_attribute :emails, :email_address

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -35,6 +35,7 @@ module Nylas
     has_n_of_attribute :labels, :label
 
     attribute :tracking, :message_tracking
+    attribute :job_status_id, :string, read_only: true
 
     transfer :api, to: %i[events files folder labels]
 

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -31,6 +31,7 @@ module Nylas
     attribute :conferencing, :event_conferencing
     has_n_of_attribute :notifications, :event_notification
     attribute :original_start_time, :unix_timestamp
+    attribute :job_status_id, :string, read_only: true
 
     attr_accessor :notify_participants
 

--- a/lib/nylas/folder.rb
+++ b/lib/nylas/folder.rb
@@ -20,5 +20,6 @@ module Nylas
 
     attribute :name, :string
     attribute :display_name, :string
+    attribute :job_status_id, :string, read_only: true
   end
 end

--- a/lib/nylas/job_status.rb
+++ b/lib/nylas/job_status.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Ruby representation of a Nylas Job Status object
+  # @see https://developer.nylas.com/docs/api/#tag--Job-Status
+  class JobStatus
+    include Model
+    self.resources_path = "/job-statuses"
+    allows_operations(listable: true)
+
+    attribute :id, :string, read_only: true
+    attribute :account_id, :string, read_only: true
+    attribute :job_status_id, :string, read_only: true
+    attribute :action, :string, read_only: true
+    attribute :object, :string, read_only: true
+    attribute :status, :string, read_only: true
+    attribute :created_at, :unix_timestamp, read_only: true
+    attribute :original_data, :message, read_only: true
+
+    # Returns the status of a job as a boolean
+    # @return [Boolean] If the job was successful
+    def successful?
+      status == "successful"
+    end
+  end
+end

--- a/lib/nylas/label.rb
+++ b/lib/nylas/label.rb
@@ -20,5 +20,6 @@ module Nylas
 
     attribute :name, :string
     attribute :display_name, :string
+    attribute :job_status_id, :string, read_only: true
   end
 end

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -37,6 +37,7 @@ module Nylas
     attribute :folder, :folder
     attribute :folder_id, :string
     attribute :metadata, :hash
+    attribute :job_status_id, :string, read_only: true
 
     has_n_of_attribute :labels, :label, read_only: true
     has_n_of_attribute :label_ids, :string

--- a/spec/nylas/job_status_spec.rb
+++ b/spec/nylas/job_status_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+describe Nylas::JobStatus do
+  it "is not creatable" do
+    expect(described_class).not_to be_creatable
+  end
+
+  it "is not filterable" do
+    expect(described_class).not_to be_filterable
+  end
+
+  it "is not be_updatable" do
+    expect(described_class).not_to be_updatable
+  end
+
+  it "is not destroyable" do
+    expect(described_class).not_to be_destroyable
+  end
+
+  it "is not showable" do
+    expect(described_class).not_to be_showable
+  end
+
+  it "is listable" do
+    expect(described_class).to be_listable
+  end
+
+  describe "#from_json" do
+    it "deserializes all the attributes successfully" do
+      json = JSON.dump(
+        account_id: "test_account_id",
+        action: "save_draft",
+        created_at: 1622846160,
+        id: "test_id",
+        job_status_id: "test_job_status_id",
+        object: "message",
+        status: "successful"
+      )
+      job_status = described_class.from_json(json, api: nil)
+      expect(job_status.id).to eql "test_id"
+      expect(job_status.account_id).to eql "test_account_id"
+      expect(job_status.job_status_id).to eql "test_job_status_id"
+      expect(job_status.action).to eql "save_draft"
+      expect(job_status.created_at).to eql(Time.at(1622846160))
+      expect(job_status.object).to eql "message"
+      expect(job_status.status).to eql "successful"
+    end
+  end
+
+  describe "#successful?" do
+    it "returns true when status == successful" do
+      json = JSON.dump(
+        account_id: "test_account_id",
+        action: "save_draft",
+        created_at: 1622846160,
+        id: "test_id",
+        job_status_id: "test_job_status_id",
+        object: "message",
+        status: "successful"
+      )
+      job_status = described_class.from_json(json, api: nil)
+      expect(job_status.successful?).is_a? TrueClass
+    end
+
+    it "returns false when status != successful" do
+      json = JSON.dump(
+        account_id: "test_account_id",
+        action: "save_draft",
+        created_at: 1622846160,
+        id: "test_id",
+        job_status_id: "test_job_status_id",
+        object: "message",
+        status: "failed"
+      )
+      job_status = described_class.from_json(json, api: nil)
+      expect(job_status.successful?).is_a? FalseClass
+    end
+  end
+end


### PR DESCRIPTION
# Description
This PR adds support for job statuses within supported models, as well as the `/job-statuses` endpoint.

# Usage
To view all Job statuses
```ruby
nylas.job_statuses
```

To view a specific Job status
```ruby
nylas.job_statuses.find("JOB_STATUS_ID")
```

To get a boolean value representing Job status success/failure
```ruby
job_status = nylas.job_statuses.find("JOB_STATUS_ID")
job_status.successful?
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.