### PR TITLE
v5.16.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 5.16.0 / 2022-03-14
 * Add missing `provider_id` attribute to `Label`
+* Add `organizer_email` and `organizer_name` to `Event`
 * Add missing job status webhook triggers
 * Fix `MESSAGE_LINK_CLICKED` trigger
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-### Unreleased
-* Fix `MESSAGE_LINK_CLICKED` trigger
+### 5.16.0 / 2022-03-14
+* Add missing `provider_id` attribute to `Label`
 * Add missing job status webhook triggers
+* Fix `MESSAGE_LINK_CLICKED` trigger
 
 ### 5.15.0 / 2022-02-02
 * Add local webhook testing support

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -40,6 +40,8 @@ module Nylas
     has_n_of_attribute :notifications, :event_notification
     has_n_of_attribute :round_robin_order, :string
     attribute :original_start_time, :unix_timestamp
+    attribute :organizer_email, :string
+    attribute :organizer_name, :string
     attribute :reminder_minutes, :string
     attribute :reminder_method, :string
     attribute :job_status_id, :string, read_only: true

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.15.0"
+  VERSION = "5.16.0"
 end

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -13,6 +13,8 @@ describe Nylas::Event do
         description: "an event",
         message_id: "mess-8766",
         owner: '"owner" <owner@example.com>',
+        organizer_email: "owner@example.com",
+        organizer_name: "owner",
         participants: [
           {
             comment: "Let me think on it",
@@ -99,6 +101,8 @@ describe Nylas::Event do
       expect(event.notifications[0].subject).to eql "Test Event Notification"
       expect(event.notifications[0].body).to eql "Reminding you about our meeting."
       expect(event.visibility).to eql "private"
+      expect(event.organizer_email).to eql "owner@example.com"
+      expect(event.organizer_name).to eql "owner"
     end
   end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New Nylas Ruby SDK v5.16.0 release brings the following additions:
* Add missing `provider_id` attribute to `Label` (#404)
* Add missing job status webhook triggers (#403)
* Fix `MESSAGE_LINK_CLICKED` trigger (#403)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.