### PR TITLE
Update Client.rb to include SmartCompose

### DIFF
--- a/lib/nylas/client.rb
+++ b/lib/nylas/client.rb
@@ -117,5 +117,12 @@ module Nylas
     def webhooks
       Webhooks.new(self)
     end
+    
+    # The smart compose resources for your Nylas application.
+    #
+    # @return [Nylas::SmartCompose] Smart Compose resources for your Nylas application.
+    def smartcompose
+      SmartCompose.new(self)
+    end     
   end
 end


### PR DESCRIPTION
# Description

SmartCompose is missing from Client.rb

https://nylas.atlassian.net/browse/TW-2501

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.