### PR TITLE
Add missing provider_id attribute to label

### DIFF
--- a/lib/nylas/label.rb
+++ b/lib/nylas/label.rb
@@ -17,11 +17,11 @@ module Nylas
 
     attribute :id, :string
     attribute :account_id, :string
-
     attribute :object, :string
 
     attribute :name, :string
     attribute :display_name, :string
+    attribute :provider_id, :string
     attribute :job_status_id, :string, read_only: true
   end
 end

--- a/spec/nylas/label_spec.rb
+++ b/spec/nylas/label_spec.rb
@@ -17,14 +17,22 @@ describe Nylas::Label do
     expect(described_class).to be_updatable
   end
 
-  describe "#from_json" do
+  describe ".from_json" do
     it "deserializes all the attributes successfully" do
-      json = JSON.dump(display_name: "All Mail", id: "label-all-mail", name: "all", account_id: "acc-234")
-      label = described_class.from_json(json, api: nil)
+      data = {
+        id: "label-all-mail",
+        account_id: "acc-234",
+        display_name: "All Mail",
+        name: "all",
+        provider_id: "provider-id"
+      }
+
+      label = described_class.from_json(JSON.dump(data), api: nil)
       expect(label.display_name).to eql "All Mail"
       expect(label.id).to eql "label-all-mail"
       expect(label.name).to eql "all"
       expect(label.account_id).to eql "acc-234"
+      expect(label.provider_id).to eql "provider-id"
     end
   end
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds the missing `provider_id` attribute to the `Label` model according to [the documentation](https://developer.nylas.com/docs/api/#tag--Labels). 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.