### PR TITLE
Add support for calendar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Add timezone fields to the `When` class
 * Adds visibility attribute to `Event` class
+* Add support for calendar colors (for Microsoft calendars)
 
 ### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -40,7 +40,6 @@ module Nylas
     end
 
     def events
-      event = api.events
       api.events.where(calendar_id: id)
     end
   end

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -29,6 +29,7 @@ module Nylas
     attribute :read_only, :boolean
     attribute :metadata, :hash
     attribute :job_status_id, :string, read_only: true
+    attribute :color, :integer, read_only: true
 
     def read_only?
       read_only == true
@@ -39,6 +40,7 @@ module Nylas
     end
 
     def events
+      event = api.events
       api.events.where(calendar_id: id)
     end
   end

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -29,7 +29,7 @@ module Nylas
     attribute :read_only, :boolean
     attribute :metadata, :hash
     attribute :job_status_id, :string, read_only: true
-    attribute :color, :integer, read_only: true
+    attribute :hex_color, :string, read_only: true
 
     def read_only?
       read_only == true

--- a/spec/nylas/calendar_spec.rb
+++ b/spec/nylas/calendar_spec.rb
@@ -2,7 +2,7 @@
 
 describe Nylas::Calendar do
   describe "JSONs" do
-    let(:calendar) {
+    let(:calendar) do
       api = instance_double(Nylas::API)
       data = {
         id: "cal-8766",
@@ -22,7 +22,7 @@ describe Nylas::Calendar do
       }
 
       described_class.from_json(JSON.dump(data), api: api)
-    }
+    end
 
     it "Deserializes all the attributes into Ruby objects" do
       expect(calendar.id).to eql "cal-8766"

--- a/spec/nylas/calendar_spec.rb
+++ b/spec/nylas/calendar_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+describe Nylas::Calendar do
+  describe "JSONs" do
+    let(:calendar) {
+      api = instance_double(Nylas::API)
+      data = {
+        id: "cal-8766",
+        object: "calendar",
+        account_id: "acc-1234",
+        name: "My Calendar",
+        description: "Ruby Test Calendar",
+        location: "Ruby SDK",
+        timezone: "America/New_York",
+        job_status_id: "job-1234",
+        metadata: {
+          lang: "ruby"
+        },
+        color: 1,
+        is_primary: false,
+        read_only: true
+      }
+
+      described_class.from_json(JSON.dump(data), api: api)
+    }
+
+    it "Deserializes all the attributes into Ruby objects" do
+      expect(calendar.id).to eql "cal-8766"
+      expect(calendar.object).to eql "calendar"
+      expect(calendar.account_id).to eql "acc-1234"
+      expect(calendar.name).to eql "My Calendar"
+      expect(calendar.description).to eql "Ruby Test Calendar"
+      expect(calendar.location).to eql "Ruby SDK"
+      expect(calendar.timezone).to eql "America/New_York"
+      expect(calendar.job_status_id).to eql "job-1234"
+      expect(calendar.metadata).to eq(lang: "ruby")
+      expect(calendar.color).to be 1
+      expect(calendar.is_primary).to be false
+      expect(calendar.read_only).to be true
+    end
+
+    it "Serializes all non-read only attributes for the API" do
+      expected_json = {
+        id: "cal-8766",
+        account_id: "acc-1234",
+        object: "calendar",
+        name: "My Calendar",
+        description: "Ruby Test Calendar",
+        is_primary: false,
+        location: "Ruby SDK",
+        timezone: "America/New_York",
+        read_only: true,
+        metadata: {
+          lang: "ruby"
+        }
+      }.to_json
+
+      json = calendar.attributes.serialize_for_api
+
+      expect(json).to eql expected_json
+    end
+  end
+
+  describe "read on" do
+    it "Serializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API)
+      data = {
+        id: "cal-8766",
+        object: "calendar",
+        account_id: "acc-1234",
+        name: "My Calendar",
+        description: "Ruby Test Calendar",
+        location: "Ruby SDK",
+        timezone: "America/New_York",
+        job_status_id: "job-1234",
+        metadata: {
+          lang: "ruby"
+        },
+        color: 1,
+        is_primary: false,
+        read_only: true
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar.id).to eql "cal-8766"
+      expect(calendar.object).to eql "calendar"
+      expect(calendar.account_id).to eql "acc-1234"
+      expect(calendar.name).to eql "My Calendar"
+      expect(calendar.description).to eql "Ruby Test Calendar"
+      expect(calendar.location).to eql "Ruby SDK"
+      expect(calendar.timezone).to eql "America/New_York"
+      expect(calendar.job_status_id).to eql "job-1234"
+      expect(calendar.metadata).to eq(lang: "ruby")
+      expect(calendar.color).to be 1
+      expect(calendar.is_primary).to be false
+      expect(calendar.read_only).to be true
+    end
+  end
+
+  describe "#read_only?" do
+    it "returns true when read_only attribute from API return true" do
+      api = instance_double(Nylas::API)
+      data = {
+        read_only: true
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).to be_read_only
+    end
+
+    it "returns false when read_only attribute from API return false" do
+      api = instance_double(Nylas::API)
+      data = {
+        read_only: false
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).not_to be_read_only
+    end
+  end
+
+  describe "#primary?" do
+    it "returns true when is_primary attribute from API return true" do
+      api = instance_double(Nylas::API)
+      data = {
+        is_primary: true
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).to be_primary
+    end
+
+    it "returns false when is_primary attribute from API return false" do
+      api = instance_double(Nylas::API)
+      data = {
+        is_primary: false
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).not_to be_primary
+    end
+  end
+
+  describe "#events" do
+    it "sets the constraints properly for getting child events" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      events = Nylas::EventCollection.new(model: Nylas::Event, api: api)
+      allow(api).to receive(:events).and_return(events)
+      data = {
+        id: "cal-123"
+      }
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      event_collection = calendar.events
+
+      expect(event_collection).to be_a Nylas::EventCollection
+
+      event_collection.execute
+
+      expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        headers: {},
+        method: :get,
+        path: "/events",
+        query: { calendar_id: "cal-123", limit: 100, offset: 0 }
+      )
+    end
+  end
+end

--- a/spec/nylas/calendar_spec.rb
+++ b/spec/nylas/calendar_spec.rb
@@ -16,7 +16,7 @@ describe Nylas::Calendar do
         metadata: {
           lang: "ruby"
         },
-        color: 1,
+        hex_color: "#0099EE",
         is_primary: false,
         read_only: true
       }
@@ -34,7 +34,7 @@ describe Nylas::Calendar do
       expect(calendar.timezone).to eql "America/New_York"
       expect(calendar.job_status_id).to eql "job-1234"
       expect(calendar.metadata).to eq(lang: "ruby")
-      expect(calendar.color).to be 1
+      expect(calendar.hex_color).to eql "#0099EE"
       expect(calendar.is_primary).to be false
       expect(calendar.read_only).to be true
     end
@@ -76,7 +76,7 @@ describe Nylas::Calendar do
         metadata: {
           lang: "ruby"
         },
-        color: 1,
+        hex_color: "#0099EE",
         is_primary: false,
         read_only: true
       }
@@ -92,7 +92,7 @@ describe Nylas::Calendar do
       expect(calendar.timezone).to eql "America/New_York"
       expect(calendar.job_status_id).to eql "job-1234"
       expect(calendar.metadata).to eq(lang: "ruby")
-      expect(calendar.color).to be 1
+      expect(calendar.hex_color).to eql "#0099EE"
       expect(calendar.is_primary).to be false
       expect(calendar.read_only).to be true
     end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds support for the new colors field in the Calendar model. Please note that this field is read only, and for Microsoft calendars only.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.