### PR TITLE
v5.12.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.12.0 / 2022-07-29
 * Add missing hosted authentication parameters
 * Add `reply_to_message_id` field in `Messages`
 * Fix calendar availability failing when `round_robin` is `nil`

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.11.0"
+  VERSION = "5.12.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New `nylas` v5.12.0 release brings the following:

* Add missing hosted authentication parameters #374 
* Add `reply_to_message_id` field in `Messages` #376 
* Fix calendar availability failing when `round_robin` is `nil` #375, #373 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.