### PR TITLE
Adds visibility attribute in Event.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add timezone fields to the `When` class
+* Adds visibility attribute to `Event` class
 
 ### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API
@@ -88,8 +89,8 @@
 * Add support for read only attributes
 * Add `save_all_attributes` and `update_all_attributes` methods to support
   nullifying attributes.
-* Add support new `Event` metadata feature  
-* Fix attributes assignment for `Delta`  
+* Add support new `Event` metadata feature
+* Fix attributes assignment for `Delta`
 * Fix issue where files couldn't be attached to drafts
 * Fix exception raise when content-type is not JSON
 * Fix issue where draft version wouldn't update after `update` or `save`

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -43,6 +43,7 @@ module Nylas
     attribute :reminder_minutes, :string
     attribute :reminder_method, :string
     attribute :job_status_id, :string, read_only: true
+    attribute :visibility, :string, read_only: true
 
     attr_accessor :notify_participants
 

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -43,7 +43,7 @@ module Nylas
     attribute :reminder_minutes, :string
     attribute :reminder_method, :string
     attribute :job_status_id, :string, read_only: true
-    attribute :visibility, :string, read_only: true
+    attribute :visibility, :string
 
     attr_accessor :notify_participants
 

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -55,7 +55,8 @@ describe Nylas::Event do
           minutes_before_event: "60",
           subject: "Test Event Notification",
           body: "Reminding you about our meeting."
-        }]
+        }],
+        visibility: "private"
       }
 
       event = described_class.from_json(JSON.dump(data), api: api)
@@ -97,6 +98,7 @@ describe Nylas::Event do
       expect(event.notifications[0].minutes_before_event).to be 60
       expect(event.notifications[0].subject).to eql "Test Event Notification"
       expect(event.notifications[0].body).to eql "Reminding you about our meeting."
+      expect(event.visibility).to eql "private"
     end
   end
 


### PR DESCRIPTION
This PR adds the `visibility` attribute to the `Event` class.

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.