### PR TITLE
Fix account not filterable error

### DIFF
--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -9,6 +9,7 @@ module Nylas
     self.showable = true
     self.updatable = true
     self.destroyable = true
+    self.filterable = true
     self.auth_method = HttpClient::AuthMethod::BASIC
 
     attribute :id, :string, read_only: true

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe Nylas::Account do
-  it "is not filterable" do
-    expect(described_class).not_to be_filterable
+  it "is filterable" do
+    expect(described_class).to be_filterable
   end
 
   it "is not creatable" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
Fix account not filterable error when querying for accounts with metadata.  The following now works:

```
nylas.accounts.where(metadata_pair: { "provider": "eas" })
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.