### PR TITLE
v5.9.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-### Unreleased
+### 5.9.2 / 2022-05-04
 * Fix calendar availability not serializing `FreeBusy` and `OpenHours` properly
+* Fix Authentication demo app using deprecated Google scopes
 
 ### 5.9.1 / 2022-04-20
 * Add missing `phone_number` field in `Participant`

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.9.1"
+  VERSION = "5.9.2"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New `nylas` v5.9.2 release brings in the following features and changes:
* Fix calendar availability not serializing `FreeBusy` and `OpenHours` properly (#364, #363)
* Fix Authentication demo app using deprecated Google scopes (#362)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.