### PR TITLE
Add Rate Limit error support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tags
 TAGS
 *.swp
 vendor/
+out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added support for rate limit errors
+
 ### 5.13.0 / 2022-10-21
 * Add timezone fields to the `When` class
 * Adds visibility attribute to `Event` class

--- a/lib/nylas/errors.rb
+++ b/lib/nylas/errors.rb
@@ -45,7 +45,45 @@ module Nylas
       self.message = message
       self.server_error = server_error
     end
+
+  # Error class representing a 429 error response, with details on the rate limit
+  class RateLimitError < APIError
+    attr_accessor :rate_limit
+    attr_accessor :rate_limit_reset
+
+    RATE_LIMIT_LIMIT_HEADER = "x_ratelimit_limit"
+    RATE_LIMIT_RESET_HEADER = "x_ratelimit_reset"
+
+    def initialize(type, message, server_error = nil, rate_limit = nil, rate_limit_reset = nil)
+      super(type, message, server_error)
+      self.rate_limit = rate_limit
+      self.rate_limit_reset = rate_limit_reset
+    end
+
+    def self.parse_error_response(response)
+      rate_limit, rate_limit_rest = extract_rate_limit_details(response)
+
+      new(
+        response["type"],
+        response["message"],
+        response["server_error"],
+        rate_limit,
+        rate_limit_rest
+      )
+    end
+
+    def self.extract_rate_limit_details(response)
+      return nil, nil unless response.respond_to?(:headers)
+
+      rate_limit = response.headers[RATE_LIMIT_LIMIT_HEADER.to_sym].to_i
+      rate_limit_rest = response.headers[RATE_LIMIT_RESET_HEADER.to_sym].to_i
+
+      [rate_limit, rate_limit_rest]
+    end
+
+    private_class_method :extract_rate_limit_details
   end
+
   AccessDenied = Class.new(APIError)
   ResourceNotFound = Class.new(APIError)
   MethodNotAllowed = Class.new(APIError)
@@ -55,7 +93,7 @@ module Nylas
   TeapotError = Class.new(APIError)
   RequestTimedOut = Class.new(APIError)
   MessageRejected = Class.new(APIError)
-  SendingQuotaExceeded = Class.new(APIError)
+  SendingQuotaExceeded = Class.new(RateLimitError)
   ServiceUnavailable = Class.new(APIError)
   BadGateway = Class.new(APIError)
   InternalError = Class.new(APIError)

--- a/lib/nylas/errors.rb
+++ b/lib/nylas/errors.rb
@@ -46,6 +46,15 @@ module Nylas
       self.server_error = server_error
     end
 
+    def self.parse_error_response(response)
+      new(
+        response["type"],
+        response["message"],
+        response["server_error"]
+      )
+    end
+  end
+
   # Error class representing a 429 error response, with details on the rate limit
   class RateLimitError < APIError
     attr_accessor :rate_limit

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -224,16 +224,20 @@ module Nylas
       exception = HTTP_CODE_TO_EXCEPTIONS.fetch(http_code, APIError)
       case response
       when Hash
-        raise exception.new(
-          response[:type],
-          response[:message],
-          response.fetch(:server_error, nil)
-        )
+        raise error_hash_to_exception(exception, response)
       when RestClient::Response
         raise exception.parse_error_response(response)
       else
         raise exception.new(http_code, response)
       end
+    end
+
+    def error_hash_to_exception(exception, response)
+      exception.new(
+        response[:type],
+        response[:message],
+        response.fetch(:server_error, nil)
+      )
     end
 
     def add_query_params_to_url(url, query)

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -157,25 +157,6 @@ describe Nylas::HttpClient do
                                 rate_limit_reset: 10
                               )))
     end
-
-    it "handles hash responses and parses the error properly" do
-      error_hash = {
-        message: "Too many requests",
-        type: "invalid_request_error"
-      }
-      response = {
-        response: error_hash,
-        request: {},
-        result: {
-          code: 400
-        }
-      }
-
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
-      allow(nylas).to receive(:rest_client_execute).and_return(response)
-
-      expect { nylas.execute(method: :get, path: "/contacts") }.to raise_error(Nylas::InvalidRequest)
-    end
   end
 
   describe "building URL with query params" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds support for rate limit 429 headers from the API.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.