### PR TITLE
Add `metadata` field to `JobStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add support for event reminders
+* Add `metadata` field to `JobStatus`
 
 ### 5.10.0 / 2022-05-10
 * Support collective and group events

--- a/lib/nylas/job_status.rb
+++ b/lib/nylas/job_status.rb
@@ -16,6 +16,7 @@ module Nylas
     attribute :status, :string, read_only: true
     attribute :created_at, :unix_timestamp, read_only: true
     attribute :reason, :string, read_only: true
+    attribute :metadata, :hash, read_only: true
 
     # Returns the status of a job as a boolean
     # @return [Boolean] If the job was successful

--- a/spec/nylas/job_status_spec.rb
+++ b/spec/nylas/job_status_spec.rb
@@ -34,7 +34,10 @@ describe Nylas::JobStatus do
         id: "test_id",
         job_status_id: "test_job_status_id",
         object: "message",
-        status: "successful"
+        status: "successful",
+        metadata: {
+          message_id: "nylas_message_id"
+        }
       )
       job_status = described_class.from_json(json, api: nil)
       expect(job_status.id).to eql "test_id"
@@ -44,6 +47,7 @@ describe Nylas::JobStatus do
       expect(job_status.created_at).to eql(Time.at(1622846160))
       expect(job_status.object).to eql "message"
       expect(job_status.status).to eql "successful"
+      expect(job_status.metadata).to eq(message_id: "nylas_message_id")
     end
   end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds a new `metadata` field to the `JobStatus` class.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.