### PR TITLE
Fix `NoMethodError` when calling `NewMessage#send!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix `NoMethodError` when calling `NewMessage#send!`
+
 ### 5.9.0 / 2022-04-07
 * Add Outbox support
 * Add new `authentication_type` field in Account

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -26,8 +26,14 @@ module Nylas
 
     attribute :tracking, :message_tracking
 
+    # Sends the new message
+    # @return [Message] The sent message
+    # @raise [RuntimeError] if the API response data was not a hash
     def send!
-      Message.new(**api.execute(method: :post, path: "/send", payload: to_json).merge(api: api))
+      message_data = api.execute(method: :post, path: "/send", payload: to_json)
+      raise "Unexpected response from the server, data received not a Message" unless message_data.is_a?(Hash)
+
+      Message.from_hash(message_data, api: api)
     end
   end
 end


### PR DESCRIPTION
# Description
This PR adds an extra check when sending a `NewMessage` object by checking if the API response is a Hash before attempting to create a `Message` option out of it, preventing the chance of a `NoMethodError`. This PR closes issue #358.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.