### PR TITLE
support draft filtering

### DIFF
--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -13,6 +13,7 @@ module Nylas
     self.destroyable = true
     self.id_listable = true
     self.countable = true
+    self.filterable = true
 
     attribute :id, :string
     attribute :object, :string

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -3,8 +3,8 @@
 require "spec_helper"
 
 describe Nylas::Draft do
-  it "is not filterable" do
-    expect(described_class).not_to be_filterable
+  it "is filterable" do
+    expect(described_class).to be_filterable
   end
 
   it "is creatable" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
Support filtering draft messages, using the `/drafts` endpoint according to the [documentation](https://developer.nylas.com/docs/api/v2/#get-/drafts). 

As an example, this allows querying for drafts on a given a `thread_id` using:
```
nylas_api.drafts.where(thread_id:)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.