### PR TITLE
[TSDK-265] Add `authentication_type` field in `Account`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add new `authentication_type` field in Account
 * Enable Nylas API v2.5 support
 
 ### 5.8.0 / 2022-03-18

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -15,6 +15,7 @@ module Nylas
     attribute :billing_state, :string, read_only: true
     attribute :sync_state, :string, read_only: true
     attribute :provider, :string, read_only: true
+    attribute :authentication_type, :string, read_only: true
 
     attribute :email, :string, read_only: true
     attribute :trial, :boolean, read_only: true

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -20,6 +20,7 @@ describe Nylas::Account do
       email: "test@example.com",
       id: "30zipv27dtrsnkleg59mprw5p",
       sync_state: "running",
+      authentication_type: "password",
       trial: false,
       provider: "gmail",
       metadata: {
@@ -32,6 +33,7 @@ describe Nylas::Account do
     expect(account.email).to eql "test@example.com"
     expect(account.id).to eql "30zipv27dtrsnkleg59mprw5p"
     expect(account.sync_state).to eql "running"
+    expect(account.authentication_type).to eql "password"
     expect(account.trial).to be false
     expect(account.provider).to eq("gmail")
     expect(account.metadata).to include(key: "value")


### PR DESCRIPTION
# Description
This PR adds a new field `authentication_type` in `Account` model

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.