### PR TITLE
v5.9.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.9.1 / 2022-04-20
 * Add missing `phone_number` field in `Participant`
 * Fix `NoMethodError` when calling `NewMessage#send!`
 

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.9.0"
+  VERSION = "5.9.1"
 end


### PR DESCRIPTION
# Description
New `nylas` v5.9.1 release brings in the following features and changes:
* Add missing `phone_number` field in `Participant` (#360)
* Fix `NoMethodError` when calling `NewMessage#send!` (#359, #358)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.