### PR TITLE
Local webhook testing support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,11 @@ Metrics/ParameterLists:
 Metrics/MethodLength:
   Exclude:
     - "lib/nylas/calendar_collection.rb"
+    - "lib/nylas/services/tunnel.rb"
+
+Metrics/AbcSize:
+  Exclude:
+    - "lib/nylas/services/tunnel.rb"
 
 Metrics/ModuleLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add local webhook testing support
+
 ### 5.14.0 / 2022-12-16
 * Added support for rate limit errors
 * Added `disable_provider_selection` option for building auth URL

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -41,8 +41,8 @@ module GemConfig
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
      ["tzinfo", "~> 2.0.5"],
-     # ["eventmachine", "~> 1.2.7"],
-     # ["faye-websocket", "~> 0.11.1"],
+     ["eventmachine", "~> 1.2.7"],
+     ["faye-websocket", "~> 0.11.1"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,9 +47,9 @@ module GemConfig
   end
 
   def self.testing_and_debugging_dependencies
-    [["pry", "~>  0.14.1"],
-     ["pry-nav", "~> 0.2.4"],
-     ["pry-stack_explorer", "~> 0.4.9"],
+    [["pry", "~>  0.13.0"],
+     ["pry-nav", "~> 1.0.0"],
+     ["pry-stack_explorer", "~> 0.6.1"],
      ["rspec", "~> 3.7"],
      ["rspec-json_matcher", "~> 0.1"],
      ["webmock", "~> 3.0"],

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,9 +47,9 @@ module GemConfig
   end
 
   def self.testing_and_debugging_dependencies
-    [["pry", "~>  0.13.0"],
-     ["pry-nav", "~> 1.0.0"],
-     ["pry-stack_explorer", "~> 0.6.1"],
+    [["pry", "~>  0.14.1"],
+     ["pry-nav", "~> 0.2.4"],
+     ["pry-stack_explorer", "~> 0.4.9"],
      ["rspec", "~> 3.7"],
      ["rspec-json_matcher", "~> 0.1"],
      ["webmock", "~> 3.0"],

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -41,6 +41,8 @@ module GemConfig
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
      ["tzinfo", "~> 2.0.5"],
+     ["eventmachine", "~> 1.2.7"],
+     ["faye-websocket", "~> 0.11.1"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,7 +47,7 @@ module GemConfig
   end
 
   def self.testing_and_debugging_dependencies
-    [["pry", "~>  0.14.1"],
+    [["pry", "~>  0.10.4"],
      ["pry-nav", "~> 0.2.4"],
      ["pry-stack_explorer", "~> 0.4.9"],
      ["rspec", "~> 3.7"],

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,9 +47,9 @@ module GemConfig
   end
 
   def self.testing_and_debugging_dependencies
-    [["pry", "~>  0.10.4"],
-     ["pry-nav", "~> 0.2.4"],
-     ["pry-stack_explorer", "~> 0.4.9"],
+    [["pry", "~>  0.14.1"],
+     ["pry-nav", "~> 1.0.0"],
+     ["pry-stack_explorer", "~> 0.6.1"],
      ["rspec", "~> 3.7"],
      ["rspec-json_matcher", "~> 0.1"],
      ["webmock", "~> 3.0"],

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -41,8 +41,8 @@ module GemConfig
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
      ["tzinfo", "~> 2.0.5"],
-     ["eventmachine", "~> 1.2.7"],
-     ["faye-websocket", "~> 0.11.1"],
+     # ["eventmachine", "~> 1.2.7"],
+     # ["faye-websocket", "~> 0.11.1"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -49,7 +49,7 @@ module GemConfig
   def self.testing_and_debugging_dependencies
     [["pry", "~>  0.14.1"],
      ["pry-nav", "~> 1.0.0"],
-     ["pry-stack_explorer", "~> 0.6.1"],
+     ["pry-stack_explorer", "~> 0.4.9.3"],
      ["rspec", "~> 3.7"],
      ["rspec-json_matcher", "~> 0.1"],
      ["webmock", "~> 3.0"],

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -47,7 +47,7 @@ module GemConfig
   end
 
   def self.testing_and_debugging_dependencies
-    [["pry", "~>  0.10.4"],
+    [["pry", "~>  0.14.1"],
      ["pry-nav", "~> 0.2.4"],
      ["pry-stack_explorer", "~> 0.4.9"],
      ["rspec", "~> 3.7"],

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -116,6 +116,8 @@ require_relative "nylas/scheduler_booking_confirmation"
 require_relative "nylas/native_authentication"
 
 require_relative "nylas/filter_attributes"
+
+require_relative "nylas/services/tunnel"
 # an SDK for interacting with the Nylas API
 # @see https://docs.nylas.com/reference
 module Nylas

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -98,6 +98,6 @@ module Nylas
       !obj.nil? && obj.respond_to?(:call)
     end
 
-    private_class_method :build_webhook_tunnel, :setup_websocket_client, :callable
+    private_class_method :setup_websocket_client, :callable
   end
 end

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -19,7 +19,7 @@ module Nylas
     def self.open_webhook_tunnel(api, config = nil)
       tunnel_id = SecureRandom.uuid
       triggers = config[:triggers]
-      region = config[:region]
+      region = config[:region] || "us"
       websocket_domain = "tunnel.nylas.com"
       callback_domain = "cb.nylas.com"
 

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -51,6 +51,7 @@ module Nylas
     # @param tunnel_id [String] The ID of the tunnel
     # @param region [String] The Nylas region to configure for
     # @param config [Hash] The object containing all the callback methods
+    # @return [WebSocket::Client] The configured websocket client
     def self.setup_websocket_client(websocket_domain, api, tunnel_id, region, config)
       ws = Faye::WebSocket::Client.new(
         "wss://#{websocket_domain}",
@@ -89,6 +90,8 @@ module Nylas
           config[:on_message].call(Delta.new(**delta)) if callable(config[:on_message])
         end
       end
+
+      ws
     end
 
     # Check if the object is a method

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -16,9 +16,9 @@ module Nylas
     # @param api [Nylas::API] The configured Nylas API client
     # @param config [Hash] Configuration for the webhook tunnel, including callback functions, region, and
     #   events to subscribe to
-    def self.open_webhook_tunnel(api, config = nil)
+    def self.open_webhook_tunnel(api, config = {})
       tunnel_id = SecureRandom.uuid
-      triggers = config[:triggers]
+      triggers = config[:triggers] || WebhookTrigger.constants(false).map { |c| WebhookTrigger.const_get c }
       region = config[:region] || "us"
       websocket_domain = "tunnel.nylas.com"
       callback_domain = "cb.nylas.com"

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "faye/websocket"
+require "eventmachine"
+
+module Nylas
+  # Class containing methods to spin up a developmental websocket connection to test webhooks
+  class Tunnel
+    # Open a webhook tunnel and register it with the Nylas API
+    # 1. Creates a UUID
+    # 2. Opens a websocket connection to Nylas' webhook forwarding service, with the UUID as a header
+    # 3. Creates a new webhook pointed at the forwarding service with the UUID as the path
+    # When an event is received by the forwarding service, it will push directly to this websocket connection
+    #
+    # @param api [Nylas::API] The configured Nylas API client
+    # @param config [Hash] Configuration for the webhook tunnel, including callback functions, region, and
+    #   events to subscribe to
+    def self.open_webhook_tunnel(api, config = nil)
+      tunnel_id = SecureRandom.uuid
+      triggers = config[:triggers]
+      region = config[:region]
+      websocket_domain = "tunnel.nylas.com"
+      callback_domain = "cb.nylas.com"
+
+      EM.run do
+        setup_websocket_client(websocket_domain, api, tunnel_id, region, config)
+        register_webhook_callback(api, callback_domain, tunnel_id, triggers)
+      end
+    end
+
+    # Register callback with the Nylas forwarding service which will pass messages to the websocket
+    # @param api [Nylas::API] The configured Nylas API client
+    # @param callback_domain [String] The domain name of the callback
+    # @param tunnel_path [String] The path to the tunnel
+    # @param triggers [Array<WebhookTrigger>] The list of triggers to subscribe to
+    # @return [Nylas::Webhook] The webhook details response from the API
+    def self.register_webhook_callback(api, callback_domain, tunnel_path, triggers)
+      callback_url = "https://#{callback_domain}/#{tunnel_path}"
+
+      api.webhooks.create(
+        callback_url: callback_url,
+        state: WebhookState::ACTIVE,
+        triggers: triggers
+      )
+    end
+
+    # Setup the websocket client and register the callbacks
+    # @param websocket_domain [String] The domain of the websocket to connect to
+    # @param api [Nylas::API] The configured Nylas API client
+    # @param tunnel_id [String] The ID of the tunnel
+    # @param region [String] The Nylas region to configure for
+    # @param config [Hash] The object containing all the callback methods
+    def self.setup_websocket_client(websocket_domain, api, tunnel_id, region, config)
+      ws = Faye::WebSocket::Client.new(
+        "wss://#{websocket_domain}",
+        [],
+        {
+          headers: {
+            "Client-Id" => api.client.app_id,
+            "Client-Secret" => api.client.app_secret,
+            "Tunnel-Id" => tunnel_id,
+            "Region" => region
+          }
+        }
+      )
+
+      ws.on :open do |event|
+        config[:on_open].call(event) if callable(config[:on_open])
+      end
+
+      ws.on :close do |close|
+        config[:on_close].call(close) if callable(config[:on_close])
+        EM.stop
+      end
+
+      ws.on :error do |error|
+        config[:on_error].call(error) if callable(config[:on_error])
+      end
+
+      ws.on :message do |message|
+        json = JSON.parse(message.data)
+        deltas = JSON.parse(json["body"])["deltas"]
+        next if deltas.nil?
+
+        deltas.each do |delta|
+          object_data = delta.delete("object_data")
+          delta = delta.merge(object_data).transform_keys(&:to_sym)
+          config[:on_message].call(Delta.new(**delta)) if callable(config[:on_message])
+        end
+      end
+    end
+
+    # Check if the object is a method
+    # @param obj [Any] The object to check
+    # @return [Boolean] True if the object is a method
+    def self.callable(obj)
+      !obj.nil? && obj.respond_to?(:call)
+    end
+
+    private_class_method :build_webhook_tunnel, :setup_websocket_client, :callable
+  end
+end

--- a/lib/nylas/services/tunnel.rb
+++ b/lib/nylas/services/tunnel.rb
@@ -80,6 +80,8 @@ module Nylas
       end
 
       ws.on :message do |message|
+        next unless message.data
+
         json = JSON.parse(message.data)
         deltas = JSON.parse(json["body"])["deltas"]
         next if deltas.nil?

--- a/spec/nylas/tunnel_spec.rb
+++ b/spec/nylas/tunnel_spec.rb
@@ -2,6 +2,37 @@
 
 require "rspec"
 
+##
+# Mock class and functions
+##
+
+class MockWebsocketClient
+  attr_accessor :url, :protocols, :options, :listeners
+
+  def initialize(url, protocols, options)
+    self.url = url
+    self.protocols = protocols
+    self.options = options
+    self.listeners = {}
+  end
+
+  def on(event, &block)
+    listeners[event.to_s] = block
+  end
+end
+
+def on_open(_)
+  "on_open"
+end
+
+def on_close(_)
+  "on_close"
+end
+
+def on_error(_)
+  "on_error"
+end
+
 describe Nylas::Tunnel do
   describe "register_webhook_callback" do
     it "creates a webhook with the correct parameters" do

--- a/spec/nylas/tunnel_spec.rb
+++ b/spec/nylas/tunnel_spec.rb
@@ -65,11 +65,7 @@ describe Nylas::Tunnel do
     end
 
     it "calls the functions with the default values" do
-      default_webhooks = %w[contact.created contact.updated contact.deleted calendar.created calendar.updated
-                            calendar.deleted event.created event.updated event.deleted job.successful
-                            job.failed account.connected account.running account.stopped account.invalid
-                            account.sync_error message.created message.opened message.link_created
-                            message.updated message.bounced thread.replied]
+      default_webhooks = WebhookTrigger.constants(false).map { |c| WebhookTrigger.const_get c }
 
       described_class.open_webhook_tunnel(api)
 

--- a/spec/nylas/tunnel_spec.rb
+++ b/spec/nylas/tunnel_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rspec"
+
+describe Nylas::Tunnel do
+  describe "register_webhook_callback" do
+    it "creates a webhook with the correct parameters" do
+      client = Nylas::HttpClient.new(
+        app_id: "not-real",
+        app_secret: "also-not-real"
+      )
+      api = instance_double(
+        Nylas::API,
+        client: client,
+        webhooks: Nylas::Collection.new(model: Nylas::Webhook, api: client)
+      )
+      allow(client).to receive(:execute).and_return({})
+      callback_domain = "domain.com"
+      tunnel_path = "tunnel"
+      triggers = [WebhookTrigger::EVENT_CREATED]
+
+      described_class.register_webhook_callback(api, callback_domain, tunnel_path, triggers)
+
+      expect(client).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        method: :post,
+        path: "/a/not-real/webhooks",
+        payload: JSON.dump(
+          callback_url: "https://domain.com/tunnel",
+          state: "active",
+          triggers: ["event.created"]
+        ),
+        query: {}
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR enables support for local webhook development. When implementing this feature in your app, the SDK will create a tunnel connection to a websocket server and registers it as a webhook callback to your Nylas account. 

# Usage
During the setup process you can pass in methods to override the websocket client's callback methods. The most important method is the `on_message` method which returns a parsed delta event from the webhook server.
```ruby
nylas = Nylas::API.new(
    app_id: CLIENT_ID,
    app_secret: CLIENT_SECRET
)

# Define the callback for the on_message event
def on_message(delta)
  if delta.type == Nylas::WebhookTrigger::MESSAGE_UPDATED
    p [:delta, delta]
  end
end

# Config that sets the region, triggers, and callbacks
config = {
  "region": "us",
  "triggers": [WebhookTrigger::MESSAGE_UPDATED],
  "on_message": method(:on_message)
}

# Create, register, and open the webhook tunnel for testing
Nylas::Tunnel::open_webhook_tunnel(nylas, config)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.