### PR TITLE
Move Detect Provider from Auth to Connectors

### DIFF
--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -100,16 +100,6 @@ module Nylas
       true
     end
 
-    # Detects the provider of an email address.
-    # @param params [Hash] Parameters to detect the provider.
-    # @return [Array(Hash, String)] Detected provider, if found and API Request ID.
-    def detect_provider(params)
-      post(
-        path: "#{api_uri}/v3/providers/detect",
-        query_params: params
-      )
-    end
-
     private
 
     # Builds the query with admin consent authentication for Microsoft.

--- a/lib/nylas/resources/auth.rb
+++ b/lib/nylas/resources/auth.rb
@@ -100,6 +100,16 @@ module Nylas
       true
     end
 
+    # Detects the provider of an email address.
+    # @param params [Hash] Parameters to detect the provider.
+    # @return [Array(Hash, String)] Detected provider, if found and API Request ID.
+    def detect_provider(params)
+      post(
+        path: "#{api_uri}/v3/providers/detect",
+        query_params: params
+      )
+    end
+
     private
 
     # Builds the query with admin consent authentication for Microsoft.

--- a/lib/nylas/resources/connectors.rb
+++ b/lib/nylas/resources/connectors.rb
@@ -85,6 +85,6 @@ module Nylas
         path: "#{api_uri}/v3/providers/detect",
         query_params: params
       )
-    end    
+    end
   end
 end

--- a/lib/nylas/resources/connectors.rb
+++ b/lib/nylas/resources/connectors.rb
@@ -76,5 +76,15 @@ module Nylas
 
       [true, request_id]
     end
+    
+    # Detects the provider of an email address.
+    # @param params [Hash] Parameters to detect the provider.
+    # @return [Array(Hash, String)] Detected provider, if found and API Request ID.
+    def detect_provider(params)
+      post(
+        path: "#{api_uri}/v3/providers/detect",
+        query_params: params
+      )
+    end    
   end
 end

--- a/lib/nylas/resources/connectors.rb
+++ b/lib/nylas/resources/connectors.rb
@@ -76,7 +76,7 @@ module Nylas
 
       [true, request_id]
     end
-    
+
     # Detects the provider of an email address.
     # @param params [Hash] Parameters to detect the provider.
     # @return [Array(Hash, String)] Detected provider, if found and API Request ID.


### PR DESCRIPTION
# Description
Currently Detect Provider is on Auth, but it should be on Connectors too

https://nylas.atlassian.net/browse/TW-2599

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.