### PR TITLE
Added send-rsvp support for events api

### DIFF
--- a/lib/nylas/resources/events.rb
+++ b/lib/nylas/resources/events.rb
@@ -79,5 +79,20 @@ module Nylas
 
       [true, request_id]
     end
+
+    # Send RSVP. Allows users to respond to events they have been added to as an attendee.
+    #
+    # @param identifier [String] Grant ID or email account from which to send RSVP with.
+    # @param event_id [String] The id of the event to respond to.
+    # @param request_body [Hash] The status values to send the RSVP with.
+    # @param query_params [Hash] The query parameters to include in the request
+    # @return [Hash] Response object with the API Request ID.
+    def send_rsvp(identifier:, event_id:, request_body:, query_params:)
+      post(
+        path: "#{api_uri}/v3/grants/#{identifier}/events/#{event_id}/send-rsvp",
+        query_params: query_params,
+        request_body: request_body
+      )
+    end    
   end
 end


### PR DESCRIPTION
- Added send-rsvp support for events api

[JIRA](https://nylas.atlassian.net/browse/AV-2762)


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.