### PR TITLE
Fix OAuth URL building

### DIFF
--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -151,7 +151,7 @@ module Nylas
     def url_auth_builder(config)
       builder = URI.parse(api_uri)
       builder.path = "/v3/connect/auth"
-      builder.query = URI.encode_www_form(build_query(config)).gsub!("+", "%20")
+      builder.query = URI.encode_www_form(build_query(config)).gsub(/\+/, "%20")
 
       builder
     end


### PR DESCRIPTION
Fix url_auth_builder call

# Description

This line:

```
builder.query = URI.encode_www_form(build_query(config)).gsub!("+", "%20")
```

Replaces the whole value, so the Auth doesn’t work.

Replaced it with this:

```
builder.query = URI.encode_www_form(build_query(config)).gsub(/\+/, "%20")
```

https://nylas.atlassian.net/browse/TW-2543

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.