### PR TITLE
Added event.updated_at

### DIFF
--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -46,6 +46,7 @@ module Nylas
     attribute :reminder_method, :string
     attribute :job_status_id, :string, read_only: true
     attribute :visibility, :string
+    attribute :updated_at, :unix_timestamp, read_only: true
 
     attr_accessor :notify_participants
 

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -58,7 +58,8 @@ describe Nylas::Event do
           subject: "Test Event Notification",
           body: "Reminding you about our meeting."
         }],
-        visibility: "private"
+        visibility: "private",
+        updated_at: 1649179701
       }
 
       event = described_class.from_json(JSON.dump(data), api: api)
@@ -103,6 +104,7 @@ describe Nylas::Event do
       expect(event.visibility).to eql "private"
       expect(event.organizer_email).to eql "owner@example.com"
       expect(event.organizer_name).to eql "owner"
+      expect(event.updated_at).to eql Time.at(1649179701)
     end
   end
 


### PR DESCRIPTION
# Description
The API returns `updated_at` for events, but it is not included in the ruby client event model. This PR adds the `updated_at` attribute and related spec. This was referenced in #407 which was closed by #409, but it didn't actually add the `updated_at` attribute.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.