### PR TITLE
v5.10.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-### Unreleased
+### 5.10.0 / 2022-05-10
 * Support collective and group events
+* Fix `ModelNotFilterableError` when querying for accounts with metadata
 
 ### 5.9.2 / 2022-05-04
 * Fix calendar availability not serializing `FreeBusy` and `OpenHours` properly

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.9.2"
+  VERSION = "5.10.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New `nylas` v5.10.0 release provides the following addition and fix:
* Support collective and group events (#366)
* Fix `ModelNotFilterableError` when querying for accounts with metadata (#367)


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.