### PR TITLE
Fixed issue when sending message without attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 6.0.0-beta.3 / TBD
+* Fixed issue when sending message without attachments
+
 ### 6.0.0-beta.2 / 2023-11-21
 * Added additional error classes
 * Added support for free/busy endpoint

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -11,9 +11,14 @@ module Nylas
     # @!visibility private
     def self.build_form_request(request_body)
       attachments = request_body.delete(:attachments) || request_body.delete("attachments") || []
-      message_payload = request_body.to_json
+
+      # RestClient will not send a multipart request if there are no attachments
+      # so we need to return the message payload to be used as a json payload
+      return [request_body, []] if attachments.empty?
 
       # Prepare the data to return
+      message_payload = request_body.to_json
+
       form_data = {}
       opened_files = []
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR fixes a bug that arises when sending messages and creating or modifying drafts without any attachments present.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.