### PR TITLE
v5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.9.0 / 2022-04-07
 * Add Outbox support
 * Add new `authentication_type` field in Account
 * Add support for basic authentication

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.8.0"
+  VERSION = "5.9.0"
 end


### PR DESCRIPTION
# Description
New `nylas` v5.9.0 release brings in the following features and changes:
* Add Outbox support (#355)
* Add new `authentication_type` field in Account (#354)
* Add support for basic authentication (#356)
* Enable Nylas API v2.5 support (#353)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.