### PR TITLE
[75855] Enable Account deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Add job status support
+* Enable account deletion
+
 ### 5.6.1 / 2021-12-13
 * Enabled support for adding metadata to a `NewMessage`/`Draft`
 * Fix bug where updating an Event results in an API error

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -38,8 +38,8 @@ module GemConfig
     [["bundler", ">= 1.3.0"],
      ["yard", "~> 0.9.0"],
      ["awesome_print", "~> 1.0"],
-     ["rubocop", "~> 0.52.0"],
-     ["rubocop-rspec", "~> 1.20.1"],
+     ["rubocop", "~> 1.24.1"],
+     ["rubocop-rspec", "~> 2.7.0"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -8,6 +8,7 @@ module Nylas
     self.listable = true
     self.showable = true
     self.updatable = true
+    self.destroyable = true
 
     attribute :id, :string, read_only: true
     attribute :account_id, :string, read_only: true

--- a/lib/nylas/application_details.rb
+++ b/lib/nylas/application_details.rb
@@ -11,4 +11,3 @@ module Nylas
     has_n_of_attribute :redirect_uris, :string
   end
 end
-

--- a/lib/nylas/token_info.rb
+++ b/lib/nylas/token_info.rb
@@ -18,5 +18,3 @@ module Nylas
     end
   end
 end
-
-

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -100,4 +100,18 @@ describe Nylas::Account do
       query: {}
     )
   end
+
+  it "can be destroyed" do
+    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    account = described_class.from_json('{ "id": "acc-1234" }', api: api)
+
+    expect(account.destroy).to be_truthy
+
+    expect(api).to have_received(:execute).with(
+      method: :delete,
+      path: "/a/app-987/accounts/acc-1234",
+      payload: nil,
+      query: {}
+    )
+  end
 end

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -9,10 +9,6 @@ describe Nylas::Account do
     expect(described_class).not_to be_creatable
   end
 
-  it "is not destroyable" do
-    expect(described_class).not_to be_destroyable
-  end
-
   it "is listable" do
     expect(described_class).to be_listable
   end

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -113,6 +113,7 @@ describe Nylas::Account do
       payload: nil,
       query: {}
     )
+  end
 
   it "can return token information" do
     api = instance_double("Nylas::API", app_id: "app-987")


### PR DESCRIPTION
# Description
Enable the ability to delete an account via the `/a/{client_id}/accounts/{id}` [endpoint](https://developer.nylas.com/docs/api/#delete/a/client_id/accounts/id).

# Usage
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET,
    access_token: ACCESS_TOKEN
)

account = nylas.accounts.find('{id}')

# Delete the account
account.destroy
```

# License 
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.