### PR TITLE
v6.0.0 beta 2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ### 6.0.0-beta.2 / TBD
 * Added additional error classes
 * Added support for free/busy endpoint
+* Added support for Messages, Drafts, and Smart Compose APIs
+* Added support for custom authentication, connectors, and credentials APIs
 * Added support for folders API
+* Added support for attachments API
 * Set default timeout to 30 seconds
 
 ### 6.0.0-beta.1 / 2023-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 6.0.0-beta.2 / TBD
+### 6.0.0-beta.2 / 2023-11-21
 * Added additional error classes
 * Added support for free/busy endpoint
 * Added support for Messages, Drafts, and Smart Compose APIs

--- a/lib/nylas/resources/smart_compose.rb
+++ b/lib/nylas/resources/smart_compose.rb
@@ -24,7 +24,7 @@ module Nylas
     #
     # @param identifier [String] Grant ID or email account to generate a message suggestion for.
     # @param message_id [String] The id of the message to reply to.
-    # @param request_body [Hash] The prompt that smart compose will use to generate a message reply suggestion.
+    # @param request_body [Hash] The prompt that smart compose will use to generate a message reply.
     # @return [Array(Hash, String)] The generated message reply and API Request ID.
     def compose_message_reply(identifier:, message_id:, request_body:)
       post(

--- a/lib/nylas/resources/webhooks.rb
+++ b/lib/nylas/resources/webhooks.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: trues
+# frozen_string_literal: true
 
 require_relative "resource"
 require_relative "../handler/api_operations"
@@ -7,18 +7,18 @@ module Nylas
   # Module representing the possible 'trigger' values in a Webhook.
   # @see https://developer.nylas.com/docs/api#post/a/client_id/webhooks
   module WebhookTrigger
-    CALENDAR_CREATED = "calendar.created".freeze
-    CALENDAR_UPDATED = "calendar.updated".freeze
-    CALENDAR_DELETED = "calendar.deleted".freeze
-    EVENT_CREATED = "event.created".freeze
-    EVENT_UPDATED = "event.updated".freeze
-    EVENT_DELETED = "event.deleted".freeze
-    GRANT_CREATED = "grant.created".freeze
-    GRANT_UPDATED = "grant.updated".freeze
-    GRANT_DELETED = "grant.deleted".freeze
-    GRANT_EXPIRED = "grant.expired".freeze
-    MESSAGE_SEND_SUCCESS = "message.send_success".freeze
-    MESSAGE_SEND_FAILED = "message.send_failed".freeze
+    CALENDAR_CREATED = "calendar.created"
+    CALENDAR_UPDATED = "calendar.updated"
+    CALENDAR_DELETED = "calendar.deleted"
+    EVENT_CREATED = "event.created"
+    EVENT_UPDATED = "event.updated"
+    EVENT_DELETED = "event.deleted"
+    GRANT_CREATED = "grant.created"
+    GRANT_UPDATED = "grant.updated"
+    GRANT_DELETED = "grant.deleted"
+    GRANT_EXPIRED = "grant.expired"
+    MESSAGE_SEND_SUCCESS = "message.send_success"
+    MESSAGE_SEND_FAILED = "message.send_failed"
   end
 
   # Nylas Webhooks API

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.0.0.beta.1"
+  VERSION = "6.0.0.beta.2"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Changelog
* Added additional error classes (#426)
* Added support for free/busy endpoint (#428)
* Added support for Messages, Drafts, and Smart Compose APIs (#432)
* Added support for custom authentication, connectors, and credentials APIs (#431)
* Added support for folders API (#433)
* Added support for attachments API (#434)
* Set default timeout to 30 seconds (#426)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.