### PR TITLE
v6.0.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-### Unreleased
+### 6.0.1 / 2024-04-12
+* Fixed a bug during OAuth URL building
 * Fixed a bug where the `next_cursor` field was omitted for list responses
 
 ### 6.0.0 / 2024-02-05

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.0.0"
+  VERSION = "6.0.1"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Changelog
* Fixed a bug during OAuth URL building (#462)
* Fixed a bug where the `next_cursor` field was omitted for list responses (#461)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.