### PR TITLE
[76799] Fix saving and deleting `Folder` objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `Event` to ICS support
 * Added support for getting access token information
 * Improved support for Application Details
+* Fix saving and deleting `Folder` objects
 
 ### 5.6.1 / 2021-12-13
 * Enabled support for adding metadata to a `NewMessage`/`Draft`

--- a/lib/nylas/folder.rb
+++ b/lib/nylas/folder.rb
@@ -13,10 +13,9 @@ module Nylas
     self.updatable = true
     self.destroyable = true
 
-    attribute :id, :string
-    attribute :account_id, :string
-
-    attribute :object, :string
+    attribute :id, :string, read_only: true
+    attribute :account_id, :string, read_only: true
+    attribute :object, :string, read_only: true
 
     attribute :name, :string
     attribute :display_name, :string

--- a/spec/nylas/folder_spec.rb
+++ b/spec/nylas/folder_spec.rb
@@ -21,6 +21,82 @@ describe Nylas::Folder do
     expect(described_class).to be_destroyable
   end
 
+  describe "API operations" do
+    it "sends a POST when saving a new folder" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      json = JSON.dump(display_name: "All Mail", name: "all")
+      folder = described_class.from_json(json, api: api)
+      allow(api).to receive(:execute).and_return({})
+
+      folder.save
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/folders",
+        payload: {
+          name: "all",
+          display_name: "All Mail"
+        }.to_json,
+        query: {}
+      )
+    end
+
+    it "sends a PUT when updating an existing folder" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234", object: "folder")
+      folder = described_class.from_json(json, api: api)
+      allow(api).to receive(:execute).and_return({})
+
+      folder.update(
+        display_name: "New Display Name"
+      )
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/folders/folder_id",
+        payload: {
+          display_name: "New Display Name"
+        }.to_json,
+        query: {}
+      )
+    end
+
+    it "sends a PUT when saving an existing folder" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234", object: "folder")
+      folder = described_class.from_json(json, api: api)
+      allow(api).to receive(:execute).and_return({})
+
+      folder.save
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/folders/folder_id",
+        payload: {
+          name: "all",
+          display_name: "All Mail"
+        }.to_json,
+        query: {}
+      )
+    end
+
+    it "sends a DELETE when deleting an existing folder" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234", object: "folder")
+      folder = described_class.from_json(json, api: api)
+      allow(api).to receive(:execute).and_return({})
+
+      folder.destroy
+
+      expect(api).to have_received(:execute).with(
+        method: :delete,
+        path: "/folders/folder_id",
+        payload: nil,
+        query: {}
+      )
+    end
+  end
+
   describe "#from_json" do
     it "deserializes all the attributes successfully" do
       json = JSON.dump(display_name: "All Mail", id: "folder-all-mail", name: "all", account_id: "acc-234")

--- a/spec/nylas/folder_spec.rb
+++ b/spec/nylas/folder_spec.rb
@@ -43,7 +43,8 @@ describe Nylas::Folder do
 
     it "sends a PUT when updating an existing folder" do
       api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234", object: "folder")
+      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234",
+                       object: "folder")
       folder = described_class.from_json(json, api: api)
       allow(api).to receive(:execute).and_return({})
 
@@ -63,7 +64,8 @@ describe Nylas::Folder do
 
     it "sends a PUT when saving an existing folder" do
       api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234", object: "folder")
+      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234",
+                       object: "folder")
       folder = described_class.from_json(json, api: api)
       allow(api).to receive(:execute).and_return({})
 
@@ -82,7 +84,8 @@ describe Nylas::Folder do
 
     it "sends a DELETE when deleting an existing folder" do
       api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234", object: "folder")
+      json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234",
+                       object: "folder")
       folder = described_class.from_json(json, api: api)
       allow(api).to receive(:execute).and_return({})
 


### PR DESCRIPTION
# Description
The `Folder` class was sending over read-only attributes like `id`, `object`, and `account_id`. This PR fixes that, and adds test coverage for this.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.