### PR TITLE
Update app.rb to replace deprecated Google scopes

### DIFF
--- a/examples/authentication/app.rb
+++ b/examples/authentication/app.rb
@@ -9,7 +9,7 @@ use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
     { name: 'google', access_type: :offline, approval_prompt: "force", prompt: 'consent',
       scope: ['email', 'profile', 'https://mail.google.com/',
-              'https://www.google.com/m8/feeds/',
+              'https://www.googleapis.com/auth/contacts',
               'calendar'].join(', ') }
 end
 get "/" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
https://www.google.com/m8/feeds/ is a deprecated scope. We have users relying on this example code for our authentication. This code won't work unless the scope mentioned is replaced with https://www.googleapis.com/auth/contacts

Related CC PR here (not public): https://github.com/nylas/cloud-core/pull/5960/files

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.