### PR TITLE
v5.17.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### 5.17.0 / 2022-04-04
 * Add support for verifying webhook signatures
-* Add the `organizer_email` and `organizer_name` attributes to the Event Object
 * Add `event.updated_at`
 * Allow native authentication to return the full response like the `exchange_code_for_token`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-### Unreleased
+### 5.17.0 / 2022-04-04
 * Add support for verifying webhook signatures
+* Add the `organizer_email` and `organizer_name` attributes to the Event Object
+* Add `event.updated_at`
+* Allow native authentication to return the full response like the `exchange_code_for_token`
 
 ### 5.16.0 / 2022-03-14
 * Add missing `provider_id` attribute to `Label`

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.16.0"
+  VERSION = "5.17.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
New Nylas Ruby SDK v5.17.0 release brings the following additions:
* Added support for verifying webhook signatures (#413)
* Added `event.updated_at` (#410)
* Allow native authentication to return the full response like the `exchange_code_for_token` (#411)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.