### PR TITLE
v5.15.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.15.0 / 2022-02-02
 * Add local webhook testing support
 * Add `tzinfo`, `faye-websocket`, `eventmachine` as runtime dependencies
 

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.14.0"
+  VERSION = "5.15.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New Nylas Ruby SDK v5.15.0 release brings the following additions:
* Add local webhook testing support (#399)
* Add `tzinfo`, `faye-websocket`, `eventmachine` as runtime dependencies (#401)


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.