### PR TITLE
Skip creating instance of StringIO before parsing JSON

### DIFF
--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -189,8 +189,7 @@ module Nylas
     def parse_response(response)
       return response if response.is_a?(Enumerable)
 
-      json = StringIO.new(response)
-      Yajl::Parser.new(symbolize_names: true).parse(json)
+      Yajl::Parser.new(symbolize_names: true).parse(response)
     rescue Yajl::ParseError
       raise Nylas::JsonParseError
     end


### PR DESCRIPTION
# Description
Removes creating an instance of `StringIO` before passing the Nylas API response to the JSON parser.

Recently ran into into an issue when trying to fetch some bigger email messages. The requests were taking longer than expected but only when fetching via the Ruby SDK. A request via the Ruby SDK would take a couple of minutes to fetch these messages while a request directly via cURL for the same messages would only take a few seconds.
This change, as far as I can tell, implies no loss in functionality.

Some quick benchmark results of fetching one of the troublesome email messages before and after this change:

```ruby
Benchmark.measure { nylas.messages.find('...') }
```

## Before
```ruby
<Benchmark::Tms:0x000000010293a500
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=89.72193600004539,
 @stime=0.454271,
 @total=87.57788400000001,
 @utime=87.123613>
```

## After
```ruby
<Benchmark::Tms:0x00000001099a8210
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=1.1800639999564737,
 @stime=0.023003999999999983,
 @total=0.14577099999999998,
 @utime=0.12276699999999999>
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.