### PR TITLE
Add missing `phone_number` field in `Participant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Add missing `phone_number` field in `Participant`
 * Fix `NoMethodError` when calling `NewMessage#send!`
 
 ### 5.9.0 / 2022-04-07

--- a/lib/nylas/participant.rb
+++ b/lib/nylas/participant.rb
@@ -6,6 +6,7 @@ module Nylas
     include Model::Attributable
     attribute :name, :string
     attribute :email, :string
+    attribute :phone_number, :string
     attribute :comment, :string
     attribute :status, :string, read_only: true
   end

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -16,6 +16,7 @@ describe Nylas::Event do
         participants: [
           {
             comment: "Let me think on it",
+            phone_number: "+14160000000",
             email: "participant@example.com",
             name: "Participant",
             status: "noreply"
@@ -69,6 +70,7 @@ describe Nylas::Event do
       expect(event.description).to eql "an event"
       expect(event.owner).to eql '"owner" <owner@example.com>'
       expect(event.participants[0].comment).to eql "Let me think on it"
+      expect(event.participants[0].phone_number).to eql "+14160000000"
       expect(event.participants[0].email).to eql "participant@example.com"
       expect(event.participants[0].name).to eql "Participant"
       expect(event.participants[0].status).to eql "noreply"


### PR DESCRIPTION
# Description
This PR adds the missing `phone_number` field in `Participant`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.