### PR TITLE
Add `reply_to_message_id` field in `Messages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add missing hosted authentication parameters
+* Add `reply_to_message_id` field in `Messages`
 * Fix calendar availability failing when `round_robin` is `nil`
 
 ### 5.11.0 / 2022-07-08

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -37,6 +37,7 @@ module Nylas
     attribute :folder, :folder
     attribute :folder_id, :string
     attribute :metadata, :hash
+    attribute :reply_to_message_id, :string, read_only: true
     attribute :job_status_id, :string, read_only: true
 
     has_n_of_attribute :labels, :label, read_only: true

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -31,7 +31,8 @@ describe Nylas::Message do
                folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
                labels: [{ display_name: "Inbox", id: "label-inbox", name: "inbox" },
                         { display_name: "All Mail", id: "label-all", name: "all" }],
-               metadata: { key: "value" } }
+               metadata: { key: "value" },
+               reply_to_message_id: "reply-id" }
 
       message = described_class.from_json(JSON.dump(data), api: api)
       expect(message.id).to eql "mess-8766"
@@ -122,6 +123,8 @@ describe Nylas::Message do
       expect(message.labels[1].api).to be api
 
       expect(message.metadata).to include(key: "value")
+
+      expect(message.reply_to_message_id).to eql "reply-id"
     end
   end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds a a new field for messages, `reply_to_message_id`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.