### PR TITLE
[TSDK-281] Implement Basic Auth support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Add Outbox support
 * Add new `authentication_type` field in Account
+* Add support for basic authentication
 * Enable Nylas API v2.5 support
 
 ### 5.8.0 / 2022-03-18

--- a/examples/plain-ruby/components.rb
+++ b/examples/plain-ruby/components.rb
@@ -5,8 +5,8 @@ require_relative '../helpers'
 api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
 
 # Create a component
-# NOTE: you will need to fill in the account_id and, if not set, the access_token
-demonstrate { api.components.create(name: "Ruby Component Test", type: "agenda", public_account_id: "ACCOUNT_ID", access_token: ENV['NYLAS_ACCESS_TOKEN']) }
+# NOTE: you will need to set the account_id and the access_token
+demonstrate { api.components.create(name: "Ruby Component Test", type: "agenda", public_account_id: ENV['NYLAS_ACCOUNT_ID'], access_token: ENV['NYLAS_ACCESS_TOKEN']) }
 
 # Get all components
 demonstrate { api.components }

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -29,6 +29,8 @@ require_relative "nylas/registry"
 require_relative "nylas/types"
 require_relative "nylas/constraints"
 
+require_relative "nylas/http_client"
+require_relative "nylas/api"
 require_relative "nylas/collection"
 require_relative "nylas/model"
 
@@ -111,9 +113,6 @@ require_relative "nylas/scheduler_booking_request"
 require_relative "nylas/scheduler_booking_confirmation"
 
 require_relative "nylas/native_authentication"
-
-require_relative "nylas/http_client"
-require_relative "nylas/api"
 
 require_relative "nylas/filter_attributes"
 # an SDK for interacting with the Nylas API

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -9,6 +9,7 @@ module Nylas
     self.showable = true
     self.updatable = true
     self.destroyable = true
+    self.auth_method = HttpClient::AuthMethod::BASIC
 
     attribute :id, :string, read_only: true
     attribute :account_id, :string, read_only: true

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -168,7 +168,11 @@ module Nylas
     # Returns the application details
     # @return [ApplicationDetail] The application details
     def application_details
-      response = client.as(client.app_secret).execute(method: :get, path: "/a/#{app_id}")
+      response = client.as(client.app_secret).execute(
+        method: :get,
+        path: "/a/#{app_id}",
+        auth_method: HttpClient::AuthMethod::BASIC
+      )
       ApplicationDetail.new(**response)
     end
 
@@ -179,7 +183,8 @@ module Nylas
       response = client.as(client.app_secret).execute(
         method: :put,
         path: "/a/#{app_id}",
-        payload: JSON.dump(application_details.to_h)
+        payload: JSON.dump(application_details.to_h),
+        auth_method: HttpClient::AuthMethod::BASIC
       )
       ApplicationDetail.new(**response)
     end
@@ -189,7 +194,7 @@ module Nylas
     # hash has keys of :updated_at (unix timestamp) and :ip_addresses (array of strings)
     def ip_addresses
       path = "/a/#{app_id}/ip_addresses"
-      client.as(client.app_secret).get(path: path)
+      client.as(client.app_secret).get(path: path, auth_method: HttpClient::AuthMethod::BASIC)
     end
 
     # @param message [Hash, String, #send!]

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -139,7 +139,7 @@ module Nylas
     # @return [Hash] Specification for request to be passed to {API#execute}
     def to_be_executed
       { method: :get, path: resources_path, query: constraints.to_query,
-        headers: constraints.to_headers }
+        headers: constraints.to_headers, auth_method: model.auth_method }
     end
 
     # Retrieves the data from the API for the particular constraints

--- a/lib/nylas/component.rb
+++ b/lib/nylas/component.rb
@@ -6,6 +6,7 @@ module Nylas
     include Model
     allows_operations(creatable: true, listable: true, filterable: true, showable: true, updatable: true,
                       destroyable: true)
+    self.auth_method = HttpClient::AuthMethod::BASIC
 
     attribute :id, :string, read_only: true
     attribute :account_id, :string

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -2,6 +2,7 @@
 
 module Nylas
   require "yajl"
+  require "base64"
 
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient # rubocop:disable Metrics/ClassLength
@@ -223,8 +224,15 @@ module Nylas
       query
     end
 
-    def auth_header
-      authorization_string = "Bearer #{access_token}"
+    def auth_header(auth_method)
+      authorization_string = case auth_method
+                             when AuthMethod::BEARER
+                               "Bearer #{access_token}"
+                             when AuthMethod::BASIC
+                               "Basic #{Base64.encode64("#{access_token}:")}"
+                             else
+                               "Bearer #{access_token}"
+                             end
 
       { "Authorization" => authorization_string }
     end

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -5,6 +5,11 @@ module Nylas
 
   # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
   class HttpClient # rubocop:disable Metrics/ClassLength
+    module AuthMethod
+      BEARER = 1
+      BASIC = 2
+    end
+
     HTTP_SUCCESS_CODES = [200, 201, 202, 302].freeze
 
     HTTP_CODE_TO_EXCEPTIONS = {
@@ -32,10 +37,6 @@ module Nylas
       "/delta" => 3650,
       "/delta/longpoll" => 3650,
       "/delta/streaming" => 3650
-    }.freeze
-
-    AUTH_METHOD = {
-      "Bearer" => 1
     }.freeze
 
     SUPPORTED_API_VERSION = "2.5"

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -116,7 +116,15 @@ module Nylas
     inform_on :execute, level: :debug,
                         also_log: { result: true, values: %i[method url path headers query payload] }
 
-    def build_request(method:, path: nil, headers: {}, query: {}, payload: nil, timeout: nil, auth_method: nil)
+    def build_request(
+      method:,
+      path: nil,
+      headers: {},
+      query: {},
+      payload: nil,
+      timeout: nil,
+      auth_method: nil
+    )
       url ||= url_for_path(path)
       url = add_query_params_to_url(url, query)
       resulting_headers = default_headers.merge(headers).merge(auth_header(auth_method))

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -107,6 +107,10 @@ module Nylas
       self.class.resources_path(api: api)
     end
 
+    def auth_method
+      self.class.auth_method(api: api) || HttpClient::AuthMethod::BEARER
+    end
+
     def destroy
       raise ModelNotDestroyableError, self unless destroyable?
 
@@ -138,7 +142,7 @@ module Nylas
     module ClassMethods
       attr_accessor :raw_mime_type, :creatable, :showable, :filterable, :searchable, :listable, :updatable,
                     :destroyable
-      attr_writer :resources_path
+      attr_writer :resources_path, :auth_method
 
       def allows_operations(creatable: false, showable: false, listable: false, filterable: false,
                             searchable: false, updatable: false, destroyable: false)
@@ -182,6 +186,10 @@ module Nylas
 
       def resources_path(*)
         @resources_path
+      end
+
+      def auth_method(*)
+        @auth_method
       end
 
       def exposable_as_raw?

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -39,8 +39,8 @@ module Nylas
       !id.nil?
     end
 
-    def execute(method:, payload: nil, path:, query: {})
-      api.execute(method: method, payload: payload, path: path, query: query)
+    def execute(method:, payload: nil, path:, query: {}, auth_method: self.auth_method)
+      api.execute(method: method, payload: payload, path: path, query: query, auth_method: auth_method)
     end
 
     def create

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -108,7 +108,7 @@ module Nylas
     end
 
     def auth_method
-      self.class.auth_method(api: api) || HttpClient::AuthMethod::BEARER
+      self.class.auth_method(api: api)
     end
 
     def destroy
@@ -189,7 +189,7 @@ module Nylas
       end
 
       def auth_method(*)
-        @auth_method
+        @auth_method || HttpClient::AuthMethod::BEARER
       end
 
       def exposable_as_raw?

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -43,6 +43,7 @@ module Nylas
     include Model
     allows_operations(creatable: true, listable: true, showable: true, updatable: true,
                       destroyable: true)
+    self.auth_method = HttpClient::AuthMethod::BASIC
     attribute :id, :string, read_only: true
     attribute :application_id, :string, read_only: true
 

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -49,6 +49,7 @@ describe Nylas::Account do
     account.save
 
     expect(api).to have_received(:execute).with(
+      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
       method: :put,
       path: "/a/app-987/accounts/acc-1234",
       payload: JSON.dump(
@@ -67,6 +68,7 @@ describe Nylas::Account do
     expect(account.downgrade).to be_truthy
 
     expect(api).to have_received(:execute).with(
+      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/downgrade",
       payload: nil,
@@ -81,6 +83,7 @@ describe Nylas::Account do
     expect(account.upgrade).to be_truthy
 
     expect(api).to have_received(:execute).with(
+      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/upgrade",
       payload: nil,
@@ -96,6 +99,7 @@ describe Nylas::Account do
     expect(account.revoke_all(keep_access_token: access_token)).to be_truthy
 
     expect(api).to have_received(:execute).with(
+      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/revoke-all",
       payload: be_json("keep_access_token" => access_token),
@@ -110,6 +114,7 @@ describe Nylas::Account do
     expect(account.destroy).to be_truthy
 
     expect(api).to have_received(:execute).with(
+      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
       method: :delete,
       path: "/a/app-987/accounts/acc-1234",
       payload: nil,
@@ -131,6 +136,7 @@ describe Nylas::Account do
     token_info = account.token_info("test-token")
 
     expect(api).to have_received(:execute).with(
+      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/token-info",
       payload: be_json("access_token" => "test-token"),

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -16,8 +16,13 @@ describe Nylas::Collection do
   describe "#each" do
     it "Returns an enumerable for a single page of results, filtered by `offset` and `limit` and `where`" do
       allow(api).to receive(:execute)
-        .with(method: :get, path: "/collection", query: { limit: 100, offset: 0 }, headers: {})
-        .and_return([example_instance_hash])
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection",
+          query: { limit: 100, offset: 0 },
+          headers: {}
+        ).and_return([example_instance_hash])
 
       collection = described_class.new(model: FullModel, api: api)
 
@@ -28,8 +33,13 @@ describe Nylas::Collection do
 
     it "allows you to use a block directly" do
       allow(api).to receive(:execute)
-        .with(method: :get, path: "/collection", query: { limit: 100, offset: 0 }, headers: {})
-        .and_return([example_instance_hash])
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection",
+          query: { limit: 100, offset: 0 },
+          headers: {}
+        ).and_return([example_instance_hash])
 
       collection = described_class.new(model: FullModel, api: api)
 
@@ -46,13 +56,23 @@ describe Nylas::Collection do
   describe "#find_each" do
     it "iterates over every page filtered based on `limit` and `where`" do
       collection = described_class.new(model: FullModel, api: api)
-      allow(api).to receive(:execute).with(method: :get, path: "/collection",
-                                           query: { limit: 100, offset: 0 }, headers: {})
-                                     .and_return(Array.new(100) { example_instance_hash })
+      allow(api).to receive(:execute)
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection",
+          query: { limit: 100, offset: 0 },
+          headers: {}
+        ).and_return(Array.new(100) { example_instance_hash })
 
-      allow(api).to receive(:execute).with(method: :get, path: "/collection",
-                                           query: { limit: 100, offset: 100 }, headers: {})
-                                     .and_return(Array.new(50) { example_instance_hash })
+      allow(api).to receive(:execute)
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection",
+          query: { limit: 100, offset: 100 },
+          headers: {}
+        ).and_return(Array.new(50) { example_instance_hash })
 
       expect(collection.find_each.to_a.size).to be 150
     end
@@ -62,6 +82,7 @@ describe Nylas::Collection do
     it "retrieves a single object, without filtering based upon `where` clauses earlier in the chain" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: {},
@@ -83,6 +104,7 @@ describe Nylas::Collection do
       expect(instance.id).to eql "1234"
       expect(instance.api).to eq(api)
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: { view: "expanded" },
@@ -99,6 +121,7 @@ describe Nylas::Collection do
       expect(instance.id).to eql "1234"
       expect(instance.api).to eq(api)
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: {},
@@ -116,6 +139,7 @@ describe Nylas::Collection do
         ]
       )
       allow(api).to receive(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: {},
@@ -147,8 +171,13 @@ describe Nylas::Collection do
     it "returns collection count" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
-        .with(method: :get, path: "/collection", query: { limit: 100, offset: 0, view: "count" }, headers: {})
-        .and_return(count: 1)
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection",
+          query: { limit: 100, offset: 0, view: "count" },
+          headers: {}
+        ).and_return(count: 1)
 
       expect(collection.count).to be 1
     end
@@ -156,11 +185,13 @@ describe Nylas::Collection do
     it "returns collection count filtered by `where`" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
-        .with(method: :get,
-              path: "/collection",
-              query: { id: "1234", limit: 100, offset: 0, view: "count" },
-              headers: {})
-        .and_return(count: 1)
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection",
+          query: { id: "1234", limit: 100, offset: 0, view: "count" },
+          headers: {}
+        ).and_return(count: 1)
 
       expect(collection.where(id: "1234").count).to be 1
     end
@@ -191,6 +222,7 @@ describe Nylas::Collection do
         model = instance_double("Model")
         allow(model).to receive(:searchable?).and_return(true)
         allow(model).to receive(:resources_path)
+        allow(model).to receive(:auth_method)
         collection = described_class.new(model: model, api: api)
         stub_request(:get, "https://api.nylas.com/search?limit=100&offset=0&q=%7B%7D")
           .to_return(status: code, body: {}.to_json)

--- a/spec/nylas/component_spec.rb
+++ b/spec/nylas/component_spec.rb
@@ -71,6 +71,7 @@ describe Nylas::Component do
       component.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :post,
         path: "/component/not-real",
         payload: JSON.dump(
@@ -116,6 +117,7 @@ describe Nylas::Component do
       scheduler.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :put,
         path: "/component/not-real/abc-123",
         payload: JSON.dump(

--- a/spec/nylas/deltas_collection_spec.rb
+++ b/spec/nylas/deltas_collection_spec.rb
@@ -7,14 +7,29 @@ describe Nylas::DeltasCollection do
     it "supports iterating until the responses are empty" do
       api = instance_double(Nylas::API)
       allow(api).to receive(:execute)
-        .with(path: "/delta", method: :get, query: { cursor: "1", limit: 100, offset: 0 }, headers: {})
-        .and_return(deltas: [{ object: "draft" }], cursor_start: "1", cursor_end: "2")
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          path: "/delta",
+          method: :get,
+          query: { cursor: "1", limit: 100, offset: 0 },
+          headers: {}
+        ).and_return(deltas: [{ object: "draft" }], cursor_start: "1", cursor_end: "2")
       allow(api).to receive(:execute)
-        .with(path: "/delta", method: :get, query: { cursor: "2", limit: 100, offset: 0 }, headers: {})
-        .and_return(deltas: [{ object: "message" }], cursor_start: "2", cursor_end: "3")
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          path: "/delta",
+          method: :get,
+          query: { cursor: "2", limit: 100, offset: 0 },
+          headers: {}
+        ).and_return(deltas: [{ object: "message" }], cursor_start: "2", cursor_end: "3")
       allow(api).to receive(:execute)
-        .with(path: "/delta", method: :get, query: { cursor: "3", limit: 100, offset: 0 }, headers: {})
-        .and_return(deltas: [], cursor_start: "3", cursor_end: "4")
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          path: "/delta",
+          method: :get,
+          query: { cursor: "3", limit: 100, offset: 0 },
+          headers: {}
+        ).and_return(deltas: [], cursor_start: "3", cursor_end: "4")
 
       deltas = described_class.new(api: api).since("1")
       all_deltas = deltas.find_each.map(&:to_h)
@@ -33,8 +48,13 @@ describe Nylas::DeltasCollection do
         .and_return(cursor: "4")
 
       allow(api).to receive(:execute)
-        .with(path: "/delta", method: :get, query: { cursor: "4", limit: 100, offset: 0 }, headers: {})
-        .and_return(deltas: [], cursor_start: "4", cursor_end: "5")
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          path: "/delta",
+          method: :get,
+          query: { cursor: "4", limit: 100, offset: 0 },
+          headers: {}
+        ).and_return(deltas: [], cursor_start: "4", cursor_end: "5")
 
       deltas = described_class.new(api: api).latest
       expect(deltas).to be_empty

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -43,6 +43,7 @@ describe Nylas::Draft do
         draft.update(subject: "Updated subject", files: [file])
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -68,6 +69,7 @@ describe Nylas::Draft do
         draft.update(subject: "Updated subject")
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -116,6 +118,7 @@ describe Nylas::Draft do
       draft.update(**updated)
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/drafts/draft-1234",
         payload: JSON.dump(
@@ -144,6 +147,7 @@ describe Nylas::Draft do
         draft.create
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/drafts",
           payload: JSON.dump(
@@ -169,6 +173,7 @@ describe Nylas::Draft do
         draft.create
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/drafts",
           payload: JSON.dump(
@@ -197,6 +202,7 @@ describe Nylas::Draft do
         draft.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -222,6 +228,7 @@ describe Nylas::Draft do
         draft.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -266,6 +273,7 @@ describe Nylas::Draft do
       draft.send!
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/send",
         payload: update_json,
@@ -282,6 +290,7 @@ describe Nylas::Draft do
       draft.send!
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/send",
         payload: JSON.dump(

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -196,6 +196,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -223,6 +224,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -248,6 +250,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -275,6 +278,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -313,6 +317,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -378,6 +383,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {
@@ -403,6 +409,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {
@@ -430,6 +437,7 @@ describe Nylas::Event do
         event.update(location: "Somewhere else!")
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-8766",
           payload: {
@@ -455,6 +463,7 @@ describe Nylas::Event do
         event.update(location: "Somewhere else!")
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-8766",
           payload: {
@@ -481,6 +490,7 @@ describe Nylas::Event do
         event.destroy
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :delete,
           path: "/events/event-8766",
           payload: nil,
@@ -504,6 +514,7 @@ describe Nylas::Event do
         event.destroy
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :delete,
           path: "/events/event-8766",
           payload: nil,

--- a/spec/nylas/folder_spec.rb
+++ b/spec/nylas/folder_spec.rb
@@ -31,6 +31,7 @@ describe Nylas::Folder do
       folder.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/folders",
         payload: {
@@ -53,6 +54,7 @@ describe Nylas::Folder do
       )
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/folders/folder_id",
         payload: {
@@ -72,6 +74,7 @@ describe Nylas::Folder do
       folder.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/folders/folder_id",
         payload: {
@@ -92,6 +95,7 @@ describe Nylas::Folder do
       folder.destroy
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :delete,
         path: "/folders/folder_id",
         payload: nil,

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -144,6 +144,7 @@ describe Nylas::Message do
         message.save
 
         expect(api).to have_received(:execute).with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/messages/message-1234",
           payload: JSON.dump(
@@ -170,6 +171,7 @@ describe Nylas::Message do
       message.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: JSON.dump(
@@ -197,6 +199,7 @@ describe Nylas::Message do
       message.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: JSON.dump(
@@ -222,6 +225,7 @@ describe Nylas::Message do
       )
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: JSON.dump(
@@ -254,6 +258,7 @@ describe Nylas::Message do
       message.update_folder(folder_id)
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: { folder_id: folder_id }.to_json,

--- a/spec/nylas/model_spec.rb
+++ b/spec/nylas/model_spec.rb
@@ -57,6 +57,7 @@ describe Nylas::Model do
       instance.save_all_attributes
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         payload: {
           id: "1234",
@@ -110,6 +111,7 @@ describe Nylas::Model do
       instance.update_all_attributes(**update_params)
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         payload: update_params.to_json,
         path: "/collection/1234",

--- a/spec/nylas/room_resource_spec.rb
+++ b/spec/nylas/room_resource_spec.rb
@@ -55,6 +55,7 @@ describe Nylas::RoomResource do
       api.execute(resource.to_be_executed)
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/resources",
         headers: {},

--- a/spec/nylas/scheduler_spec.rb
+++ b/spec/nylas/scheduler_spec.rb
@@ -79,6 +79,7 @@ describe Nylas::Scheduler do
       scheduler.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/manage/pages",
         payload: JSON.dump(
@@ -123,6 +124,7 @@ describe Nylas::Scheduler do
       scheduler.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/manage/pages/123",
         payload: JSON.dump(

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -86,6 +86,7 @@ describe Nylas::Thread do
       thread.update_folder(folder_id)
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/threads/thread-1234",
         payload: { folder_id: folder_id }.to_json,
@@ -107,6 +108,7 @@ describe Nylas::Thread do
       )
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/threads/thread-1234",
         payload: JSON.dump(

--- a/spec/nylas/webhook_spec.rb
+++ b/spec/nylas/webhook_spec.rb
@@ -62,6 +62,7 @@ describe Nylas::Webhook do
       webhook.create
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :post,
         path: "/a/app-987/webhooks",
         payload: JSON.dump(
@@ -91,6 +92,7 @@ describe Nylas::Webhook do
       webhook.update(state: WebhookState::INACTIVE)
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :put,
         path: "/a/app-987/webhooks/webhook-123",
         payload: JSON.dump(
@@ -135,6 +137,7 @@ describe Nylas::Webhook do
       webhook.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :post,
         path: "/a/app-987/webhooks",
         payload: JSON.dump(
@@ -162,6 +165,7 @@ describe Nylas::Webhook do
       webhook.save
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :put,
         path: "/a/app-987/webhooks/webhook-123",
         payload: JSON.dump(
@@ -189,6 +193,7 @@ describe Nylas::Webhook do
       webhook.destroy
 
       expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
         method: :delete,
         path: "/a/app-987/webhooks/webhook-123",
         payload: nil,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,8 @@ require "rspec-json_matcher"
 RSpec.configuration.include RSpec::JsonMatcher
 
 class FakeAPI
-  def execute(method:, path:, payload: nil, query: {})
-    requests.push(method: method, path: path, payload: payload, query: query)
+  def execute(method:, path:, payload: nil, query: {}, auth_method: Nylas::HttpClient::AuthMethod::BEARER)
+    requests.push(method: method, path: path, payload: payload, query: query, auth_method: auth_method)
   end
 
   def requests


### PR DESCRIPTION
# Description
This PR enables basic auth support for the APIs that need it

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.