### PR TITLE
Issue-394: Add disable_provider_selection kwarg to Api.authentication_url

### DIFF
--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -36,7 +36,7 @@ module Nylas
     end
 
     def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil,
-                           provider: nil, redirect_on_error: nil)
+                           provider: nil, redirect_on_error: nil, disable_provider_selection: nil)
       params = {
         client_id: app_id,
         redirect_uri: redirect_uri,
@@ -48,6 +48,7 @@ module Nylas
       params[:scopes] = scopes.join(",") if scopes
       params[:provider] = provider if provider
       params[:redirect_on_error] = redirect_on_error if redirect_on_error
+      params[:disable_provider_selection] = disable_provider_selection if disable_provider_selection
 
       "#{api_server}/oauth/authorize?#{URI.encode_www_form(params)}"
     end

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -82,7 +82,8 @@ describe Nylas::API do
           login_hint: "email@example.com",
           state: "some-state",
           provider: "gmail",
-          redirect_on_error: true
+          redirect_on_error: true,
+          disable_provider_selection: true
         )
 
         expected_url = "https://api.nylas.com/oauth/authorize"\
@@ -93,7 +94,8 @@ describe Nylas::API do
         "&state=some-state"\
         "&scopes=email%2Ccalendar"\
         "&provider=gmail"\
-        "&redirect_on_error=true"
+        "&redirect_on_error=true"\
+        "&disable_provider_selection=true"
         expect(hosted_auth_url).to eq expected_url
       end
     end


### PR DESCRIPTION
# Description
We need the option to disable the "Select different provider" button in Nylas' hosted auth when we are trying to authenticate against a specific provider. This is necessary to prevent our users from escaping the intended auth flow and selecting a provider that we do not support.

This commit addresses this need by adding and optional keyword argument to the Api.authentication_url method and, if it is provided, including it in the params payload appended on the call to the /oauth/authorize endpoint. Tests have been added to account for this change and I tested it locally to confirm that the "Select different provider" button was no longer visible when I included disable_provider_selection: true in my call to the authentication_url method.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.