### PR TITLE
Add support for count on message/thread search

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,9 +9,9 @@ name: Rubocop
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -23,14 +23,14 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/Gemfile.${{ matrix.gemfile }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
-      with:
-        ruby-version: 2.6
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run rubocop
-      run: bundle exec rubocop --config .rubocop.yml
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+        # change this to (see https://github.com/ruby/setup-ruby#versioning):
+        # uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+        with:
+          ruby-version: 3.0
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run rubocop
+        run: bundle exec rubocop --config .rubocop.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add support for count on message/thread search
+
 ### 5.17.0 / 2022-04-04
 * Add support for verifying webhook signatures
 * Add `event.updated_at`

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -223,7 +223,7 @@ module Nylas
     def send!(message)
       return message.send! if message.respond_to?(:send!)
       return NewMessage.new(**message.merge(api: self)).send! if message.respond_to?(:key?)
-      
+
       RawMessage.new(message, api: self).send! if message.is_a? String
     end
 

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -223,7 +223,8 @@ module Nylas
     def send!(message)
       return message.send! if message.respond_to?(:send!)
       return NewMessage.new(**message.merge(api: self)).send! if message.respond_to?(:key?)
-      return RawMessage.new(message, api: self).send! if message.is_a? String
+      
+      RawMessage.new(message, api: self).send! if message.is_a? String
     end
 
     # Allows you to get an API that acts as a different user but otherwise has the same settings

--- a/lib/nylas/search_collection.rb
+++ b/lib/nylas/search_collection.rb
@@ -6,5 +6,9 @@ module Nylas
     def resources_path
       "#{model.resources_path(api: api)}/search"
     end
+
+    def count
+      self.class.new(model: model, api: api, constraints: constraints).find_each.map.count
+    end
   end
 end

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -34,7 +34,7 @@ module Nylas
 
       def cast(value)
         return JSON.parse(value, symbolize_names: true) if value.is_a?(String)
-        
+
         value if value.respond_to?(:key)
       end
     end

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -34,7 +34,8 @@ module Nylas
 
       def cast(value)
         return JSON.parse(value, symbolize_names: true) if value.is_a?(String)
-        return value if value.respond_to?(:key)
+        
+        value if value.respond_to?(:key)
       end
     end
     Types.registry[:hash] = HashType.new

--- a/spec/nylas/search_collection_spec.rb
+++ b/spec/nylas/search_collection_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Nylas::SearchCollection do
+  let(:api) { FakeAPI.new }
+
+  describe "#count" do
+    it "Returns an enumerable for a single page of results, filtered by `offset` and `limit` and `where`" do
+      allow(api).to receive(:execute)
+        .with(
+          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          method: :get,
+          path: "/collection/search",
+          query: { limit: 100, offset: 0 },
+          headers: {}
+        ).and_return([{ id: "1234" }])
+
+      collection = described_class.new(model: FullModel, api: api)
+
+      results = collection.each.to_a
+
+      expect(results.count).to be 1
+    end
+  end
+end

--- a/spec/nylas/search_collection_spec.rb
+++ b/spec/nylas/search_collection_spec.rb
@@ -18,9 +18,7 @@ describe Nylas::SearchCollection do
 
       collection = described_class.new(model: FullModel, api: api)
 
-      results = collection.each.to_a
-
-      expect(results.count).to be 1
+      expect(collection.count).to be 1
     end
   end
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds count support for SearchCollection type. Closes #416.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.