### PR TITLE
Add support for getting `count` for collections not supported by the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Unreleased
-* Add support for getting `ids` for collections not supported by the API
+* Add support for getting `ids` and `count` for collections not supported by the API
 
 ### 5.12.0 / 2022-07-29
 * Add missing hosted authentication parameters

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -13,6 +13,7 @@ module Nylas
     self.updatable = true
     self.destroyable = true
     self.id_listable = true
+    self.countable = true
 
     attribute :id, :string
     attribute :account_id, :string

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -74,7 +74,7 @@ module Nylas
         collection.constraints = collection.constraints.merge(view: "ids")
         collection.execute
       else
-        collection.execute.map { |entry| entry[:id] }
+        collection.find_each.map(&:id)
       end
     end
 

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -51,7 +51,14 @@ module Nylas
 
     # @return [Integer]
     def count
-      self.class.new(model: model, api: api, constraints: constraints.merge(view: "count")).execute[:count]
+      collection = self.class.new(model: model, api: api, constraints: constraints)
+
+      if model.countable
+        collection.constraints = collection.constraints.merge(view: "count")
+        collection.execute[:count]
+      else
+        collection.find_each.map.count
+      end
     end
 
     # @return [Collection<Model>]

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -12,6 +12,7 @@ module Nylas
     self.updatable = true
     self.destroyable = true
     self.id_listable = true
+    self.countable = true
 
     attribute :id, :string
     attribute :object, :string

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -13,6 +13,7 @@ module Nylas
     self.updatable = true
     self.destroyable = true
     self.id_listable = true
+    self.countable = true
 
     attribute :id, :string, read_only: true
     attribute :object, :string, read_only: true

--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -12,6 +12,7 @@ module Nylas
     self.filterable = true
     self.destroyable = true
     self.id_listable = true
+    self.countable = true
 
     attribute :id, :string
     attribute :account_id, :string

--- a/lib/nylas/folder.rb
+++ b/lib/nylas/folder.rb
@@ -13,6 +13,7 @@ module Nylas
     self.updatable = true
     self.destroyable = true
     self.id_listable = true
+    self.countable = true
 
     attribute :id, :string, read_only: true
     attribute :account_id, :string, read_only: true

--- a/lib/nylas/label.rb
+++ b/lib/nylas/label.rb
@@ -13,6 +13,7 @@ module Nylas
     self.updatable = true
     self.destroyable = true
     self.id_listable = true
+    self.countable = true
 
     attribute :id, :string
     attribute :account_id, :string

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -13,6 +13,7 @@ module Nylas
     self.updatable = true
     self.searchable = true
     self.id_listable = true
+    self.countable = true
     UPDATABLE_ATTRIBUTES = %i[label_ids folder_id starred unread metadata].freeze
 
     attribute :id, :string

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -20,7 +20,7 @@ module Nylas
       model.extend(ClassMethods)
       model.extend(Forwardable)
       model.def_delegators :model_class, :creatable?, :filterable?, :listable?, :searchable?, :showable?,
-                           :updatable?, :destroyable?, :id_listable?
+                           :updatable?, :destroyable?, :id_listable?, :countable?
       model.init_operations
     end
 
@@ -141,7 +141,7 @@ module Nylas
     # Allows you to narrow in exactly what kind of model you're working with
     module ClassMethods
       attr_accessor :raw_mime_type, :creatable, :showable, :filterable, :searchable, :listable, :updatable,
-                    :destroyable, :id_listable
+                    :destroyable, :id_listable, :countable
       attr_writer :resources_path, :auth_method
 
       def init_operations
@@ -153,6 +153,7 @@ module Nylas
         self.updatable = false
         self.destroyable = false
         self.id_listable = false
+        self.countable = false
       end
 
       def creatable?
@@ -185,6 +186,10 @@ module Nylas
 
       def id_listable?
         id_listable
+      end
+
+      def countable?
+        countable
       end
 
       def resources_path(*)

--- a/lib/nylas/thread.rb
+++ b/lib/nylas/thread.rb
@@ -10,6 +10,7 @@ module Nylas
     self.filterable = true
     self.updatable = true
     self.id_listable = true
+    self.countable = true
 
     self.resources_path = "/threads"
 

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -169,6 +169,7 @@ describe Nylas::Collection do
 
   describe "#count" do
     it "returns collection count" do
+      FullModel.countable = true
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
         .with(
@@ -194,6 +195,23 @@ describe Nylas::Collection do
         ).and_return(count: 1)
 
       expect(collection.where(id: "1234").count).to be 1
+    end
+
+    describe "models that are not countable" do
+      it "still returns collection count" do
+        FullModel.countable = false
+        collection = described_class.new(model: FullModel, api: api)
+        allow(api).to receive(:execute)
+          .with(
+            auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+            method: :get,
+            path: "/collection",
+            query: { limit: 100, offset: 0 },
+            headers: {}
+          ).and_return([{ id: "abc123" }])
+
+        expect(collection.count).to be 1
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This is built on #380, we enable the ability for getting the total count for every collection, regardless of their support on the API side.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.