### PR TITLE
Fix calendar availability failing when `round_robin` is `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Add missing hosted authentication parameters
+* Fix calendar availability failing when `round_robin` is `nil`
+
 ### 5.11.0 / 2022-07-08
 * Add support for event reminders
 * Add `metadata` field to `JobStatus`

--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -31,18 +31,21 @@ module Nylas
       validate_calendars_or_emails(calendars, emails)
       validate_open_hours(emails, free_busy, open_hours) unless open_hours.empty?
 
-      execute_availability("/calendars/availability",
-                           duration_minutes: duration_minutes,
-                           interval_minutes: interval_minutes,
-                           start_time: start_time,
-                           end_time: end_time,
-                           emails: emails,
-                           buffer: buffer,
-                           round_robin: round_robin,
-                           event_collection_id: event_collection_id,
-                           free_busy: free_busy.map(&:to_h),
-                           open_hours: open_hours.map(&:to_h),
-                           calendars: calendars)
+      payload = {
+        duration_minutes: duration_minutes,
+        interval_minutes: interval_minutes,
+        start_time: start_time,
+        end_time: end_time,
+        emails: emails,
+        free_busy: free_busy.map(&:to_h),
+        open_hours: open_hours.map(&:to_h),
+        calendars: calendars
+      }
+      payload[:buffer] = buffer if buffer
+      payload[:round_robin] = round_robin if round_robin
+      payload[:event_collection_id] = event_collection_id if event_collection_id
+
+      execute_availability("/calendars/availability", payload)
     end
 
     # Check multiple calendars to find availability for multiple meetings with several participants
@@ -68,16 +71,19 @@ module Nylas
       validate_calendars_or_emails(emails, calendars)
       validate_open_hours(emails, free_busy, open_hours) unless open_hours.empty?
 
-      execute_availability("/calendars/availability/consecutive",
-                           duration_minutes: duration_minutes,
-                           interval_minutes: interval_minutes,
-                           start_time: start_time,
-                           end_time: end_time,
-                           emails: emails,
-                           buffer: buffer,
-                           free_busy: free_busy.map(&:to_h),
-                           open_hours: open_hours.map(&:to_h),
-                           calendars: calendars)
+      payload = {
+        duration_minutes: duration_minutes,
+        interval_minutes: interval_minutes,
+        start_time: start_time,
+        end_time: end_time,
+        emails: emails,
+        free_busy: free_busy.map(&:to_h),
+        open_hours: open_hours.map(&:to_h),
+        calendars: calendars
+      }
+      payload[:buffer] = buffer if buffer
+
+      execute_availability("/calendars/availability/consecutive", payload)
     end
 
     private

--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -45,7 +45,7 @@ module Nylas
       payload[:round_robin] = round_robin if round_robin
       payload[:event_collection_id] = event_collection_id if event_collection_id
 
-      execute_availability("/calendars/availability", payload)
+      execute_availability("/calendars/availability", **payload)
     end
 
     # Check multiple calendars to find availability for multiple meetings with several participants
@@ -83,7 +83,7 @@ module Nylas
       }
       payload[:buffer] = buffer if buffer
 
-      execute_availability("/calendars/availability/consecutive", payload)
+      execute_availability("/calendars/availability/consecutive", **payload)
     end
 
     private

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -150,7 +150,6 @@ describe Nylas::CalendarCollection do
           start_time: 1590454800,
           end_time: 1590780800,
           emails: [["one@example.com"], %w[two@example.com three@example.com]],
-          buffer: 5,
           free_busy: [
             {
               email: "swag@nylas.com",
@@ -173,7 +172,8 @@ describe Nylas::CalendarCollection do
               days: [0]
             }
           ],
-          calendars: []
+          calendars: [],
+          buffer: 5
         )
       )
     end

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -49,9 +49,6 @@ describe Nylas::CalendarCollection do
           start_time: 1590454800,
           end_time: 1590780800,
           emails: ["swag@nylas.com"],
-          buffer: 5,
-          round_robin: "max-fairness",
-          event_collection_id: "abc-123",
           free_busy: [
             {
               email: "swag@nylas.com",
@@ -74,6 +71,37 @@ describe Nylas::CalendarCollection do
               days: [0]
             }
           ],
+          calendars: [],
+          buffer: 5,
+          round_robin: "max-fairness",
+          event_collection_id: "abc-123"
+        )
+      )
+    end
+
+    it "optional params are omitted when getting single availability" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
+
+      calendar_collection.availability(
+        duration_minutes: 30,
+        interval_minutes: 5,
+        start_time: 1590454800,
+        end_time: 1590780800,
+        emails: ["swag@nylas.com"]
+      )
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/calendars/availability",
+        payload: JSON.dump(
+          duration_minutes: 30,
+          interval_minutes: 5,
+          start_time: 1590454800,
+          end_time: 1590780800,
+          emails: ["swag@nylas.com"],
+          free_busy: [],
+          open_hours: [],
           calendars: []
         )
       )
@@ -145,6 +173,34 @@ describe Nylas::CalendarCollection do
               days: [0]
             }
           ],
+          calendars: []
+        )
+      )
+    end
+
+    it "optional params are omitted when getting multiple availability" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
+
+      calendar_collection.consecutive_availability(
+        duration_minutes: 30,
+        interval_minutes: 5,
+        start_time: 1590454800,
+        end_time: 1590780800,
+        emails: [["swag@nylas.com"]]
+      )
+
+      expect(api).to have_received(:execute).with(
+        method: :post,
+        path: "/calendars/availability/consecutive",
+        payload: JSON.dump(
+          duration_minutes: 30,
+          interval_minutes: 5,
+          start_time: 1590454800,
+          end_time: 1590780800,
+          emails: [["swag@nylas.com"]],
+          free_busy: [],
+          open_hours: [],
           calendars: []
         )
       )


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR address the issue where, if `round_robin` is left as `nil`, it always yields an error. This is because the Nylas Docs were out of date for the availability endpoint. `round_robin` is optional, and when omitted, returns collective availability. However, sending `null` is not valid despite what it says in the documentation. Now, we omit the value from the json payload if the value is `nil`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.