### PR TITLE
v5.14.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-### Unreleased
+### 5.14.0 / 2022-12-16
 * Added support for rate limit errors
+* Added `disable_provider_selection` option for building auth URL
+* Improved performance by skipping creating instance of StringIO before parsing JSON
 
 ### 5.13.0 / 2022-10-21
 * Add timezone fields to the `When` class

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.13.0"
+  VERSION = "5.14.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New `nylas` v5.14.0 release brings the following:
* Added support for rate limit errors (#389)
* Added `disable_provider_selection` option for building auth URL (#395)
* Improved performance by skipping creating instance of StringIO before parsing JSON (#393)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.