### PR TITLE
v5.6.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.6.1 / 2021-12-13
 * Enabled support for adding metadata to a `NewMessage`/`Draft`
 * Fix bug where updating an Event results in an API error
 

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.6.0"
+  VERSION = "5.6.1"
 end


### PR DESCRIPTION
# Description
New `nylas` v5.6.1 release brings in the following fix/enhancement:
* Enabled support for adding metadata to a `NewMessage`/`Draft` (#341)
* Fix bug where updating an Event results in an API error (#340)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.