### PR TITLE
Allow native authentication to return the  full response like the exchange_code_for_token

### DIFF
--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -24,14 +24,15 @@ module Nylas
     end
 
     # @return [String] A Nylas access token for that particular user.
-    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil)
+    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil, return_full_response: false)
       NativeAuthentication.new(api: self).authenticate(
         name: name,
         email_address: email_address,
         provider: provider,
         settings: settings,
         reauth_account_id: reauth_account_id,
-        scopes: scopes
+        scopes: scopes,
+        return_full_response: return_full_response
       )
     end
 

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -24,7 +24,8 @@ module Nylas
     end
 
     # @return [String] A Nylas access token for that particular user.
-    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil, return_full_response: false)
+    def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil,
+                     return_full_response: false)
       NativeAuthentication.new(api: self).authenticate(
         name: name,
         email_address: email_address,

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -11,13 +11,13 @@ module Nylas
     end
 
     def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil,
-                     scopes: nil)
+                     scopes: nil, return_full_response: false)
       scopes ||= %w[email calendar contacts]
       scopes = scopes.join(",") unless scopes.is_a?(String)
       code = retrieve_code(name: name, email_address: email_address, provider: provider,
                            settings: settings, reauth_account_id: reauth_account_id, scopes: scopes)
 
-      exchange_code_for_access_token(code)
+      exchange_code_for_access_token(code, return_full_response)
     end
 
     private
@@ -30,10 +30,10 @@ module Nylas
       response[:code]
     end
 
-    def exchange_code_for_access_token(code)
+    def exchange_code_for_access_token(code, return_full_response)
       payload = { client_id: api.client.app_id, client_secret: api.client.app_secret, code: code }
       response = api.execute(method: :post, path: "/connect/token", payload: JSON.dump(payload))
-      response[:access_token]
+      return_full_response ? response : response[:access_token]
     end
   end
 end

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -6,6 +6,52 @@ require "spec_helper"
 
 describe Nylas::NativeAuthentication do
   describe "#authenticate" do
+    context "return_full_response parameter" do
+      let(:client) { Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real", access_token: "seriously-unreal") }
+      let(:api) { Nylas::API.new(client: client) }
+      let(:scopes) { "email,calendar,contacts" }
+      let(:scopes_array) { %w[email calendar contacts] }
+      let(:token_response) { { access_token: "fake-token", other_data: "other-data" } }
+
+      shared_examples "a successful authentication" do |return_full_response|
+        it "returns the expected value" do
+          expect(client).to receive(:execute).with(
+            method: :post, path: "/connect/authorize",
+            payload: be_json_including("scopes" => scopes)
+          ).and_return(code: 1234)
+          expect(client).to receive(:execute).with(
+            method: :post, path: "/connect/token",
+            payload: be_json_including("code" => 1234)
+          ).and_return(token_response)
+          expect(
+            api.authenticate(
+              name: "fake",
+              email_address: "fake@example.com",
+              provider: :gmail,
+              settings: {},
+              scopes: scopes_array,
+              return_full_response: return_full_response
+            )
+          ).to eql(expected_result)
+        end
+      end
+
+      context "when return_full_response is not set" do
+        let(:expected_result) { "fake-token" }
+        it_behaves_like "a successful authentication"
+      end
+
+      context "when return_full_response is false" do
+        let(:expected_result) { "fake-token" }
+        it_behaves_like "a successful authentication", false
+      end
+
+      context "when return_full_response is true" do
+        let(:expected_result) { token_response }
+        it_behaves_like "a successful authentication", true
+      end
+    end
+
     it "sets all scopes by default" do
       client = Nylas::HttpClient.new(
         app_id: "not-real",

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -3,11 +3,16 @@
 require "spec_helper"
 
 # rubocop:disable RSpec/MessageSpies
+# rubocop:disable Rspec/NestedGroups
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 
 describe Nylas::NativeAuthentication do
   describe "#authenticate" do
-    context "return_full_response parameter" do
-      let(:client) { Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real", access_token: "seriously-unreal") }
+    context "when called return_full_response parameter" do
+      let(:client) do
+        Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real",
+                              access_token: "seriously-unreal")
+      end
       let(:api) { Nylas::API.new(client: client) }
       let(:scopes) { "email,calendar,contacts" }
       let(:scopes_array) { %w[email calendar contacts] }
@@ -38,16 +43,19 @@ describe Nylas::NativeAuthentication do
 
       context "when return_full_response is not set" do
         let(:expected_result) { "fake-token" }
+
         it_behaves_like "a successful authentication"
       end
 
       context "when return_full_response is false" do
         let(:expected_result) { "fake-token" }
+
         it_behaves_like "a successful authentication", false
       end
 
       context "when return_full_response is true" do
         let(:expected_result) { token_response }
+
         it_behaves_like "a successful authentication", true
       end
     end
@@ -162,3 +170,5 @@ describe Nylas::NativeAuthentication do
 end
 
 # rubocop:enable RSpec/MessageSpies
+# rubocop:enable Rspec/NestedGroups
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
# Description
Adds a `return_full_response` argument to the `Api#authenticate` method, along with it an implementation in `NativeAuthentication` which mirrors the code in the `exchange_code_for_token` method.

This let's us perform NativeAuthentication, and get back the full token response vs just the access token. On the implementers end, this lets us share some of our account creation code between the two different types of authentication by being able to rely on the full_response.

Why is this needed? Nylas webhooks come in as "skinny payloads", just enough information to make a request to get the objects data with a request back to Nylas's servers (see: https://developer.nylas.com/docs/developer-guide/webhooks/available-webhooks/#event-webhooks). A calendar event's may look something like:
```
{"date"=>1679710508, "object"=>"event", "type"=>"event.created", "object_data"=>{"namespace_id"=>"3q5iuy16vqjr....", "account_id"=>"3q5iuy16vqj....", "object"=>"event", "attributes"=>nil, "id"=>"7o6mk16jw....", "metadata"=>nil}}
``` 
To look up this object you'll need the access_token for the related account, plus the event id.

Now when using Hosted Authentication, you exchange your oauth code for an access token (https://developer.nylas.com/docs/api/#post/oauth/token). The Ruby API lets you include `return_full_response` in the call to `exchange_code_for_token` which gives back not just the access_token, but the full response from the `/oauth/token` call:
```
{
  "access_token": "string",
  "account_id": "string",
  "email_address": "string",
  "provider": "eas",
  "token_type": "bearer"
}
```

However if you're using Native Authentication, you don't have this option, the call just returns the `access_token`, so now we have to made a follow up call to `/account` to get the `account_id` for the `access_token` in question. Not the end of the world, but ideally we could treat these two the same, and not make extra requests if we don't have to.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.