### PR TITLE
TW-2466 - url_for_oauth2 not building url properly

### DIFF
--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -151,9 +151,9 @@ module Nylas
     # @return [Array(Hash, String)] List of encoded parameters for the query.
     def build_query(config)
       params = {
-        "client_id" => config[:client_id],
-        "redirect_uri" => config[:redirect_uri],
-        "access_type" => config[:access_type] || "online",
+        "client_id" => config[:config][:client_id],
+        "redirect_uri" => config[:config][:redirect_uri],
+        "access_type" => config[:config][:access_type] || "online",
         "response_type" => "code"
       }
       set_params(config)


### PR DESCRIPTION
# Description

The internal function build_query is missing a key that allows to extract the information properly

https://nylas.atlassian.net/browse/TW-2466

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.