### PR TITLE
Enable Nylas API v2.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Enable Nylas API v2.5 support
+
 ### 5.8.0 / 2022-03-18
 * Improved support for `Webhook` objects
 * Support `calendars` for availability methods

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -33,7 +33,7 @@ module Nylas
       "/delta/longpoll" => 3650,
       "/delta/streaming" => 3650
     }.freeze
-    SUPPORTED_API_VERSION = "2.2"
+    SUPPORTED_API_VERSION = "2.5"
 
     include Logging
     attr_accessor :api_server

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,5 @@
 <!-- Your PR comment must contain the following lines for us to merge the PR. -->
+
 # Description
 <!-- A clear and concise description of what the PR is introducing/changing. -->
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,2 +1,6 @@
-<!-- Your PR comment must contain the following line for us to merge the PR. -->
+<!-- Your PR comment must contain the following lines for us to merge the PR. -->
+# Description
+<!-- A clear and concise description of what the PR is introducing/changing. -->
+
+# License
 I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -45,7 +45,7 @@ describe Nylas::HttpClient do
 
   describe "#execute" do
     it "includes Nylas API Version in headers" do
-      supported_api_version = "2.2"
+      supported_api_version = "2.5"
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       allow(RestClient::Request).to receive(:execute)
 


### PR DESCRIPTION
# Description
This PR enables Nylas API v2.5 for the Ruby SDK

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.