### PR TITLE
Add `tzinfo` as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add local webhook testing support
+* Add `tzinfo` as a runtime dependency
 
 ### 5.14.0 / 2022-12-16
 * Added support for rate limit errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 * Add local webhook testing support
-* Add `tzinfo` as a runtime dependency
+* Add `tzinfo`, `faye-websocket`, `eventmachine` as runtime dependencies
 
 ### 5.14.0 / 2022-12-16
 * Added support for rate limit errors

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -40,9 +40,6 @@ module GemConfig
      ["awesome_print", "~> 1.0"],
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
-     ["tzinfo", "~> 2.0.5"],
-     ["eventmachine", "~> 1.2.7"],
-     ["faye-websocket", "~> 0.11.1"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -6,6 +6,8 @@ Gem::Specification.new do |gem|
   GemConfig.apply(gem, "nylas")
   gem.summary = %(Gem for interacting with the Nylas API)
   gem.description = %(Gem for interacting with the Nylas API.)
+  gem.add_runtime_dependency "eventmachine", "~> 1.2.7"
+  gem.add_runtime_dependency "faye-websocket", "~> 0.11.1"
   gem.add_runtime_dependency "rest-client", ">= 2.0", "< 3.0"
   gem.add_runtime_dependency "tzinfo", "~> 2.0.5"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.2", ">= 1.2.1"

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -7,5 +7,6 @@ Gem::Specification.new do |gem|
   gem.summary = %(Gem for interacting with the Nylas API)
   gem.description = %(Gem for interacting with the Nylas API.)
   gem.add_runtime_dependency "rest-client", ">= 2.0", "< 3.0"
+  gem.add_runtime_dependency "tzinfo", "~> 2.0.5"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.2", ">= 1.2.1"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds `tzinfo` as a runtime dependency as it is used by `Nylas::When`, as well as `faye-websockets` and `eventmachine` as used by `Nylas::Tunnel`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.