### PR TITLE
Add support for async send using the sendnow query parameter

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -34,6 +34,7 @@ module Nylas
     attribute :starred, :boolean
     attribute :unread, :boolean
     attribute :metadata, :hash
+    attribute :sendnow, :boolean
 
     has_n_of_attribute :events, :event
     has_n_of_attribute :files, :file, read_only: true
@@ -64,11 +65,12 @@ module Nylas
     end
 
     def send!
-      return execute(method: :post, path: "/send", payload: to_json) unless id
+      query = sendnow ? { sendnow: sendnow } : {}
+      return execute(method: :post, path: "/send", payload: to_json, query: query) unless id
 
       data = { draft_id: id, version: version }
       data[:tracking] = tracking.to_h if tracking
-      execute(method: :post, path: "/send", payload: JSON.dump(data))
+      execute(method: :post, path: "/send", payload: JSON.dump(data), query: query)
     end
 
     def starred?

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -21,7 +21,7 @@ module Nylas
     attribute :body, :string
     attribute :reply_to_message_id, :string
     attribute :metadata, :hash
-    has_n_of_attribute :sendnow, :boolean
+    attribute :sendnow, :boolean
 
     has_n_of_attribute :file_ids, :string
 

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -21,6 +21,7 @@ module Nylas
     attribute :body, :string
     attribute :reply_to_message_id, :string
     attribute :metadata, :hash
+    has_n_of_attribute :sendnow, :boolean
 
     has_n_of_attribute :file_ids, :string
 
@@ -30,7 +31,8 @@ module Nylas
     # @return [Message] The sent message
     # @raise [RuntimeError] if the API response data was not a hash
     def send!
-      message_data = api.execute(method: :post, path: "/send", payload: to_json)
+      query = sendnow ? { sendnow: sendnow } : {}
+      message_data = api.execute(method: :post, path: "/send", payload: to_json, query: query)
       raise "Unexpected response from the server, data received not a Message" unless message_data.is_a?(Hash)
 
       Message.from_hash(message_data, api: api)


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description

Add support for async message sending using the sendnow query parameter

https://developer.nylas.com/docs/connectivity/email/outbox-guide/#sending-messages
<!-- A clear and concise description of what the PR is introducing/changing. -->

# License
I confirm that this contribution is made under the terms of the MIT license and
that I have the authority necessary to make this contribution on behalf of its
copyright owner.
