### PR TITLE
Fix calendar availability not serializing `FreeBusy` and `OpenHours` properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fix calendar availability not serializing `FreeBusy` and `OpenHours` properly
+
 ### 5.9.1 / 2022-04-20
 * Add missing `phone_number` field in `Participant`
 * Fix `NoMethodError` when calling `NewMessage#send!`

--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -25,8 +25,8 @@ module Nylas
                            emails: emails,
                            buffer: buffer,
                            round_robin: round_robin,
-                           free_busy: free_busy,
-                           open_hours: open_hours,
+                           free_busy: free_busy.map(&:to_h),
+                           open_hours: open_hours.map(&:to_h),
                            calendars: calendars)
     end
 
@@ -49,8 +49,8 @@ module Nylas
                            end_time: end_time,
                            emails: emails,
                            buffer: buffer,
-                           free_busy: free_busy,
-                           open_hours: open_hours,
+                           free_busy: free_busy.map(&:to_h),
+                           open_hours: open_hours.map(&:to_h),
                            calendars: calendars)
     end
 

--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -4,6 +4,18 @@ module Nylas
   # Additional methods for some of Calendar's other functionality
   # @see https://developer.nylas.com/docs/connectivity/calendar
   class CalendarCollection < Collection
+    # Check multiple calendars to find available time slots for a single meeting
+    # @param duration_minutes [Integer] The total number of minutes the event should last
+    # @param interval_minutes [Integer] How many minutes it should check for availability
+    # @param start_time [Integer] The timestamp for the beginning of the event
+    # @param end_time [Integer] The timestamp for the end of the event
+    # @param emails [Array<String>] Emails on the same domain to check
+    # @param buffer [Integer] The amount of buffer time in minutes that you want around existing meetings
+    # @param round_robin [String] Finds available meeting times in a round-robin style
+    # @param free_busy [Array<Nylas::FreeBusy>] A list of free-busy data for users not in your organization
+    # @param open_hours [Array<Nylas::OpenHours>] Additional times email accounts are available
+    # @param calendars [Array] Check account and calendar IDs for free/busy status
+    # @return [Hash] The availability information; a list of time slots where all participants are available
     def availability(duration_minutes:,
                      interval_minutes:,
                      start_time:,
@@ -30,6 +42,17 @@ module Nylas
                            calendars: calendars)
     end
 
+    # Check multiple calendars to find availability for multiple meetings with several participants
+    # @param duration_minutes [Integer] The total number of minutes the event should last
+    # @param interval_minutes [Integer] How many minutes it should check for availability
+    # @param start_time [Integer] The timestamp for the beginning of the event
+    # @param end_time [Integer] The timestamp for the end of the event
+    # @param emails [Array<Array<String>>] Emails on the same domain to check
+    # @param buffer [Integer] The amount of buffer time in minutes that you want around existing meetings
+    # @param free_busy [Array<Nylas::FreeBusy>] A list of free-busy data for users not in your organization
+    # @param open_hours [Array<Nylas::OpenHours>] Additional times email accounts are available
+    # @param calendars [Array] Check account and calendar IDs for free/busy status
+    # @return [Hash] The availability information; a list of all possible groupings that share time slots
     def consecutive_availability(duration_minutes:,
                                  interval_minutes:,
                                  start_time:,

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -50,8 +50,28 @@ describe Nylas::CalendarCollection do
           emails: ["swag@nylas.com"],
           buffer: 5,
           round_robin: "max-fairness",
-          free_busy: [free_busy],
-          open_hours: [open_hours],
+          free_busy: [
+            {
+              email: "swag@nylas.com",
+              time_slots: [
+                {
+                  object: "time_slot",
+                  status: "busy",
+                  start_time: 1_609_439_400,
+                  end_time: 1_640_975_400
+                }
+              ]
+            }
+          ],
+          open_hours: [
+            {
+              timezone: "America/Chicago",
+              start: "10:00",
+              end: "14:00",
+              emails: ["swag@nylas.com"],
+              days: [0]
+            }
+          ],
           calendars: []
         )
       )
@@ -101,8 +121,28 @@ describe Nylas::CalendarCollection do
           end_time: 1590780800,
           emails: [["one@example.com"], %w[two@example.com three@example.com]],
           buffer: 5,
-          free_busy: [free_busy],
-          open_hours: [open_hours],
+          free_busy: [
+            {
+              email: "swag@nylas.com",
+              time_slots: [
+                {
+                  object: "time_slot",
+                  status: "busy",
+                  start_time: 1_609_439_400,
+                  end_time: 1_640_975_400
+                }
+              ]
+            }
+          ],
+          open_hours: [
+            {
+              timezone: "America/Chicago",
+              start: "10:00",
+              end: "14:00",
+              emails: %w[one@example.com two@example.com three@example.com swag@nylas.com],
+              days: [0]
+            }
+          ],
           calendars: []
         )
       )


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
The availability methods in `CalendarCollection` were sending the list of `FreeBusy` and `OpenHours` without serializing them, which the Nylas API rejects with an error. This PR serializes them before sending it to the API. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.