### PR TITLE
[76807] Improve webhook support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Improved support for `Webhook` objects
+
 ### 5.7.0 / 2022-01-21
 * Add job status support
 * Add `Event` to ICS support

--- a/examples/plain-ruby/webhooks.rb
+++ b/examples/plain-ruby/webhooks.rb
@@ -16,14 +16,14 @@ demonstrate { api.webhooks.find(example_webhook.id).to_h }
 demonstrate do
   api.webhooks.create(
     callback_url: ENV['NYLAS_WEBHOOK_URL'],
-    state: "active",
-    triggers: ["event.created"],
+    state: WebhookState::ACTIVE,
+    triggers: [WebhookTrigger::EVENT_CREATED],
   )
 end
 
 # Update the status of the webhook
 created_webhook = api.webhooks.last
-demonstrate { created_webhook.update(state: "inactive") }
+demonstrate { created_webhook.update(WebhookState::INACTIVE) }
 
 # Delete webhook
 demonstrate { created_webhook.destroy }

--- a/examples/plain-ruby/webhooks.rb
+++ b/examples/plain-ruby/webhooks.rb
@@ -7,8 +7,23 @@ api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SEC
 
 # Webhooks can be retrieved as a collection
 demonstrate { api.webhooks.map(&:to_h) }
+
 # Or independently
 example_webhook = api.webhooks.first
 demonstrate { api.webhooks.find(example_webhook.id).to_h }
 
+# Create a webhook
+demonstrate do
+  api.webhooks.create(
+    callback_url: ENV['NYLAS_WEBHOOK_URL'],
+    state: "active",
+    triggers: ["event.created"],
+  )
+end
 
+# Update the status of the webhook
+created_webhook = api.webhooks.last
+demonstrate { created_webhook.update(state: "inactive") }
+
+# Delete webhook
+demonstrate { created_webhook.destroy }

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -5,17 +5,52 @@ module Nylas
   # @see https://docs.nylas.com/reference#webhooks
   class Webhook
     include Model
-    allows_operations(listable: true, showable: true)
-    attribute :id, :string
-    attribute :application_id, :string
+    allows_operations(creatable: true, listable: true, showable: true, updatable: true,
+                      destroyable: true)
+    attribute :id, :string, read_only: true
+    attribute :application_id, :string, read_only: true
 
     attribute :callback_url, :string
     attribute :state, :string
-    attribute :version, :string
+    attribute :version, :string, read_only: true
     has_n_of_attribute :triggers, :string
+
+    def save
+      result = if persisted?
+                 update_call(update_payload)
+               else
+                 create
+               end
+
+      attributes.merge(result)
+    end
+
+    def save_all_attributes
+      save
+    end
+
+    def update(**data)
+      raise ArgumentError, "Only 'state' is allowed to be updated" if data.length > 1 || !data.key?(:state)
+
+      attributes.merge(**data)
+      payload = JSON.dump(data)
+      update_call(payload)
+
+      true
+    end
+
+    def update_all_attributes(**data)
+      update(**data)
+    end
 
     def self.resources_path(api:)
       "/a/#{api.app_id}/webhooks"
+    end
+
+    private
+
+    def update_payload
+      JSON.dump({ state: state })
     end
   end
 end

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -1,5 +1,41 @@
 # frozen_string_literal: true
 
+module WebhookState
+  # Module representing the possible 'state' values in a Webhook
+  # @see https://developer.nylas.com/docs/api#post/a/client_id/webhooks
+
+  ACTIVE = "active"
+  INACTIVE = "inactive"
+end
+
+module WebhookTrigger
+  # Module representing the possible 'trigger' values in a Webhook
+  # @see https://developer.nylas.com/docs/api#post/a/client_id/webhooks
+
+  ACCOUNT_CONNECTED = "account.connected"
+  ACCOUNT_RUNNING = "account.running"
+  ACCOUNT_STOPPED = "account.stopped"
+  ACCOUNT_INVALID = "account.invalid"
+  ACCOUNT_SYNC_ERROR = "account.sync_error"
+  MESSAGE_CREATED = "message.created"
+  MESSAGE_OPENED = "message.opened"
+  MESSAGE_LINK_CLICKED = "message.link_created"
+  MESSAGE_UPDATED = "message.updated"
+  MESSAGE_BOUNCED = "message.bounced"
+  THREAD_REPLIED = "thread.replied"
+  CONTACT_CREATED = "contact.created"
+  CONTACT_UPDATED = "contact.updated"
+  CONTACT_DELETED = "contact.deleted"
+  CALENDAR_CREATED = "calendar.created"
+  CALENDAR_UPDATED = "calendar.updated"
+  CALENDAR_DELETED = "calendar.deleted"
+  EVENT_CREATED = "event.created"
+  EVENT_UPDATED = "event.updated"
+  EVENT_DELETED = "event.deleted"
+  JOB_SUCCESSFUL = "job.successful"
+  JOB_FAILED = "job.failed"
+end
+
 module Nylas
   # Represents a webhook attached to your application.
   # @see https://docs.nylas.com/reference#webhooks
@@ -14,6 +50,8 @@ module Nylas
     attribute :state, :string
     attribute :version, :string, read_only: true
     has_n_of_attribute :triggers, :string
+
+    STATE = [:inactive].freeze
 
     def save
       result = if persisted?

--- a/spec/nylas/webhook_spec.rb
+++ b/spec/nylas/webhook_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Nylas::Webhook do
+  it "is creatable" do
+    expect(described_class).to be_creatable
+  end
+
+  it "is listable" do
+    expect(described_class).to be_listable
+  end
+
+  it "is showable" do
+    expect(described_class).to be_showable
+  end
+
+  it "is updatable" do
+    expect(described_class).to be_updatable
+  end
+
+  it "is destroyable" do
+    expect(described_class).to be_destroyable
+  end
+
+  describe ".from_json" do
+    it "Deserializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API)
+      data = {
+        id: "webhook-123",
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(webhook.id).to eql "webhook-123"
+      expect(webhook.application_id).to eql "app-123"
+      expect(webhook.callback_url).to eql "https://url.com/callback"
+      expect(webhook.state).to eql "active"
+      expect(webhook.triggers).to eql ["event.created"]
+      expect(webhook.version).to eql "v1"
+    end
+  end
+
+  describe "#create" do
+    it "Serializes all non-read-only attributes" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      data = {
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      webhook.create
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/a/app-987/webhooks",
+        payload: JSON.dump(
+          callback_url: "https://url.com/callback",
+          state: "active",
+          triggers: ["event.created"]
+        ),
+        query: {}
+      )
+    end
+  end
+
+  describe "update" do
+    it "Serializes only state" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      data = {
+        id: "webhook-123",
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      webhook.update(state: "inactive")
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/a/app-987/webhooks/webhook-123",
+        payload: JSON.dump(
+          state: "inactive"
+        ),
+        query: {}
+      )
+    end
+
+    it "Throws an error if update was called with something other than just state" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      data = {
+        id: "webhook-123",
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      expect do
+        webhook.update(version: "v2")
+      end.to raise_error(ArgumentError, "Only 'state' is allowed to be updated")
+    end
+  end
+
+  describe "save" do
+    it "Creates if no id exists" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      data = {
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      webhook.save
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/a/app-987/webhooks",
+        payload: JSON.dump(
+          callback_url: "https://url.com/callback",
+          state: "active",
+          triggers: ["event.created"]
+        ),
+        query: {}
+      )
+    end
+
+    it "Updates if id exists" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      data = {
+        id: "webhook-123",
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      webhook.save
+
+      expect(api).to have_received(:execute).with(
+        method: :put,
+        path: "/a/app-987/webhooks/webhook-123",
+        payload: JSON.dump(
+          state: "active"
+        ),
+        query: {}
+      )
+    end
+  end
+
+  describe "#destroy" do
+    it "Deletes the webhook on the API" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      data = {
+        id: "webhook-123",
+        application_id: "app-123",
+        callback_url: "https://url.com/callback",
+        state: "active",
+        triggers: ["event.created"],
+        version: "v1"
+      }
+
+      webhook = described_class.from_json(JSON.dump(data), api: api)
+
+      webhook.destroy
+
+      expect(api).to have_received(:execute).with(
+        method: :delete,
+        path: "/a/app-987/webhooks/webhook-123",
+        payload: nil,
+        query: {}
+      )
+    end
+  end
+end

--- a/spec/nylas/webhook_spec.rb
+++ b/spec/nylas/webhook_spec.rb
@@ -31,7 +31,7 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 
@@ -53,7 +53,7 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 
@@ -82,13 +82,13 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 
       webhook = described_class.from_json(JSON.dump(data), api: api)
 
-      webhook.update(state: "inactive")
+      webhook.update(state: WebhookState::INACTIVE)
 
       expect(api).to have_received(:execute).with(
         method: :put,
@@ -107,7 +107,7 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 
@@ -126,7 +126,7 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 
@@ -153,7 +153,7 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 
@@ -180,7 +180,7 @@ describe Nylas::Webhook do
         application_id: "app-123",
         callback_url: "https://url.com/callback",
         state: "active",
-        triggers: ["event.created"],
+        triggers: [WebhookTrigger::EVENT_CREATED],
         version: "v1"
       }
 


### PR DESCRIPTION
# Description
The Nylas API supports creating, updating and deleting webhooks and this PR enables support for these additional operations. We also provide a couple of helper modules with strings representing various webhook `status` and `trigger`values.

# Usage
We have provided some modules that can help with setting the correct values for webhooks:
```ruby
# For state,
WebhookState::ACTIVE # = "active"
WebhookState::INACTIVE # = "inactive"

# For triggers
WebhookTrigger::ACCOUNT_CONNECTED # = "account.connected"
WebhookTrigger::MESSAGE_CREATED # = "message.created"
WebhookTrigger::THREAD_REPLIED # = "thread.replied"
WebhookTrigger::CALENDAR_UPDATED # = "calendar.updated"
# ... and many, many more!
```

To create a webhook:
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET,
    access_token: ACCESS_TOKEN
)

webhook = nylas.webhooks.create(
  callback_url: "WEBHOOK_URL",
  state: WebhookState::ACTIVE,
  triggers: [WebhookTrigger::EVENT_CREATED],
)
```

To update a webhook:
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET,
    access_token: ACCESS_TOKEN
)

webhook = api.webhooks.first

webhook.update(state: WebhookState::INACTIVE)
```

To delete a webhook:
```ruby
nylas = Nylas::API.new(
    app_id: APP_ID,
    app_secret: APP_SECRET,
    access_token: ACCESS_TOKEN
)

webhook = api.webhooks.first

webhook.destroy
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.