### PR TITLE
Support calendars keyword for availability requests

### DIFF
--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -8,11 +8,13 @@ module Nylas
                      interval:,
                      start_time:,
                      end_time:,
-                     emails:,
+                     emails: [],
                      buffer: nil,
                      round_robin: nil,
                      free_busy: [],
-                     open_hours: [])
+                     open_hours: [],
+                     calendars: [])
+      validate_calendars_or_emails(calendars, emails)
       validate_open_hours(emails, free_busy, open_hours) unless open_hours.empty?
 
       execute_availability("/calendars/availability",
@@ -24,17 +26,20 @@ module Nylas
                            buffer: buffer,
                            round_robin: round_robin,
                            free_busy: free_busy,
-                           open_hours: open_hours)
+                           open_hours: open_hours,
+                           calendars: calendars)
     end
 
     def consecutive_availability(duration_minutes:,
                                  interval:,
                                  start_time:,
                                  end_time:,
-                                 emails:,
+                                 emails: [],
                                  buffer: nil,
                                  free_busy: [],
-                                 open_hours: [])
+                                 open_hours: [],
+                                 calendars: [])
+      validate_calendars_or_emails(emails, calendars)
       validate_open_hours(emails, free_busy, open_hours) unless open_hours.empty?
 
       execute_availability("/calendars/availability/consecutive",
@@ -45,7 +50,8 @@ module Nylas
                            emails: emails,
                            buffer: buffer,
                            free_busy: free_busy,
-                           open_hours: open_hours)
+                           open_hours: open_hours,
+                           calendars: calendars)
     end
 
     private
@@ -56,6 +62,12 @@ module Nylas
         path: path,
         payload: JSON.dump(payload)
       )
+    end
+
+    def validate_calendars_or_emails(calendars, emails)
+      if calendars.empty? && emails.empty?
+        raise ArgumentError, "You must provide at least one of 'emails' or 'calendars'"
+      end
     end
 
     def validate_open_hours(emails, free_busy, open_hours)

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -51,7 +51,8 @@ describe Nylas::CalendarCollection do
           buffer: 5,
           round_robin: "max-fairness",
           free_busy: [free_busy],
-          open_hours: [open_hours]
+          open_hours: [open_hours],
+          calendars: []
         )
       )
     end
@@ -101,7 +102,8 @@ describe Nylas::CalendarCollection do
           emails: [["one@example.com"], %w[two@example.com three@example.com]],
           buffer: 5,
           free_busy: [free_busy],
-          open_hours: [open_hours]
+          open_hours: [open_hours],
+          calendars: []
         )
       )
     end
@@ -140,9 +142,25 @@ describe Nylas::CalendarCollection do
           emails: [["one@example.com"], %w[two@example.com three@example.com]],
           buffer: 5,
           free_busy: [free_busy],
-          open_hours: [open_hours]
+          open_hours: [open_hours],
+          calendars: []
         )
       end.to raise_error(ArgumentError)
     end
+  end
+
+  it "throws an error if at least one of 'emails' or 'calendars' is not provided" do
+    api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+    calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
+
+    expect do
+      calendar_collection.consecutive_availability(
+        duration_minutes: 30,
+        interval: 5,
+        start_time: 1590454800,
+        end_time: 1590780800,
+        buffer: 5,
+      )
+    end.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
This commit adds an optional keyword argument `calendar` to the
Nylas::CalendarCollection's availability related methods. This is
parameter is accepted by the latest API, but was not previously included
in the method definitions.

The argument requirements match the parameter requirements of the
endpoint. A user must provide one of `calendar` or `emails`

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.