### PR TITLE
Move `Grants` to `NylasClient` and custom authentication to `Auth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### 6.0.0-beta.3 / TBD
+* **BREAKING CHANGE**: Moved grants API out of `Auth` to `NylasClient`
+* **BREAKING CHANGE**: Moved `Grants.create()` to `Auth.customAuthentication()`
 * Add support for contacts API
 * Fixed issue when sending message without attachments
 

--- a/lib/nylas/client.rb
+++ b/lib/nylas/client.rb
@@ -90,6 +90,13 @@ module Nylas
       Folders.new(self)
     end
 
+    # The grants resources for your Nylas application.
+    #
+    # @return [Nylas::Grants] Grant resources for your Nylas application
+    def grants
+      Grants.new(self)
+    end
+
     # The message resources for your Nylas application.
     #
     # @return [Nylas::Messages] Message resources for your Nylas application

--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -16,15 +16,6 @@ module Nylas
     include ApiOperations::Post
     include ApiOperations::Get
 
-    # Initializes Auth.
-    def initialize(sdk_instance)
-      super(sdk_instance)
-
-      @grants = Grants.new(sdk_instance)
-    end
-
-    attr_reader :grants
-
     # Builds the URL for authenticating users to your application with OAuth 2.0.
     #
     # @param config [Hash] Configuration for building the URL.

--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -34,6 +34,17 @@ module Nylas
       execute_token_request(request)
     end
 
+    # Create a Grant via Custom Authentication.
+    #
+    # @param request_body [Hash] The values to create the Grant with.
+    # @return [Array(Hash, String)] Created grant and API Request ID.
+    def custom_authentication(request_body)
+      post(
+        path: "#{api_uri}/v3/connect/custom",
+        request_body: request_body
+      )
+    end
+
     # Refreshes an access token.
     #
     # @param request [Hash] Code exchange request.

--- a/lib/nylas/resources/grants.rb
+++ b/lib/nylas/resources/grants.rb
@@ -7,7 +7,6 @@ module Nylas
   # Grants
   class Grants < Resource
     include ApiOperations::Get
-    include ApiOperations::Post
     include ApiOperations::Put
     include ApiOperations::Delete
 
@@ -29,17 +28,6 @@ module Nylas
     def find(grant_id:)
       get(
         path: "#{api_uri}/v3/grant/#{grant_id}"
-      )
-    end
-
-    # Create a Grant via Custom Authentication.
-    #
-    # @param request_body [Hash] The values to create the Grant with.
-    # @return [Array(Hash, String)] Created grant and API Request ID.
-    def create(request_body)
-      post(
-        path: "#{api_uri}/v3/#{resource_name}/custom",
-        request_body: request_body
       )
     end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
⚠️ This is a breaking change ⚠️ 

This PR moves the following:
* `Auth.grants()` to `NylasClient.grants()`
* `Grants.create()` to `Auth.customAuthentication()`

Functionality remains the same.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.