### PR TITLE
Build middleware infrastructure for use cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,11 @@ Metrics/ParameterLists:
 Metrics/MethodLength:
   Exclude:
     - "lib/nylas/calendar_collection.rb"
+    - "lib/nylas/services/tunnel.rb"
+
+Metrics/AbcSize:
+  Exclude:
+    - "lib/nylas/services/tunnel.rb"
 
 Metrics/ModuleLength:
   Exclude:

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -41,6 +41,7 @@ module GemConfig
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
      ["tzinfo", "~> 2.0.5"],
+     ["rack", "~> 2.0.1"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -42,6 +42,8 @@ module GemConfig
      ["rubocop-rspec", "~> 2.7.0"],
      ["tzinfo", "~> 2.0.5"],
      ["rack", "~> 2.0.1"],
+     ["eventmachine", "~> 1.2.7"],
+     ["faye-websocket", "~> 0.11.1"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -119,6 +119,7 @@ require_relative "nylas/filter_attributes"
 
 # Middleware specific
 require_relative "nylas/services/routes"
+require_relative "nylas/server-bindings/rack_binding"
 
 # an SDK for interacting with the Nylas API
 # @see https://docs.nylas.com/reference

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -116,6 +116,10 @@ require_relative "nylas/scheduler_booking_confirmation"
 require_relative "nylas/native_authentication"
 
 require_relative "nylas/filter_attributes"
+
+# Middleware specific
+require_relative "nylas/services/routes"
+
 # an SDK for interacting with the Nylas API
 # @see https://docs.nylas.com/reference
 module Nylas

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -120,6 +120,7 @@ require_relative "nylas/filter_attributes"
 # Middleware specific
 require_relative "nylas/services/routes"
 require_relative "nylas/server-bindings/rack_binding"
+require_relative "nylas/services/tunnel"
 
 # an SDK for interacting with the Nylas API
 # @see https://docs.nylas.com/reference

--- a/lib/nylas/server-bindings/rack_binding.rb
+++ b/lib/nylas/server-bindings/rack_binding.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Nylas
+  # Build a Rack middleware binding with routes for:
+  #  1. '/nylas/generate-auth-url': Building the URL for authenticating users to your app via Hosted Auth
+  #  2. '/nylas/exchange-mailbox-token': Exchange an authorization code for an access token
+  class RackBinding
+    # @param app [Rack::Builder] The Rack app
+    # @param nylas [Nylas::API] The configured Nylas API client
+    # @param default_scopes [Array<String>] Authentication scopes to request from the authenticating user
+    # @param exchange_mailbox_token_callback [Method] The callback method that takes the access token response
+    #   and returns an API value
+    # @param client_uri [String] The route of the client
+    # @param build_auth_url [String] Override URL of building the Nylas hosted auth URL
+    # @param exchange_code_for_token_url [String] Override URL of exchanging the auth code for access token
+    def initialize(
+      app,
+      nylas,
+      default_scopes,
+      exchange_mailbox_token_callback,
+      client_uri: nil,
+      build_auth_url: nil,
+      exchange_code_for_token_url: nil
+    )
+      @app = app
+      @nylas = nylas
+      @nylas_routes = Nylas::Routes.new(nylas)
+      @default_scopes = default_scopes
+      @exchange_mailbox_token_callback = exchange_mailbox_token_callback
+      @client_uri = client_uri || ""
+      @build_auth_url = build_auth_url || Nylas::DefaultPaths::BUILD_AUTH_URL
+      @exchange_code_for_token_url =
+        exchange_code_for_token_url || Nylas::DefaultPaths::EXCHANGE_CODE_FOR_TOKEN
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+
+      if env["PATH_INFO"] == @build_auth_url
+        build_auth_url(JSON.parse(request.body.read))
+      elsif env["PATH_INFO"] == @exchange_code_for_token_url
+        exchange_code_for_token(JSON.parse(request.body.read))
+      else
+        @app.call(env)
+      end
+    end
+
+    private
+
+    def build_auth_url(params)
+      url = @nylas_routes.build_auth_url(
+        scopes: @default_scopes,
+        email_address: params["email_address"] || "",
+        success_url: params["success_url"] || "",
+        client_uri: @client_uri
+      )
+
+      [200, { "Content-Type" => "text/plain" }, [url]]
+    end
+
+    def exchange_code_for_token(params)
+      access_token = @nylas_routes.exchange_code_for_token(params["token"])
+
+      if @exchange_mailbox_token_callback.respond_to? :call
+        @exchange_mailbox_token_callback.call(access_token)
+      else
+        [200, { "Content-Type" => "application/json" }, [access_token.to_json]]
+      end
+    end
+  end
+end

--- a/lib/nylas/services/routes.rb
+++ b/lib/nylas/services/routes.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Collection of helpful routes to be integrated into Ruby servers to simplify integration with Nylas
+module Nylas
+  # This is an Enum representing the default paths the Nylas backend middlewares
+  # and frontend SDKs are preconfigured to
+  module DefaultPaths
+    BUILD_AUTH_URL = "/nylas/generate-auth-url"
+    EXCHANGE_CODE_FOR_TOKEN = "/nylas/exchange-mailbox-token"
+    WEBHOOKS = "/nylas/webhook"
+  end
+
+  # Collection of helpful routes to be integrated into Ruby servers to simplify integration with Nylas
+  class Routes
+    attr_accessor :api
+
+    # @param api [Nylas::API]
+    # @return [Nylas::Routes]
+    def initialize(api)
+      self.api = api
+    end
+
+    # Build the URL for authenticating users to your application via Hosted Authentication
+    # @param scopes [Array<String>] Authentication scopes to request from the authenticating user
+    # @param email_address [String] The user's email address
+    # @param success_url [String] The URI to which the user will be redirected once authentication completes
+    # @param client_uri [String] The route of the client
+    # @param state [String] An optional arbitrary string that is returned as a URL param in your redirect URI
+    # @return [String] The URL for hosted authentication
+    def build_auth_url(scopes:, email_address:, success_url: "", client_uri: "", state: nil)
+      api.authentication_url(
+        redirect_uri: client_uri + success_url,
+        scopes: scopes,
+        login_hint: email_address,
+        state: state
+      )
+    end
+
+    # Exchange an authorization code for an access token
+    # @param code [String] One-time authorization code from Nylas
+    # @return [Hash] The object containing the access token and other information
+    def exchange_code_for_token(code)
+      api.exchange_code_for_token(code, return_full_response: true)
+    end
+
+    # Verify incoming webhook signature came from Nylas
+    # @param nylas_signature [String] The signature to verify
+    # @param raw_body [String] The raw body from the payload
+    # @return [Boolean] True if the webhook signature was verified from Nylas
+    def verify_webhook_signature(nylas_signature, raw_body)
+      nylas_signature == OpenSSL::HMAC.hexdigest("SHA256", api.client.app_secret, raw_body)
+    end
+  end
+end

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "faye/websocket"
+require "eventmachine"
+
+module Nylas
+  # Class containing methods to spin up a developmental websocket connection to test webhooks
+  class Tunnel
+    # Open a webhook tunnel and register it with the Nylas API
+    # 1. Creates a UUID
+    # 2. Opens a websocket connection to Nylas' webhook forwarding service, with the UUID as a header
+    # 3. Creates a new webhook pointed at the forwarding service with the UUID as the path
+    # When an event is received by the forwarding service, it will push directly to this websocket connection
+    #
+    # @param api [Nylas::API] The configured Nylas API client
+    # @param config [Hash] Configuration for the webhook tunnel, including callback functions, region, and
+    #   events to subscribe to
+    def self.open_webhook_tunnel(api, config = nil)
+      tunnel_id = SecureRandom.uuid
+      triggers = config[:triggers]
+      region = config[:region]
+      websocket_domain = "tunnel.nylas.com"
+      callback_domain = "cb.nylas.com"
+
+      EM.run do
+        setup_websocket_client(websocket_domain, api, tunnel_id, region, config)
+        register_webhook_callback(api, callback_domain, tunnel_id, triggers)
+      end
+    end
+
+    # Register callback with the Nylas forwarding service which will pass messages to the websocket
+    # @param api [Nylas::API] The configured Nylas API client
+    # @param callback_domain [String] The domain name of the callback
+    # @param tunnel_path [String] The path to the tunnel
+    # @param triggers [Array<WebhookTrigger>] The list of triggers to subscribe to
+    # @return [Nylas::Webhook] The webhook details response from the API
+    def self.register_webhook_callback(api, callback_domain, tunnel_path, triggers)
+      callback_url = "https://#{callback_domain}/#{tunnel_path}"
+
+      api.webhooks.create(
+        callback_url: callback_url,
+        state: WebhookState::ACTIVE,
+        triggers: triggers
+      )
+    end
+
+    # Setup the websocket client and register the callbacks
+    # @param websocket_domain [String] The domain of the websocket to connect to
+    # @param api [Nylas::API] The configured Nylas API client
+    # @param tunnel_id [String] The ID of the tunnel
+    # @param region [String] The Nylas region to configure for
+    # @param config [Hash] The object containing all the callback methods
+    def self.setup_websocket_client(websocket_domain, api, tunnel_id, region, config)
+      ws = Faye::WebSocket::Client.new(
+        "wss://#{websocket_domain}",
+        [],
+        {
+          headers: {
+            "Client-Id" => api.client.app_id,
+            "Client-Secret" => api.client.app_secret,
+            "Tunnel-Id" => tunnel_id,
+            "Region" => region
+          }
+        }
+      )
+
+      ws.on :open do |event|
+        config[:on_open].call(event) if callable(config[:on_open])
+      end
+
+      ws.on :close do |close|
+        config[:on_close].call(close) if callable(config[:on_close])
+        EM.stop
+      end
+
+      ws.on :error do |error|
+        config[:on_error].call(error) if callable(config[:on_error])
+      end
+
+      ws.on :message do |message|
+        json = JSON.parse(message.data)
+        deltas = JSON.parse(json["body"])["deltas"]
+        next if deltas.nil?
+
+        deltas.each do |delta|
+          object_data = delta.delete("object_data")
+          delta = delta.merge(object_data).transform_keys(&:to_sym)
+          config[:on_message].call(Delta.new(**delta)) if callable(config[:on_message])
+        end
+      end
+    end
+
+    # Check if the object is a method
+    # @param obj [Any] The object to check
+    # @return [Boolean] True if the object is a method
+    def self.callable(obj)
+      !obj.nil? && obj.respond_to?(:call)
+    end
+
+    private_class_method :build_webhook_tunnel, :setup_websocket_client, :callable
+  end
+end


### PR DESCRIPTION
# Description
This PR lays the foundation for the Ruby SDK to build middleware to integrate into your backend application with routes to some endpoints that would help with integrating authentication and webhook event. Currently provided routes:
*  `/nylas/generate-auth-url` - Endpoint that takes an optional email address and success redirect path, returns a URL used for authentication
*  `/nylas/exchange-mailbox-token` - Endpoint that takes a token from the JSON and exchanges that code for token, then calls a user-defined callback

This PR also includes additional integration with a Rack middleware that has these routes built in, making it only a one line addition to your already existing Rails, Sinatra, etc. application.

# Usage
Here's an example application that uses the provided routes to handle a token exchange event:

```ruby
nylas = Nylas::API.new(
    app_id: CLIENT_ID,
    app_secret: CLIENT_SECRET
)

routes = Nylas::Routes.new(nylas)
server = TCPServer.new('localhost', 1337)

#Accept Incoming Connections
loop do
  client = server.accept
  client = server.accept
  first_line = client.gets
  method_token, target, version_number = first_line.split
  response_message = ""

  # Read the HTTP request. We know it's finished when we see a line with nothing but \r\n
  request_headers = {}
  while (line = client.gets) && (line != "\r\n" && line != "")
    line = line.split(' ', 2)
    request_headers[line[0].chop] = line[1].strip
  end
  data = client.read(request_headers["Content-Length"].to_i)
  if request_headers["Content-Type"] == "application/json"
    require 'json'
    data = JSON.parse(data)
  end

  case [method_token, target]
  when ["POST", Nylas::DefaultPaths::BUILD_AUTH_URL]
    response_status_code = "200 OK"
    content_type = "text/plain"
    response_message = routes.build_auth_url(
                         scopes: ['email.read_only'],
                         email_address: data["email_address"],
                         success_url: data["success_url"],
                         client_uri: "http://localhost:3000")

  when ["POST", Nylas::DefaultPaths::EXCHANGE_CODE_FOR_TOKEN]
    response_status_code = "200 OK"
    content_type = "application/json"
    token_info = routes.exchange_code_for_token(data["code"])
    response_message = {
      access_token: token_info[:access_token]
    }.to_json
  else
    response_status_code = "200 OK"
    response_message =  "✅ Received a #{method_token} request to #{target} with #{version_number}"
    content_type = "text/plain"
  end

  # Construct the HTTP Response
  http_response = "#{version_number} #{response_status_code}\r\nContent-Type: #{content_type}\r\n\r\n#{response_message}"

  client.puts http_response
  client.close
end

server.close
```

Here's an example of the above, if it were integrated using the Rack middleware in a Rails app:

```ruby
module RailsExample
  class Application < Rails::Application
    # Initialize configuration defaults for originally generated Rails version.
    config.load_defaults 7.0
    
    def exchange_mailbox_token_callback(access_token)
      [200, { 'Content-Type' => 'application/json' }, [ { access_token: access_token[:access_token], email_address: access_token[:email_address] }.to_json ]]
    end

    nylas = Nylas::API.new(
      app_id: CLIENT_ID,
      app_secret: CLIENT_SECRET
    )
    config.middleware.use Nylas::RackBinding, nylas, ['email.read_only'], method(:exchange_mailbox_token_callback), client_uri: 'http://localhost:3000'

  end
end
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.