### PR TITLE
Update interval keyword arg for calendar availability methods

### DIFF
--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -5,7 +5,7 @@ module Nylas
   # @see https://developer.nylas.com/docs/connectivity/calendar
   class CalendarCollection < Collection
     def availability(duration_minutes:,
-                     interval:,
+                     interval_minutes:,
                      start_time:,
                      end_time:,
                      emails:,
@@ -17,7 +17,7 @@ module Nylas
 
       execute_availability("/calendars/availability",
                            duration_minutes: duration_minutes,
-                           interval: interval,
+                           interval_minutes: interval_minutes,
                            start_time: start_time,
                            end_time: end_time,
                            emails: emails,
@@ -28,7 +28,7 @@ module Nylas
     end
 
     def consecutive_availability(duration_minutes:,
-                                 interval:,
+                                 interval_minutes:,
                                  start_time:,
                                  end_time:,
                                  emails:,
@@ -39,7 +39,7 @@ module Nylas
 
       execute_availability("/calendars/availability/consecutive",
                            duration_minutes: duration_minutes,
-                           interval: interval,
+                           interval_minutes: interval_minutes,
                            start_time: start_time,
                            end_time: end_time,
                            emails: emails,

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -29,7 +29,7 @@ describe Nylas::CalendarCollection do
 
       calendar_collection.availability(
         duration_minutes: 30,
-        interval: 5,
+        interval_minutes: 5,
         start_time: 1590454800,
         end_time: 1590780800,
         emails: ["swag@nylas.com"],
@@ -44,7 +44,7 @@ describe Nylas::CalendarCollection do
         path: "/calendars/availability",
         payload: JSON.dump(
           duration_minutes: 30,
-          interval: 5,
+          interval_minutes: 5,
           start_time: 1590454800,
           end_time: 1590780800,
           emails: ["swag@nylas.com"],
@@ -81,7 +81,7 @@ describe Nylas::CalendarCollection do
 
       calendar_collection.consecutive_availability(
         duration_minutes: 30,
-        interval: 5,
+        interval_minutes: 5,
         start_time: 1590454800,
         end_time: 1590780800,
         emails: [["one@example.com"], %w[two@example.com three@example.com]],
@@ -95,7 +95,7 @@ describe Nylas::CalendarCollection do
         path: "/calendars/availability/consecutive",
         payload: JSON.dump(
           duration_minutes: 30,
-          interval: 5,
+          interval_minutes: 5,
           start_time: 1590454800,
           end_time: 1590780800,
           emails: [["one@example.com"], %w[two@example.com three@example.com]],
@@ -134,7 +134,7 @@ describe Nylas::CalendarCollection do
       expect do
         calendar_collection.consecutive_availability(
           duration_minutes: 30,
-          interval: 5,
+          interval_minutes: 5,
           start_time: 1590454800,
           end_time: 1590780800,
           emails: [["one@example.com"], %w[two@example.com three@example.com]],


### PR DESCRIPTION
This commit updates the keyword arguments for the interval parameter for
the availability-related methods to match the requirements of the API
endpoints.

According to the latest API, the availability endpoints expect an
`interval_minutes` rather than an `interval` keyword. Without this
change, the API throws an error:

```ruby
response = nylas_client.calendars.availability(
  start_time: start_time.to_i,
  end_time: end_time.to_i,
  duration_minutes: duration_minutes,
  interval: 30,
  round_robin: "max-availability",
  emails: [coach.email],
)

# => Nylas::InvalidRequest: interval_minutes: Missing data for required field.
```

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.