### PR TITLE
v5.12.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-### Unreleased
+### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API
+* Fix Ruby 3.x compatibility for expanding keyword arguments
 
 ### 5.12.0 / 2022-07-29
 * Add missing hosted authentication parameters

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.12.0"
+  VERSION = "5.12.1"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New `nylas` v5.12.1 release brings the following:
* Add support for getting `ids` and `count` for collections not supported by the API (#380, #381, #378)
* Fix Ruby 3.x compatibility for expanding keyword arguments (#379)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.