### PR TITLE
TSDK-366 - Ruby SDK Hosted Authentication missing optional parameters

### DIFF
--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -35,13 +35,16 @@ module Nylas
       )
     end
 
-    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil)
+    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil,provider:nil,redirect_on_error:nil)
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,
         response_type: response_type,
-        login_hint: login_hint
+        login_hint: login_hint,
       }
+
+      params[:provider] = provider if provider
+      params[:redirect_on_error] = redirect_on_error if redirect_on_error
       params[:state] = state if state
       params[:scopes] = scopes.join(",") if scopes
 

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -43,10 +43,10 @@ module Nylas
         login_hint: login_hint,
       }
 
-      params[:provider] = provider if provider
-      params[:redirect_on_error] = redirect_on_error if redirect_on_error
       params[:state] = state if state
       params[:scopes] = scopes.join(",") if scopes
+      params[:provider] = provider if provider
+      params[:redirect_on_error] = redirect_on_error if redirect_on_error
 
       "#{api_server}/oauth/authorize?#{URI.encode_www_form(params)}"
     end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -35,12 +35,12 @@ module Nylas
       )
     end
 
-    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil,provider:nil,redirect_on_error:nil)
+    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil, provider: nil, redirect_on_error: nil)
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,
         response_type: response_type,
-        login_hint: login_hint,
+        login_hint: login_hint
       }
 
       params[:state] = state if state

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -35,7 +35,8 @@ module Nylas
       )
     end
 
-    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil, provider: nil, redirect_on_error: nil)
+    def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil,
+                           provider: nil, redirect_on_error: nil)
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -71,6 +71,30 @@ describe Nylas::API do
         expect(hosted_auth_url).to eq expected_url
       end
     end
+    context "with required and optional parameters" do
+      it "returns url for hosted_authentication with optional parameters" do 
+        api = described_class.new(app_id:"2454354")
+
+        hosted_auth_url = api.authentication_url(
+          redirect_uri: "http://example.com",
+          scopes: %w[email calendar],
+          login_hint: "email@example.com",
+          state: "some-state",
+          provider: "gmail",
+          redirect_on_error:true
+        )
+
+        expected_url="https://api.nylas.com/oauth/authorize"\
+        "?client_id=2454354"\
+        "&redirect_uri=http%3A%2F%2Fexample.com"\
+        "&response_type=code"\
+        "&login_hint=email%40example.com"\
+        "&state=some-state"\
+        "&scopes=email%2Ccalendar"\
+        "provider=gmail"\
+        "redirect_on_error=true"
+
+        expect(hosted_auth_url).to eq expected_url
 
     context "when required parameter are missing" do
       it "throws argument error if redirect uri is mising" do

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -71,9 +71,10 @@ describe Nylas::API do
         expect(hosted_auth_url).to eq expected_url
       end
     end
+
     context "with required and optional parameters" do
-      it "returns url for hosted_authentication with optional parameters" do 
-        api = described_class.new(app_id:"2454354")
+      it "returns url for hosted_authentication with optional parameters" do
+        api = described_class.new(app_id: "2454354")
 
         hosted_auth_url = api.authentication_url(
           redirect_uri: "http://example.com",
@@ -81,20 +82,21 @@ describe Nylas::API do
           login_hint: "email@example.com",
           state: "some-state",
           provider: "gmail",
-          redirect_on_error:true
+          redirect_on_error: true
         )
 
-        expected_url="https://api.nylas.com/oauth/authorize"\
+        expected_url = "https://api.nylas.com/oauth/authorize"\
         "?client_id=2454354"\
         "&redirect_uri=http%3A%2F%2Fexample.com"\
         "&response_type=code"\
         "&login_hint=email%40example.com"\
         "&state=some-state"\
         "&scopes=email%2Ccalendar"\
-        "provider=gmail"\
-        "redirect_on_error=true"
-
+        "&provider=gmail"\
+        "&redirect_on_error=true"
         expect(hosted_auth_url).to eq expected_url
+      end
+    end
 
     context "when required parameter are missing" do
       it "throws argument error if redirect uri is mising" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
Hosted Authentication method was missing the provider and redirect_on_error params. I have added them and created a simple test
JIRA --> https://nylas.atlassian.net/browse/TSDK-366
<!-- A clear and concise description of what the PR is introducing/changing. -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.