### PR TITLE
Added attributes organizer_email and organizer_name to the Event Object

### DIFF
--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -40,6 +40,8 @@ module Nylas
     has_n_of_attribute :notifications, :event_notification
     has_n_of_attribute :round_robin_order, :string
     attribute :original_start_time, :unix_timestamp
+    attribute :organizer_email, :string
+    attribute :organizer_name, :string
     attribute :reminder_minutes, :string
     attribute :reminder_method, :string
     attribute :job_status_id, :string, read_only: true

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -13,6 +13,8 @@ describe Nylas::Event do
         description: "an event",
         message_id: "mess-8766",
         owner: '"owner" <owner@example.com>',
+        organizer_email: "owner@example.com",
+        organizer_name: "owner",
         participants: [
           {
             comment: "Let me think on it",
@@ -99,6 +101,8 @@ describe Nylas::Event do
       expect(event.notifications[0].subject).to eql "Test Event Notification"
       expect(event.notifications[0].body).to eql "Reminding you about our meeting."
       expect(event.visibility).to eql "private"
+      expect(event.organizer_email).to eql "owner@example.com"
+      expect(event.organizer_name).to eql "owner"
     end
   end
 


### PR DESCRIPTION
# Description
- Ruby SDK Event object was missing the fields `organizer_name` and `organizer_email`. The workaround previously was to parse the owner field of the Event object. 

https://nylas.atlassian.net/browse/CUST-1575

https://github.com/nylas/nylas-ruby/issues/406

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.