### PR TITLE
Tw 2456 ruby add send to drafts

### DIFF
--- a/lib/nylas/resources/drafts.rb
+++ b/lib/nylas/resources/drafts.rb
@@ -90,8 +90,8 @@ module Nylas
     
     # Send an draft.
     #
-    # @param identifier [String] Grant ID or email account from which to delete an object.
-    # @param draft_id [String] The id of the draft to delete.
+    # @param identifier [String] Grant ID or email account from which to send the draft.
+    # @param draft_id [String] The id of the draft to send.
     # @return [Array(Hash, String)] The sent message draft and the API Request ID.
     def send(identifier:, draft_id:)
     

--- a/lib/nylas/resources/drafts.rb
+++ b/lib/nylas/resources/drafts.rb
@@ -87,5 +87,20 @@ module Nylas
 
       [true, request_id]
     end
+    
+    # Send an draft.
+    #
+    # @param identifier [String] Grant ID or email account from which to delete an object.
+    # @param draft_id [String] The id of the draft to delete.
+    # @return [Array(Hash, String)] The sent message draft and the API Request ID.
+    def send(identifier:, draft_id:)
+    
+      response = post(
+        path: "#{api_uri}/v3/grants/#{identifier}/drafts/#{draft_id}"
+      )
+
+      response
+    end    
+    
   end
 end


### PR DESCRIPTION
# Description
<!-- A clear and concise description of what the PR is introducing/changing. -->

The Drafts endpoint on the Ruby SDK doesn’t have a Send option. This PR will add it.

https://nylas.atlassian.net/browse/TW-2456

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.