### PR TITLE
Add timezone fields to the When class

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -72,6 +72,7 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
     - 'lib/nylas/http_client.rb'
+    - 'lib/nylas/when.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add timezone fields to the `When` class
+
 ### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API
 * Fix Ruby 3.x compatibility for expanding keyword arguments

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -40,6 +40,7 @@ module GemConfig
      ["awesome_print", "~> 1.0"],
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
+     ["tzinfo", ">=2.0.5"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -40,7 +40,7 @@ module GemConfig
      ["awesome_print", "~> 1.0"],
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
-     ["tzinfo", ">=2.0.5"],
+     ["tzinfo", "~> 2.0.5"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gemfiles/Gemfile.rails5
+++ b/gemfiles/Gemfile.rails5
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5'
+gem 'rails', '>= 5.2.8.1'
 
 gemspec path: "..", name: 'nylas-streaming'

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Nylas
-  # Structure to represent all the Nylas time types.
-  # @see https://docs.nylas.com/reference#section-time
   require "tzinfo"
 
+  # Structure to represent all the Nylas time types.
+  # @see https://docs.nylas.com/reference#section-time
   class When
     extend Forwardable
 

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -50,10 +50,12 @@ module Nylas
       end
     end
 
-    def validate
+    def valid?
       validate_timezone(timezone) if timezone
       validate_timezone(start_timezone) if start_timezone
       validate_timezone(end_timezone) if end_timezone
+
+      true
     end
 
     private

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -19,10 +19,13 @@ module Nylas
 
     # when object == 'time'
     attribute :time, :unix_timestamp
+    attribute :timezone, :string
 
     # when object == 'timespan'
     attribute :start_time, :unix_timestamp
     attribute :end_time, :unix_timestamp
+    attribute :start_timezone, :string
+    attribute :end_timezone, :string
 
     def_delegators :range, :cover?
 

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -3,6 +3,8 @@
 module Nylas
   # Structure to represent all the Nylas time types.
   # @see https://docs.nylas.com/reference#section-time
+  require "tzinfo"
+
   class When
     extend Forwardable
 
@@ -46,6 +48,21 @@ module Nylas
       when "time"
         Range.new(time, time)
       end
+    end
+
+    def validate
+      validate_timezone(timezone) if timezone
+      validate_timezone(start_timezone) if start_timezone
+      validate_timezone(end_timezone) if end_timezone
+    end
+
+    private
+
+    def validate_timezone(timezone_var)
+      return if TZInfo::Timezone.all_identifiers.include?(timezone_var)
+
+      raise ArgumentError,
+            format("The timezone provided (%s) is not a valid IANA timezone formatted string", timezone_var)
     end
   end
 end

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -21,11 +21,13 @@ module Nylas
 
     # when object == 'time'
     attribute :time, :unix_timestamp
+    # Timezone must be set to a valid IANA database timezone name
     attribute :timezone, :string
 
     # when object == 'timespan'
     attribute :start_time, :unix_timestamp
     attribute :end_time, :unix_timestamp
+    # Both timezone fields must be set to a valid IANA database timezone name
     attribute :start_timezone, :string
     attribute :end_timezone, :string
 
@@ -50,6 +52,9 @@ module Nylas
       end
     end
 
+    # Validates the When object
+    # @return [Boolean] True if the When is valid
+    # @raise [ArgumentError] If any of the timezone fields are not valid IANA database names
     def valid?
       validate_timezone(timezone) if timezone
       validate_timezone(start_timezone) if start_timezone
@@ -64,7 +69,7 @@ module Nylas
       return if TZInfo::Timezone.all_identifiers.include?(timezone_var)
 
       raise ArgumentError,
-            format("The timezone provided (%s) is not a valid IANA timezone formatted string", timezone_var)
+            format("The timezone provided (%s) is not a valid IANA timezone database name", timezone_var)
     end
   end
 end

--- a/spec/nylas/when_spec.rb
+++ b/spec/nylas/when_spec.rb
@@ -4,21 +4,21 @@ describe Nylas::When do
   describe "valid" do
     it "throws if a timezone is set to a non-IANA string" do
       when_obj = described_class.new(timezone: "Non IANA")
-      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone database name"
 
       expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
     end
 
     it "throws if a start_timezone is set to a non-IANA string" do
       when_obj = described_class.new(start_timezone: "Non IANA")
-      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone database name"
 
       expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
     end
 
     it "throws if a end_timezone is set to a non-IANA string" do
       when_obj = described_class.new(end_timezone: "Non IANA")
-      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone database name"
 
       expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
     end

--- a/spec/nylas/when_spec.rb
+++ b/spec/nylas/when_spec.rb
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
 describe Nylas::When do
-  describe "validate" do
+  describe "valid" do
     it "throws if a timezone is set to a non-IANA string" do
       when_obj = described_class.new(timezone: "Non IANA")
       error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
 
-      expect { when_obj.validate }.to raise_error(ArgumentError, error_msg)
+      expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
     end
 
     it "throws if a start_timezone is set to a non-IANA string" do
       when_obj = described_class.new(start_timezone: "Non IANA")
       error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
 
-      expect { when_obj.validate }.to raise_error(ArgumentError, error_msg)
+      expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
     end
 
     it "throws if a end_timezone is set to a non-IANA string" do
       when_obj = described_class.new(end_timezone: "Non IANA")
       error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
 
-      expect { when_obj.validate }.to raise_error(ArgumentError, error_msg)
+      expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
     end
 
     it "does not throw if timezone is set validly (IANA string)" do
       when_obj = described_class.new(timezone: "America/New_York")
 
-      expect { when_obj.validate }.not_to raise_error
+      expect { when_obj.valid? }.not_to raise_error
     end
 
     it "does not throw if no timezone set" do
       when_obj = described_class.new
 
-      expect { when_obj.validate }.not_to raise_error
+      expect { when_obj.valid? }.not_to raise_error
     end
   end
 end

--- a/spec/nylas/when_spec.rb
+++ b/spec/nylas/when_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe Nylas::When do
+  describe "validate" do
+    it "throws if a timezone is set to a non-IANA string" do
+      when_obj = described_class.new(timezone: "Non IANA")
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
+
+      expect { when_obj.validate }.to raise_error(ArgumentError, error_msg)
+    end
+
+    it "throws if a start_timezone is set to a non-IANA string" do
+      when_obj = described_class.new(start_timezone: "Non IANA")
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
+
+      expect { when_obj.validate }.to raise_error(ArgumentError, error_msg)
+    end
+
+    it "throws if a end_timezone is set to a non-IANA string" do
+      when_obj = described_class.new(end_timezone: "Non IANA")
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone formatted string"
+
+      expect { when_obj.validate }.to raise_error(ArgumentError, error_msg)
+    end
+
+    it "does not throw if timezone is set validly (IANA string)" do
+      when_obj = described_class.new(timezone: "America/New_York")
+
+      expect { when_obj.validate }.not_to raise_error
+    end
+
+    it "does not throw if no timezone set" do
+      when_obj = described_class.new
+
+      expect { when_obj.validate }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds the `timezone`, `start_timezone` and `end_timezone` fields. This SDK also now uses tzinfo as a dev dependency to validate the strings set by the user are indeed IANA database names.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.