### PR TITLE
Fix and add missing webhook triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+* Fix `MESSAGE_LINK_CLICKED` trigger
+* Add missing job status webhook triggers
+
 ### 5.15.0 / 2022-02-02
 * Add local webhook testing support
 * Add `tzinfo`, `faye-websocket`, `eventmachine` as runtime dependencies

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -34,6 +34,8 @@ module WebhookTrigger
   EVENT_DELETED = "event.deleted"
   JOB_SUCCESSFUL = "job.successful"
   JOB_FAILED = "job.failed"
+  JOB_DELAYED = "job.delayed"
+  JOB_CANCELLED = "job.cancelled"
 end
 
 module Nylas

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -19,7 +19,7 @@ module WebhookTrigger
   ACCOUNT_SYNC_ERROR = "account.sync_error"
   MESSAGE_CREATED = "message.created"
   MESSAGE_OPENED = "message.opened"
-  MESSAGE_LINK_CLICKED = "message.link_created"
+  MESSAGE_LINK_CLICKED = "message.link_clicked"
   MESSAGE_UPDATED = "message.updated"
   MESSAGE_BOUNCED = "message.bounced"
   THREAD_REPLIED = "thread.replied"


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR fixes the `MESSAGE_LINK_CLICKED` value, and adds missing Job status webhook triggers.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.