### PR TITLE
v5.11.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.11.0 / 2022-07-08
 * Add support for event reminders
 * Add `metadata` field to `JobStatus`
 

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.10.0"
+  VERSION = "5.11.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New `nylas` v5.11.0 release provides the following addition and fix:
* Add support for event reminders (#370, #369)
* Add `metadata` field to `JobStatus` (#371)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.