### PR TITLE
Rename credential variable names to current naming notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 6.0.0 / TBD
+* **BREAKING CHANGE:** Rename credential variable names to current naming notation
+
 ### 5.14.0 / 2022-12-16
 * Added support for rate limit errors
 * Added `disable_provider_selection` option for building auth URL

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ All of the functionality of the Nylas Communications Platform is available throu
 require 'nylas'
 
 nylas = Nylas::API.new(
-    app_id: CLIENT_ID,
-    app_secret: CLIENT_SECRET,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
     access_token: ACCESS_TOKEN
 )
 ```

--- a/examples/authentication/app.rb
+++ b/examples/authentication/app.rb
@@ -24,7 +24,7 @@ end
   send(method, "/auth/:provider/callback") do
     auth_hash = env['omniauth.auth'] # => OmniAuth::AuthHash
 
-    api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
+    api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'])
     nylas_token = api.authenticate(name: auth_hash[:info][:name], email_address: auth_hash[:info][:email],
                                    provider: :gmail,
                                    settings: { google_client_id: ENV['GOOGLE_CLIENT_ID'],

--- a/examples/plain-ruby/accounts.rb
+++ b/examples/plain-ruby/accounts.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving the account information for given access token

--- a/examples/plain-ruby/calendars.rb
+++ b/examples/plain-ruby/calendars.rb
@@ -3,7 +3,7 @@ require_relative '../helpers'
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Calendar API.
 # See https://docs.nylas.com/reference#calendars
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 

--- a/examples/plain-ruby/components.rb
+++ b/examples/plain-ruby/components.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'])
 
 # Create a component
 # NOTE: you will need to set the account_id and the access_token

--- a/examples/plain-ruby/contacts.rb
+++ b/examples/plain-ruby/contacts.rb
@@ -1,7 +1,7 @@
 require_relative '../helpers'
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 # Retrieving a count of contacts
 demonstrate { api.contacts.count }

--- a/examples/plain-ruby/deltas.rb
+++ b/examples/plain-ruby/deltas.rb
@@ -3,7 +3,7 @@ require_relative '../helpers'
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas #
 # Deltas API.
 # See https://docs.nylas.com/reference#deltas
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 

--- a/examples/plain-ruby/drafts.rb
+++ b/examples/plain-ruby/drafts.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Drafts API. See https://docs.nylas.com/reference#drafts for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Creating a draft

--- a/examples/plain-ruby/events.rb
+++ b/examples/plain-ruby/events.rb
@@ -3,7 +3,7 @@ require_relative '../helpers'
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Events API.
 # See https://docs.nylas.com/reference#events
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Counting the events

--- a/examples/plain-ruby/files.rb
+++ b/examples/plain-ruby/files.rb
@@ -3,7 +3,7 @@ require_relative '../helpers'
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas Files
 # API.
 # See https://docs.nylas.com/reference#files
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Listing files

--- a/examples/plain-ruby/folders.rb
+++ b/examples/plain-ruby/folders.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_FOLDER_USERS_ACCESS_TOKEN'])
 
 # Retrieving the count of folders

--- a/examples/plain-ruby/job_status.rb
+++ b/examples/plain-ruby/job_status.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Drafts API. See https://docs.nylas.com/reference#drafts for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Getting all job statuses

--- a/examples/plain-ruby/labels.rb
+++ b/examples/plain-ruby/labels.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving the count of labels

--- a/examples/plain-ruby/messages.rb
+++ b/examples/plain-ruby/messages.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Messages API. See https://docs.nylas.com/reference#messages for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving a count of messages

--- a/examples/plain-ruby/neural.rb
+++ b/examples/plain-ruby/neural.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 message_id = api.messages.first.id

--- a/examples/plain-ruby/outbox.rb
+++ b/examples/plain-ruby/outbox.rb
@@ -3,7 +3,7 @@ require 'date'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Prepare the draft and timestamps

--- a/examples/plain-ruby/room_resource.rb
+++ b/examples/plain-ruby/room_resource.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving a list of room resources

--- a/examples/plain-ruby/scheduler.rb
+++ b/examples/plain-ruby/scheduler.rb
@@ -3,7 +3,7 @@ require_relative '../helpers'
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Scheduler API.
 # See https://developer.nylas.com/docs/api/scheduler/#overview
-nylas = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+nylas = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Create a scheduler page

--- a/examples/plain-ruby/sending-messages.rb
+++ b/examples/plain-ruby/sending-messages.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to send messages via the API
 # See https://docs.nylas.com/reference#sending
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Sending a message as a hash

--- a/examples/plain-ruby/streaming.rb
+++ b/examples/plain-ruby/streaming.rb
@@ -16,7 +16,7 @@ def interactive_stream(include_types: [], exclude_types: [])
     end
     Signal.trap("TERM") { EventMachine.stop }
 
-    api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+    api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                          access_token: ENV['NYLAS_ACCESS_TOKEN'])
     Nylas::Streaming.deltas(api: api, cursor: ENV['NYLAS_PREVIOUS_CURSOR'],
                             include_types: include_types, exclude_types: exclude_types) do |delta|

--- a/examples/plain-ruby/threads.rb
+++ b/examples/plain-ruby/threads.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
 # follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 

--- a/examples/plain-ruby/webhooks.rb
+++ b/examples/plain-ruby/webhooks.rb
@@ -2,7 +2,7 @@ require_relative '../helpers'
 
 # An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
 # Webhooks API. See https://docs.nylas.com/reference#webhooks for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
+api = Nylas::API.new(client_id: ENV['NYLAS_APP_ID'], client_secret: ENV['NYLAS_APP_SECRET'])
 
 
 # Webhooks can be retrieved as a collection

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -50,7 +50,7 @@ module Nylas
     end
 
     def self.resources_path(api:)
-      "/a/#{api.app_id}/accounts"
+      "/a/#{api.client_id}/accounts"
     end
   end
 end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -6,7 +6,7 @@ module Nylas
     attr_accessor :client
 
     extend Forwardable
-    def_delegators :client, :execute, :get, :post, :put, :delete, :app_id, :api_server
+    def_delegators :client, :execute, :get, :post, :put, :delete, :client_id, :api_server
 
     include Logging
 
@@ -37,7 +37,7 @@ module Nylas
 
     def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil,
                            provider: nil, redirect_on_error: nil, disable_provider_selection: nil)
-      params = { client_id: app_id, redirect_uri: redirect_uri, response_type: response_type,
+      params = { client_id: client_id, redirect_uri: redirect_uri, response_type: response_type,
                  login_hint: login_hint }
 
       params[:state] = state if state

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -11,15 +11,15 @@ module Nylas
     include Logging
 
     # @param client [HttpClient] Http Client to use for retrieving data
-    # @param app_id [String] Your application id from the Nylas Dashboard
-    # @param app_secret [String] Your application secret from the Nylas Dashboard
+    # @param client_id [String] Your application's client ID from the Nylas Dashboard
+    # @param client_secret [String] Your application's client secret from the Nylas Dashboard
     # @param access_token [String] (Optional) Your users access token.
     # @param api_server [String] (Optional) Which Nylas API Server to connect to. Only change this if
     #                            you're using a self-hosted Nylas instance.
     # @return [Nylas::API]
-    def initialize(client: nil, app_id: nil, app_secret: nil, access_token: nil,
+    def initialize(client: nil, client_id: nil, client_secret: nil, access_token: nil,
                    api_server: "https://api.nylas.com")
-      self.client = client || HttpClient.new(app_id: app_id, app_secret: app_secret,
+      self.client = client || HttpClient.new(client_id: client_id, client_secret: client_secret,
                                              access_token: access_token, api_server: api_server)
     end
 
@@ -55,8 +55,8 @@ module Nylas
     # @return [String | Hash] Returns just the access token as a string, or the full response as a hash
     def exchange_code_for_token(code, return_full_response: false)
       data = {
-        "client_id" => app_id,
-        "client_secret" => client.app_secret,
+        "client_id" => client_id,
+        "client_secret" => client.client_secret,
         "grant_type" => "authorization_code",
         "code" => code
       }
@@ -83,7 +83,7 @@ module Nylas
 
     # @return [Collection<Account>] A queryable collection of {Account}s
     def accounts
-      @accounts ||= Collection.new(model: Account, api: as(client.app_secret))
+      @accounts ||= Collection.new(model: Account, api: as(client.client_secret))
     end
 
     # @return [CalendarCollection<Calendar>] A queryable collection of {Calendar}s
@@ -156,7 +156,7 @@ module Nylas
 
     # @return [Collection<Component>] A queryable collection of {Component}s
     def components
-      @components ||= ComponentCollection.new(model: Component, api: as(client.app_secret))
+      @components ||= ComponentCollection.new(model: Component, api: as(client.client_secret))
     end
 
     # Revokes access to the Nylas API for the given access token
@@ -169,9 +169,9 @@ module Nylas
     # Returns the application details
     # @return [ApplicationDetail] The application details
     def application_details
-      response = client.as(client.app_secret).execute(
+      response = client.as(client.client_secret).execute(
         method: :get,
-        path: "/a/#{app_id}",
+        path: "/a/#{client_id}",
         auth_method: HttpClient::AuthMethod::BASIC
       )
       ApplicationDetail.new(**response)
@@ -181,9 +181,9 @@ module Nylas
     # @param application_details [ApplicationDetail] The updated application details
     # @return [ApplicationDetails] The updated application details, returned from the server
     def update_application_details(application_details)
-      response = client.as(client.app_secret).execute(
+      response = client.as(client.client_secret).execute(
         method: :put,
-        path: "/a/#{app_id}",
+        path: "/a/#{client_id}",
         payload: JSON.dump(application_details.to_h),
         auth_method: HttpClient::AuthMethod::BASIC
       )
@@ -194,8 +194,8 @@ module Nylas
     # @return [Hash]
     # hash has keys of :updated_at (unix timestamp) and :ip_addresses (array of strings)
     def ip_addresses
-      path = "/a/#{app_id}/ip_addresses"
-      client.as(client.app_secret).get(path: path, auth_method: HttpClient::AuthMethod::BASIC)
+      path = "/a/#{client_id}/ip_addresses"
+      client.as(client.client_secret).get(path: path, auth_method: HttpClient::AuthMethod::BASIC)
     end
 
     # @param message [Hash, String, #send!]
@@ -220,7 +220,7 @@ module Nylas
 
     # @return [Collection<Webhook>] A queryable collection of {Webhook}s
     def webhooks
-      @webhooks ||= Collection.new(model: Webhook, api: as(client.app_secret))
+      @webhooks ||= Collection.new(model: Webhook, api: as(client.client_secret))
     end
 
     # TODO: Move this into calendar collection

--- a/lib/nylas/component.rb
+++ b/lib/nylas/component.rb
@@ -29,7 +29,7 @@ module Nylas
     has_n_of_attribute :allowed_domains, :string
 
     def resources_path(*)
-      "/component/#{api.client.app_id}"
+      "/component/#{api.client.client_id}"
     end
   end
 end

--- a/lib/nylas/component_collection.rb
+++ b/lib/nylas/component_collection.rb
@@ -4,7 +4,7 @@ module Nylas
   # Additional configuration for the Component CRUD API
   class ComponentCollection < Collection
     def resources_path
-      "/component/#{api.client.app_id}"
+      "/component/#{api.client.client_id}"
     end
   end
 end

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -46,30 +46,30 @@ module Nylas
     attr_accessor :api_server
     attr_writer :default_headers
     attr_reader :access_token
-    attr_reader :app_id
-    attr_reader :app_secret
+    attr_reader :client_id
+    attr_reader :client_secret
 
-    # @param app_id [String] Your application id from the Nylas Dashboard
-    # @param app_secret [String] Your application secret from the Nylas Dashboard
+    # @param client_id [String] Your application's client ID from the Nylas Dashboard
+    # @param client_secret [String] Your application's client secret from the Nylas Dashboard
     # @param access_token [String] (Optional) Your users access token.
     # @param api_server [String] (Optional) Which Nylas API Server to connect to. Only change this if
     #                            you're using a self-hosted Nylas instance.
     # @return [Nylas::HttpClient]
-    def initialize(app_id:, app_secret:, access_token: nil, api_server: "https://api.nylas.com")
+    def initialize(client_id:, client_secret:, access_token: nil, api_server: "https://api.nylas.com")
       unless api_server.include?("://")
         raise "When overriding the Nylas API server address, you must include https://"
       end
 
       @api_server = api_server
       @access_token = access_token
-      @app_secret = app_secret
-      @app_id = app_id
+      @client_id = client_id
+      @client_secret = client_secret
     end
 
     # @return [Nylas::HttpClient[]
     def as(access_token)
-      HttpClient.new(app_id: app_id, access_token: access_token,
-                     app_secret: app_secret, api_server: api_server)
+      HttpClient.new(client_id: client_id, access_token: access_token,
+                     client_secret: client_secret, api_server: api_server)
     end
 
     # Sends a request to the Nylas API and rai

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -179,7 +179,7 @@ module Nylas
     def default_headers
       @default_headers ||= {
         "X-Nylas-API-Wrapper" => "ruby",
-        "X-Nylas-Client-Id" => @app_id,
+        "X-Nylas-Client-Id" => @client_id,
         "Nylas-API-Version" => SUPPORTED_API_VERSION,
         "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
         "Content-type" => "application/json"

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -23,7 +23,7 @@ module Nylas
     private
 
     def retrieve_code(name:, email_address:, provider:, settings:, reauth_account_id:, scopes:)
-      payload = { client_id: api.client.app_id, name: name, email_address: email_address,
+      payload = { client_id: api.client.client_id, name: name, email_address: email_address,
                   provider: provider, settings: settings, scopes: scopes }
       payload[:reauth_account_id] = reauth_account_id
       response = api.execute(method: :post, path: "/connect/authorize", payload: JSON.dump(payload))
@@ -31,7 +31,7 @@ module Nylas
     end
 
     def exchange_code_for_access_token(code)
-      payload = { client_id: api.client.app_id, client_secret: api.client.app_secret, code: code }
+      payload = { client_id: api.client.client_id, client_secret: api.client.client_secret, code: code }
       response = api.execute(method: :post, path: "/connect/token", payload: JSON.dump(payload))
       response[:access_token]
     end

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -86,7 +86,7 @@ module Nylas
     end
 
     def self.resources_path(api:)
-      "/a/#{api.app_id}/webhooks"
+      "/a/#{api.client_id}/webhooks"
     end
 
     private

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -40,7 +40,7 @@ describe Nylas::Account do
   end
 
   it "can update metadata" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("Nylas::API", execute: { success: true }, client_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     account.metadata = {
@@ -62,7 +62,7 @@ describe Nylas::Account do
   end
 
   it "can be downgraded" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("Nylas::API", execute: { success: true }, client_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     expect(account.downgrade).to be_truthy
@@ -77,7 +77,7 @@ describe Nylas::Account do
   end
 
   it "can be upgraded" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("Nylas::API", execute: { success: true }, client_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     expect(account.upgrade).to be_truthy
@@ -92,7 +92,7 @@ describe Nylas::Account do
   end
 
   it "can revoke all tokens" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("Nylas::API", execute: { success: true }, client_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
     access_token = "some_access_token"
 
@@ -108,7 +108,7 @@ describe Nylas::Account do
   end
 
   it "can be destroyed" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("Nylas::API", execute: { success: true }, client_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     expect(account.destroy).to be_truthy
@@ -123,7 +123,7 @@ describe Nylas::Account do
   end
 
   it "can return token information" do
-    api = instance_double("Nylas::API", app_id: "app-987")
+    api = instance_double("Nylas::API", client_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
     token_info_response = {
       scopes: "email.send,email.modify,calendar",

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -7,7 +7,7 @@ require "spec_helper"
 describe Nylas::API do
   describe "#exchange_code_for_token" do
     it "retrieves oauth token with code" do
-      client = Nylas::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
+      client = Nylas::HttpClient.new(client_id: "fake-app", client_secret: "fake-secret")
       data = {
         "client_id" => "fake-app",
         "client_secret" => "fake-secret",
@@ -28,7 +28,7 @@ describe Nylas::API do
     end
 
     it "retrieves full response from the server" do
-      client = Nylas::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
+      client = Nylas::HttpClient.new(client_id: "fake-app", client_secret: "fake-secret")
       data = {
         "client_id" => "fake-app",
         "client_secret" => "fake-secret",
@@ -52,7 +52,7 @@ describe Nylas::API do
   describe "#authentication_url" do
     context "with required parameters" do
       it "returns url for hosted_authentication" do
-        api = described_class.new(app_id: "2454354")
+        api = described_class.new(client_id: "2454354")
 
         hosted_auth_url = api.authentication_url(
           redirect_uri: "http://example.com",
@@ -74,7 +74,7 @@ describe Nylas::API do
 
     context "with required and optional parameters" do
       it "returns url for hosted_authentication with optional parameters" do
-        api = described_class.new(app_id: "2454354")
+        api = described_class.new(client_id: "2454354")
 
         hosted_auth_url = api.authentication_url(
           redirect_uri: "http://example.com",
@@ -102,7 +102,7 @@ describe Nylas::API do
 
     context "when required parameter are missing" do
       it "throws argument error if redirect uri is mising" do
-        api = described_class.new(app_id: "2454354")
+        api = described_class.new(client_id: "2454354")
 
         expect do
           api.authentication_url(scopes: ["email"])
@@ -110,7 +110,7 @@ describe Nylas::API do
       end
 
       it "throws argument error if scopes is mising" do
-        api = described_class.new(app_id: "2454354")
+        api = described_class.new(client_id: "2454354")
 
         expect do
           api.authentication_url(redirect_uri: "http://example.com")
@@ -118,7 +118,7 @@ describe Nylas::API do
       end
 
       it "generates wrong url if scopes and redirect_uri is nil" do
-        api = described_class.new(app_id: "2454354")
+        api = described_class.new(client_id: "2454354")
 
         hosted_auth_url = api.authentication_url(
           redirect_uri: nil,
@@ -148,7 +148,7 @@ describe Nylas::API do
 
   describe "#current_account" do
     it "retrieves the account for the current OAuth Access Token" do
-      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real",
+      client = Nylas::HttpClient.new(client_id: "not-real", client_secret: "also-not-real",
                                      access_token: "seriously-unreal")
       allow(client).to receive(:execute).with(method: :get, path: "/account").and_return(id: 1234)
       api = described_class.new(client: client)
@@ -156,7 +156,7 @@ describe Nylas::API do
     end
 
     it "raises an exception if there is not an access token set" do
-      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
+      client = Nylas::HttpClient.new(client_id: "not-real", client_secret: "also-not-real")
       allow(client).to receive(:execute).with(method: :get, path: "/account").and_return(id: 1234)
       api = described_class.new(client: client)
       expect { api.current_account.id }.to raise_error Nylas::NoAuthToken,
@@ -165,7 +165,7 @@ describe Nylas::API do
     end
 
     it "sets X-Nylas-Client-Id header" do
-      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
+      client = Nylas::HttpClient.new(client_id: "not-real", client_secret: "also-not-real")
       expect(client.default_headers).to include("X-Nylas-Client-Id" => "not-real")
     end
   end
@@ -176,8 +176,8 @@ describe Nylas::API do
       start_time = 1_609_439_400
       end_time = 1_640_975_400
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = described_class.new(client: client)
@@ -226,8 +226,8 @@ describe Nylas::API do
   describe "application details" do
     it "gets the application details" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real"
+        client_id: "not-real",
+        client_secret: "also-not-real"
       )
       api = described_class.new(client: client)
       application_details_response = {
@@ -261,8 +261,8 @@ describe Nylas::API do
       app_details.icon_url = "http://localhost/updated_icon.png"
       app_details.redirect_uris = %w[http://localhost/callback http://localhost/updated]
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real"
+        client_id: "not-real",
+        client_secret: "also-not-real"
       )
       api = described_class.new(client: client)
       stub_request(:put, "https://api.nylas.com/a/not-real")

--- a/spec/nylas/component_spec.rb
+++ b/spec/nylas/component_spec.rb
@@ -4,8 +4,8 @@ describe Nylas::Component do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -46,8 +46,8 @@ describe Nylas::Component do
   describe "saving" do
     it "POST with no ID set" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -91,8 +91,8 @@ describe Nylas::Component do
 
     it "PUT with ID set" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -10,20 +10,20 @@ describe Nylas::HttpClient do
 
   describe "#parse_response" do
     it "deserializes JSON with unicode characters" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       response = nylas.parse_response(full_json)
       expect(response).not_to be_a_kind_of(String)
     end
 
     it "raises if the JSON is unable to be deserialized" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       expect { nylas.parse_response("{{") }.to raise_error(Nylas::JsonParseError)
     end
   end
 
   describe "#execute handles content types" do
     it "parses JSON when given content-type == application/json" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
 
       stub_request(:get, "https://api.nylas.com/contacts/1234")
         .to_return(status: 200, body: full_json, headers: { "Content-Type" => "Application/Json" })
@@ -33,7 +33,7 @@ describe Nylas::HttpClient do
     end
 
     it "throws an error if content-type == application/json but response is not a json" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
 
       stub_request(:get, "https://api.nylas.com/contacts/1234")
         .to_return(status: 200, body: "abc", headers: { "Content-Type" => "Application/Json" })
@@ -42,7 +42,7 @@ describe Nylas::HttpClient do
     end
 
     it "still throws an API error if content-type == application/json but response is not a json" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
 
       stub_request(:get, "https://api.nylas.com/contacts/1234")
         .to_return(status: 400, body: "abc", headers: { "Content-Type" => "Application/Json" })
@@ -51,7 +51,7 @@ describe Nylas::HttpClient do
     end
 
     it "skips parsing when content-type is not JSON" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
 
       stub_request(:get, "https://api.nylas.com/contacts/1234/picture")
         .to_return(status: 200, body: "some values", headers: { "Content-Type" => "image/jpeg" })
@@ -64,7 +64,7 @@ describe Nylas::HttpClient do
   describe "#execute" do
     it "includes Nylas API Version in headers" do
       supported_api_version = "2.5"
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       allow(RestClient::Request).to receive(:execute)
 
       nylas.execute(method: :get, path: "/contacts/1234/picture")
@@ -79,7 +79,7 @@ describe Nylas::HttpClient do
     end
 
     it "handles redirect correctly" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
 
       stub_request(:get, "https://api.nylas.com/oauth/authorize")
         .to_return(status: 302, body: "")
@@ -115,7 +115,7 @@ describe Nylas::HttpClient do
           "type": "invalid_request_error"
         }.to_json
 
-        nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+        nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
         stub_request(:get, "https://api.nylas.com/contacts")
           .to_return(status: code, body: error_json)
 
@@ -128,7 +128,7 @@ describe Nylas::HttpClient do
           "type": "invalid_request_error"
         }.to_json
 
-        nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+        nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
         stub_request(:get, "https://api.nylas.com/contacts")
           .to_return(status: code, body: error_json, headers: { "Content-Type" => "Application/Json" })
 
@@ -146,7 +146,7 @@ describe Nylas::HttpClient do
         "X-RateLimit-Reset": "10"
       }
 
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       stub_request(:get, "https://api.nylas.com/contacts")
         .to_return(status: 429, body: error_json, headers: error_headers)
 
@@ -164,14 +164,14 @@ describe Nylas::HttpClient do
     path = "/contacts/1234/picture"
 
     it "no query parameters" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: {})
 
       expect(CGI.unescape(request[:url])).to eql(url + path)
     end
 
     it "one query parameter" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: { param: "value" })
 
       expected_params = "?param=value"
@@ -179,7 +179,7 @@ describe Nylas::HttpClient do
     end
 
     it "multiple query parameters" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       params = { id: "1234", limit: 100, offset: 0, view: "count" }
       request = nylas.build_request(method: :get, path: path, query: params)
 
@@ -188,7 +188,7 @@ describe Nylas::HttpClient do
     end
 
     it "array of query parameter values" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       request = nylas.build_request(method: :get, path: path, query: { metadata_key: %w[key1 key2 key3] })
 
       expected_params = "?metadata_key=key1&metadata_key=key2&metadata_key=key3"
@@ -196,7 +196,7 @@ describe Nylas::HttpClient do
     end
 
     it "setting metadata_pair query param (set hash of key-value pairs)" do
-      nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
+      nylas = described_class.new(client_id: "id", client_secret: "secret", access_token: "token")
       metadata_pair = { key1: "value1", key2: "value2", key3: "value3" }
       request = nylas.build_request(method: :get, path: path, query: { metadata_pair: metadata_pair })
 

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -8,8 +8,8 @@ describe Nylas::NativeAuthentication do
   describe "#authenticate" do
     it "sets all scopes by default" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
@@ -34,8 +34,8 @@ describe Nylas::NativeAuthentication do
 
     it "allows arrays of one scope" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
@@ -61,8 +61,8 @@ describe Nylas::NativeAuthentication do
 
     it "allows arrays of two scopes" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(
@@ -88,8 +88,8 @@ describe Nylas::NativeAuthentication do
 
     it "allows string scopes" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       expect(client).to receive(:execute).with(

--- a/spec/nylas/scheduler_spec.rb
+++ b/spec/nylas/scheduler_spec.rb
@@ -6,8 +6,8 @@ describe Nylas::Scheduler do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -41,8 +41,8 @@ describe Nylas::Scheduler do
 
     it "uses 'api.schedule.nylas.com' endpoint" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -56,8 +56,8 @@ describe Nylas::Scheduler do
   describe "saving" do
     it "POST with no ID set" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -100,8 +100,8 @@ describe Nylas::Scheduler do
 
     it "PUT with ID set" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -147,8 +147,8 @@ describe Nylas::Scheduler do
   describe "get available calendars" do
     it "makes a request with an ID present" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -168,8 +168,8 @@ describe Nylas::Scheduler do
 
     it "throws an error if no ID present" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -185,8 +185,8 @@ describe Nylas::Scheduler do
   describe "upload image" do
     it "makes a request with an ID present" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)
@@ -210,8 +210,8 @@ describe Nylas::Scheduler do
 
     it "throws an error if no ID present" do
       client = Nylas::HttpClient.new(
-        app_id: "not-real",
-        app_secret: "also-not-real",
+        client_id: "not-real",
+        client_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
       api = Nylas::API.new(client: client)

--- a/spec/nylas/webhook_spec.rb
+++ b/spec/nylas/webhook_spec.rb
@@ -48,7 +48,7 @@ describe Nylas::Webhook do
 
   describe "#create" do
     it "Serializes all non-read-only attributes" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), client_id: "app-987")
       data = {
         application_id: "app-123",
         callback_url: "https://url.com/callback",
@@ -77,7 +77,7 @@ describe Nylas::Webhook do
 
   describe "update" do
     it "Serializes only state" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), client_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -103,7 +103,7 @@ describe Nylas::Webhook do
     end
 
     it "Throws an error if update was called with something other than just state" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), client_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -123,7 +123,7 @@ describe Nylas::Webhook do
 
   describe "save" do
     it "Creates if no id exists" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), client_id: "app-987")
       data = {
         application_id: "app-123",
         callback_url: "https://url.com/callback",
@@ -150,7 +150,7 @@ describe Nylas::Webhook do
     end
 
     it "Updates if id exists" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), client_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -178,7 +178,7 @@ describe Nylas::Webhook do
 
   describe "#destroy" do
     it "Deletes the webhook on the API" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"), client_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
⚠️ This is a breaking change ⚠️ 

This PR is small, but a breaking change that aims to keep the Ruby SDK consistent with the rest of the SDKs and the Nylas platform as a whole. Currently the Ruby SDK refers to the credentials as `app_id` and `app_secret` which Nylas has moved on from a long time ago. They have been changed to `client_id` and `client_secret` respectively to keep consistency with the platform.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.