### PR TITLE
fix Collection new method to expand keyword args

### DIFF
--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -17,7 +17,7 @@ module Nylas
 
     # Instantiates a new model
     def new(**attributes)
-      model.new(attributes.merge(api: api))
+      model.new(**attributes.merge(api: api))
     end
 
     def create(**attributes)


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
ruby 3 does not automatically expand keyword arguments
the create method in this class already does double-splat expansion
this change makes the new method match and fixes a ruby 3 regression

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.