### PR TITLE
Add support for detect provider endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 5.17.0 / TBD
+* Add support for detect provider endpoint
+
 ### 5.17.0 / 2022-04-04
 * Add support for verifying webhook signatures
 * Add `event.updated_at`

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -210,10 +210,11 @@ module Nylas
         "client_secret" => client.app_secret,
         "email_address" => email_address
       }
-      response = client.as(client.app_secret).execute(
+
+      client.as(client.app_secret).execute(
         method: :post,
         path: "/connect/detect-provider",
-        payload: JSON.dump(payload),
+        payload: JSON.dump(payload)
       )
     end
 

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -200,6 +200,23 @@ module Nylas
       client.as(client.app_secret).get(path: path, auth_method: HttpClient::AuthMethod::BASIC)
     end
 
+    # Returns list of IP addresses
+    # @param email_address [String] The email address to detect the provider for
+    # @return [Hash] The provider information
+    # hash has keys of :updated_at (unix timestamp) and :ip_addresses (array of strings)
+    def detect_provider(email_address)
+      payload = {
+        "client_id" => app_id,
+        "client_secret" => client.app_secret,
+        "email_address" => email_address
+      }
+      response = client.as(client.app_secret).execute(
+        method: :post,
+        path: "/connect/detect-provider",
+        payload: JSON.dump(payload),
+      )
+    end
+
     # @param message [Hash, String, #send!]
     # @return [Message] The resulting message
     def send!(message)

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -5,6 +5,39 @@ require "spec_helper"
 # This spec is the only one that should have any webmock stuff going on, everything else should use the
 # FakeAPI to see what requests were made and what they included.
 describe Nylas::API do
+  describe "#detect_provider" do
+    # tests the detect_providr method
+    it "returns the provider" do
+      url = "https://api.nylas.com/connect/detect-provider"
+      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
+      data = {
+        "client_id" => "not-real",
+        "client_secret" => "also-not-real",
+        "email_address" => "test@gmail.com"
+      }
+      response = {
+        auth_name: "gmail",
+        detected: true,
+        email_address: "test@gmail.com",
+        is_imap: false,
+        provider_name: "gmail"
+      }
+
+      stub_request(:post, url)
+        .to_return(
+          status: 200,
+          body: response.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+      api = described_class.new(client: client)
+      res = api.detect_provider("test@gmail.com")
+
+      expect(res).to eq(response)
+      expect(WebMock).to have_requested(:post, url)
+        .with(body: data)
+    end
+  end
+
   describe "#exchange_code_for_token" do
     it "retrieves oauth token with code" do
       client = Nylas::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds support for the /connect/detect-provider endpoint. Closes #421.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.