### PR TITLE
v5.8.0 Release

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Metrics/ClassLength:
     - "lib/nylas/api.rb"
     - "lib/nylas/collection.rb"
 
+Metrics/MethodLength:
+  Exclude:
+    - "lib/nylas/calendar_collection.rb"
 
 Metrics/ModuleLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.8.0 / 2022-03-18
 * Improved support for `Webhook` objects
 * Support `calendars` for availability methods
 * Fix `interval_minutes` keyword for availability methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 * Improved support for `Webhook` objects
+* Support `calendars` for availability methods
+* Fix `interval_minutes` keyword for availability methods
 
 ### 5.7.0 / 2022-01-21
 * Add job status support

--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -65,9 +65,9 @@ module Nylas
     end
 
     def validate_calendars_or_emails(calendars, emails)
-      if calendars.empty? && emails.empty?
-        raise ArgumentError, "You must provide at least one of 'emails' or 'calendars'"
-      end
+      return unless calendars.empty? && emails.empty?
+
+      raise ArgumentError, "You must provide at least one of 'emails' or 'calendars'"
     end
 
     def validate_open_hours(emails, free_busy, open_hours)

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.7.0"
+  VERSION = "5.8.0"
 end

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -156,10 +156,10 @@ describe Nylas::CalendarCollection do
     expect do
       calendar_collection.consecutive_availability(
         duration_minutes: 30,
-        interval: 5,
+        interval_minutes: 5,
         start_time: 1590454800,
         end_time: 1590780800,
-        buffer: 5,
+        buffer: 5
       )
     end.to raise_error(ArgumentError)
   end


### PR DESCRIPTION
# Description
New `nylas` v5.8.0 release brings in the following features and enhancements:
* Improved support for `Webhook` objects (#349)
* Support `calendars` for availability methods (#350)
* Fix `interval_minutes` keyword for availability methods (#351)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.