### PR TITLE
v6.0.0 beta 3 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * **BREAKING CHANGE**: Moved grants API out of `Auth` to `NylasClient`
 * **BREAKING CHANGE**: Moved `Grants.create()` to `Auth.customAuthentication()`
 * Add support for contacts API
+* Add support for send RSVP
 * Add draft send support
 * Add missing webhook triggers
 * Fixed issue when sending message without attachments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-### 6.0.0-beta.3 / TBD
+### 6.0.0-beta.3 / 2024-01-04
 * **BREAKING CHANGE**: Moved grants API out of `Auth` to `NylasClient`
 * **BREAKING CHANGE**: Moved `Grants.create()` to `Auth.customAuthentication()`
 * Add support for contacts API
+* Add draft send support
+* Add missing webhook triggers
 * Fixed issue when sending message without attachments
 * Fixed issue when building an OAuth2 URL
+* Fixed free-busy endpoint path
 
 ### 6.0.0-beta.2 / 2023-11-21
 * Added additional error classes

--- a/lib/nylas/resources/drafts.rb
+++ b/lib/nylas/resources/drafts.rb
@@ -87,20 +87,16 @@ module Nylas
 
       [true, request_id]
     end
-    
+
     # Send an draft.
     #
     # @param identifier [String] Grant ID or email account from which to send the draft.
     # @param draft_id [String] The id of the draft to send.
     # @return [Array(Hash, String)] The sent message draft and the API Request ID.
     def send(identifier:, draft_id:)
-    
-      response = post(
+      post(
         path: "#{api_uri}/v3/grants/#{identifier}/drafts/#{draft_id}"
       )
-
-      response
-    end    
-    
+    end
   end
 end

--- a/lib/nylas/resources/events.rb
+++ b/lib/nylas/resources/events.rb
@@ -93,6 +93,6 @@ module Nylas
         query_params: query_params,
         request_body: request_body
       )
-    end    
+    end
   end
 end

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.0.0.beta.2"
+  VERSION = "6.0.0.beta.3"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Changelog
* **BREAKING CHANGE**: Moved grants API out of `Auth` to `NylasClient` (#447)
* **BREAKING CHANGE**: Moved `Grants.create()` to `Auth.customAuthentication()` (#447)
* Add support for contacts API (#438)
* Add support for send RSVP (#444)
* Add draft send support (#446)
* Add missing webhook triggers (#445)
* Fixed issue when sending message without attachments (#437)
* Fixed issue when building an OAuth2 URL (#449)
* Fixed free-busy endpoint path (#440)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.