### PR TITLE
Add support for verifying webhook signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for verifying webhook signatures
+
 ### 5.16.0 / 2022-03-14
 * Add missing `provider_id` attribute to `Label`
 * Add `organizer_email` and `organizer_name` to `Event`

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -42,6 +42,7 @@ module Nylas
   # Represents a webhook attached to your application.
   # @see https://docs.nylas.com/reference#webhooks
   class Webhook
+    require "openssl"
     include Model
     self.creatable = true
     self.listable = true
@@ -89,6 +90,16 @@ module Nylas
 
     def self.resources_path(api:)
       "/a/#{api.app_id}/webhooks"
+    end
+
+    # Verify incoming webhook signature came from Nylas
+    # @param nylas_signature [str] The signature to verify
+    # @param raw_body [str] The raw body from the payload
+    # @param client_secret [str] Client secret of the app receiving the webhook
+    # @return [Boolean] True if the webhook signature was verified from Nylas
+    def self.verify_webhook_signature(nylas_signature, raw_body, client_secret)
+      digest = OpenSSL::HMAC.hexdigest("SHA256", client_secret, raw_body)
+      digest == nylas_signature
     end
 
     private

--- a/spec/nylas/webhook_spec.rb
+++ b/spec/nylas/webhook_spec.rb
@@ -201,4 +201,26 @@ describe Nylas::Webhook do
       )
     end
   end
+
+  describe "verify_webhook_signature" do
+    it "returns true if the webhook signature is valid" do
+      is_verified = described_class.verify_webhook_signature(
+        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        "test123",
+        "myClientSecret"
+      )
+
+      expect(is_verified).to be(true)
+    end
+
+    it "returns false if the webhook signature is invalid" do
+      is_verified = described_class.verify_webhook_signature(
+        "ddc02f921a4835e310f249dc09770c3fea2cb6fe949adc1887d7adc04a581e1c",
+        "test1234",
+        "myClientSecret"
+      )
+
+      expect(is_verified).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds support for verifying the webhook signature of inbound webhook notifications.

# Usage
```ruby
require 'sinatra'
require 'nylas'
require 'json'

set :port, 9000
NYLAS_CLIENT_SECRET = ENV['NYLAS_CLIENT_SECRET']

post '/' do
  content_type :json
  x_nylas_signature = request.env['HTTP_X_NYLAS_SIGNATURE']
  raw_body = request.body.read

  unless Nylas::Webhook::verify_webhook_signature(NYLAS_CLIENT_SECRET, x_nylas_signature, raw_body)
    status 403
    return { error: 'Invalid signature' }.to_json
  end

  body = JSON.parse(raw_body)
  puts "Webhook event received: #{JSON.pretty_generate(body)}"

  status 200
  { success: true }.to_json
end

run Sinatra::Application.run!
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.