### PR TITLE
Add accept header by default

### DIFF
--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -182,7 +182,8 @@ module Nylas
         "X-Nylas-Client-Id" => @app_id,
         "Nylas-API-Version" => SUPPORTED_API_VERSION,
         "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
-        "Content-type" => "application/json"
+        "Content-type" => "application/json",
+        "Accept" => "application/json"
       }
     end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
We set a content-header type by default, but not an accept header. We should add it in to prevent some error messages not being formatted as JSON. Closes #405.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.