### PR TITLE
[76795] Improved Application Detail support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Added support for getting access token information
+* Improved support for Application Details
+
 ### 5.6.1 / 2021-12-13
 * Enabled support for adding metadata to a `NewMessage`/`Draft`
 * Fix bug where updating an Event results in an API error

--- a/examples/plain-ruby/accounts.rb
+++ b/examples/plain-ruby/accounts.rb
@@ -20,3 +20,6 @@ demonstrate { account.to_h }
 demonstrate { account.upgrade }
 demonstrate { account.to_h }
 
+# Get token info for access token
+demonstrate { api.accounts.first.token_info(ENV['NYLAS_ACCESS_TOKEN']).to_h }
+

--- a/examples/plain-ruby/accounts.rb
+++ b/examples/plain-ruby/accounts.rb
@@ -23,3 +23,5 @@ demonstrate { account.to_h }
 # Get token info for access token
 demonstrate { api.accounts.first.token_info(ENV['NYLAS_ACCESS_TOKEN']).to_h }
 
+# Getting application details
+demonstrate { api.application_details }

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -85,6 +85,7 @@ require_relative "nylas/thread"
 require_relative "nylas/webhook"
 require_relative "nylas/scheduler"
 require_relative "nylas/job_status"
+require_relative "nylas/token_info"
 
 # Neural specific types
 require_relative "nylas/neural"

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -86,6 +86,7 @@ require_relative "nylas/webhook"
 require_relative "nylas/scheduler"
 require_relative "nylas/job_status"
 require_relative "nylas/token_info"
+require_relative "nylas/application_details"
 
 # Neural specific types
 require_relative "nylas/neural"

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -36,6 +36,15 @@ module Nylas
       response[:success]
     end
 
+    # Return information about an account's access token
+    # @param access_token [String] The access token to inquire about
+    # @return [TokenInfo] The access token information
+    def token_info(access_token)
+      payload = JSON.dump(access_token: access_token)
+      response = execute(method: :post, path: "#{resource_path}/token-info", payload: payload)
+      TokenInfo.new(**response)
+    end
+
     def self.resources_path(api:)
       "/a/#{api.app_id}/accounts"
     end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -160,6 +160,21 @@ module Nylas
       response.code == 200 && response.empty?
     end
 
+    # Returns the application details
+    # @return [ApplicationDetail] The application details
+    def application_details
+      response = client.as(client.app_secret).execute(method: :get, path: "/a/#{app_id}")
+      ApplicationDetail.new(**response)
+    end
+
+    # Updates the application details
+    # @param application_details [ApplicationDetail] The updated application details
+    # @return [ApplicationDetails] The updated application details, returned from the server
+    def update_application_details(application_details)
+      response = client.as(client.app_secret).execute(method: :put, path: "/a/#{app_id}", payload: JSON.dump(application_details.to_h))
+      ApplicationDetail.new(**response)
+    end
+
     # Returns list of IP addresses
     # @return [Hash]
     # hash has keys of :updated_at (unix timestamp) and :ip_addresses (array of strings)
@@ -177,7 +192,7 @@ module Nylas
     end
 
     # Allows you to get an API that acts as a different user but otherwise has the same settings
-    # @param [String] Oauth Access token or app secret used to authenticate with the API
+    # @param access_token [String] Oauth Access token or app secret used to authenticate with the API
     # @return [API]
     def as(access_token)
       API.new(client: client.as(access_token))

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -171,7 +171,11 @@ module Nylas
     # @param application_details [ApplicationDetail] The updated application details
     # @return [ApplicationDetails] The updated application details, returned from the server
     def update_application_details(application_details)
-      response = client.as(client.app_secret).execute(method: :put, path: "/a/#{app_id}", payload: JSON.dump(application_details.to_h))
+      response = client.as(client.app_secret).execute(
+        method: :put,
+        path: "/a/#{app_id}",
+        payload: JSON.dump(application_details.to_h)
+      )
       ApplicationDetail.new(**response)
     end
 

--- a/lib/nylas/application_details.rb
+++ b/lib/nylas/application_details.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent a Nylas Application Detail object.
+  # @see https://developer.nylas.com/docs/api/#get/a/client_id
+  class ApplicationDetail
+    include Model::Attributable
+
+    attribute :application_name, :string
+    attribute :icon_url, :string
+    has_n_of_attribute :redirect_uris, :string
+  end
+end
+

--- a/lib/nylas/token_info.rb
+++ b/lib/nylas/token_info.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Structure to represent information about a Nylas access token.
+  # @see https://developer.nylas.com/docs/api/#post/a/client_id/accounts/id/token-info
+  class TokenInfo
+    include Model::Attributable
+
+    attribute :scopes, :string
+    attribute :state, :string
+    attribute :created_at, :unix_timestamp
+    attribute :updated_at, :unix_timestamp
+
+    # Returns the state of the token as a boolean
+    # @return [Boolean] If the token is active
+    def valid?
+      state == "valid"
+    end
+  end
+end
+
+

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -104,4 +104,30 @@ describe Nylas::Account do
       query: {}
     )
   end
+
+  it "can return token information" do
+    api = instance_double("Nylas::API", app_id: "app-987")
+    account = described_class.from_json('{ "id": "acc-1234" }', api: api)
+    token_info_response = {
+      scopes: "email.send,email.modify,calendar",
+      state: "valid",
+      created_at: 1622492343,
+      updated_at: 1622492343
+    }
+    allow(api).to receive(:execute).and_return(token_info_response)
+
+    token_info = account.token_info("test-token")
+
+    expect(api).to have_received(:execute).with(
+      method: :post,
+      path: "/a/app-987/accounts/acc-1234/token-info",
+      payload: be_json("access_token" => "test-token"),
+      query: {}
+    )
+    expect(token_info.scopes).to be("email.send,email.modify,calendar")
+    expect(token_info.state).to be("valid")
+    expect(token_info.created_at).to eql(Time.at(1622492343))
+    expect(token_info.updated_at).to eql(Time.at(1622492343))
+    expect(token_info.valid?).to be(true)
+  end
 end

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -195,6 +195,53 @@ describe Nylas::API do
     end
   end
 
+  describe "application details" do
+    it "gets the application details" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real"
+      )
+      api = described_class.new(client: client)
+      application_details_response = {
+        application_name: "My New App Name",
+        icon_url: "http://localhost/icon.png",
+        redirect_uris: %w[http://localhost/callback]
+      }
+      stub_request(:get, "https://api.nylas.com/a/not-real")
+        .to_return(status: 200, body: application_details_response.to_json, headers: { "content-type" => "application/json" })
+
+      app_details = api.application_details
+
+      expect(app_details).to be_a(Nylas::ApplicationDetail)
+      expect(app_details.application_name).to eq("My New App Name")
+      expect(app_details.icon_url).to eq("http://localhost/icon.png")
+      expect(app_details.redirect_uris).to eq(%w[http://localhost/callback])
+    end
+
+    it "updates the application details" do
+      application_details_response = {
+        application_name: "Updated App Name",
+        icon_url: "http://localhost/updated_icon.png",
+        redirect_uris: %w[http://localhost/callback http://localhost/updated]
+      }
+      app_details = Nylas::ApplicationDetail.new
+      app_details.application_name = "Updated App Name"
+      app_details.icon_url = "http://localhost/updated_icon.png"
+      app_details.redirect_uris = %w[http://localhost/callback http://localhost/updated]
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real"
+      )
+      api = described_class.new(client: client)
+      stub_request(:put, "https://api.nylas.com/a/not-real")
+        .to_return(status: 200, body: application_details_response.to_json, headers: { "content-type" => "application/json" })
+
+      updated_app_details = api.update_application_details(app_details)
+
+      expect(updated_app_details).to be_a(Nylas::ApplicationDetail)
+    end
+  end
+
   describe "#execute" do
     it "builds the URL based upon the api_server it was initialized with"
     it "adds the nylas headers to the request"

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -208,7 +208,11 @@ describe Nylas::API do
         redirect_uris: %w[http://localhost/callback]
       }
       stub_request(:get, "https://api.nylas.com/a/not-real")
-        .to_return(status: 200, body: application_details_response.to_json, headers: { "content-type" => "application/json" })
+        .to_return(
+          status: 200,
+          body: application_details_response.to_json,
+          headers: { "content-type" => "application/json" }
+        )
 
       app_details = api.application_details
 
@@ -234,7 +238,11 @@ describe Nylas::API do
       )
       api = described_class.new(client: client)
       stub_request(:put, "https://api.nylas.com/a/not-real")
-        .to_return(status: 200, body: application_details_response.to_json, headers: { "content-type" => "application/json" })
+        .to_return(
+          status: 200,
+          body: application_details_response.to_json,
+          headers: { "content-type" => "application/json" }
+        )
 
       updated_app_details = api.update_application_details(app_details)
 


### PR DESCRIPTION
# Description
This PR adds support for 3 Application-related endpoints. The Python SDK now is able to get and update application details as well as get information about an access token.

# Usage
To get application details:
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET
)

app_data = nylas.application_details
```

To update application details:
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET
)

app_data = nylas.application_details
app_data.application_name = "New Name"

updated_app_data = nylas.updated_application_details(app_data)
```

To get information about an access token:
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET,
    access_token: ACCESS_TOKEN
)

account = nylas.accounts.first
token_info = account.token_info("ACCESS_TOKEN")
```

# LIcense
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.