### PR TITLE
Fix incorrect PKCE code challenge generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 6.0.0-beta.4 / TBD
+* Fixed list and find scheduled messages
+* Fixed incorrect PKCE code challenge generation
+
 ### 6.0.0-beta.3 / 2024-01-04
 * **BREAKING CHANGE**: Moved grants API out of `Auth` to `NylasClient`
 * **BREAKING CHANGE**: Moved `Grants.create()` to `Auth.customAuthentication()`

--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -171,13 +171,13 @@ module Nylas
       URI.encode_www_form(params)
     end
 
-    # Hashes the secret for PKCE authentication.
+    # Hash a plain text secret for use in PKCE.
     #
-    # @param secret [String] Randomly-generated authentication secret.
-    # @return [Hash] Hashed authentication secret.
+    # @param secret [String] The plain text secret to hash.
+    # @return [String] The hashed secret with base64 encoding (without padding).
     def hash_pkce_secret(secret)
-      Digest::SHA256.digest(secret).unpack1("H*")
-      Base64.strict_encode64(Digest::SHA256.digest(secret))
+      sha256_hash = Digest::SHA256.hexdigest(secret)
+      Base64.urlsafe_encode64(sha256_hash, padding: false)
     end
 
     # Sends the token request to the Nylas API.


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR fixes the PKCE code challenge generation; the correct method the API wants is for us to base64 encode the hex string as opposed to base64 encoding resulting hashed bytearray directly.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.