### PR TITLE
Improved message sending and draft create/update performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Improved message sending and draft create/update performance
+
 ### 6.0.2 / 2024-02-27
 * Fixed the HTTP operation of updating grants
 * Fixed endpoint URL of rotating webhooks

--- a/lib/nylas/resources/drafts.rb
+++ b/lib/nylas/resources/drafts.rb
@@ -43,10 +43,20 @@ module Nylas
     #   you can use {FileUtils::attach_file_request_builder} to build each object attach.
     # @return [Array(Hash, String)] The created draft and API Request ID.
     def create(identifier:, request_body:)
-      form_body, opened_files = FileUtils.build_form_request(request_body)
+      payload = request_body
+      opened_files = []
+
+      # Use form data only if the attachment size is greater than 3mb
+      attachments = request_body[:attachments] || request_body["attachments"] || []
+      attachment_size = attachments&.sum { |attachment| attachment[:size] || 0 } || 0
+
+      if attachment_size >= FileUtils::FORM_DATA_ATTACHMENT_SIZE
+        payload, opened_files = FileUtils.build_form_request(request_body)
+      end
+
       response = post(
         path: "#{api_uri}/v3/grants/#{identifier}/drafts",
-        request_body: form_body
+        request_body: payload
       )
 
       opened_files.each(&:close)
@@ -63,11 +73,20 @@ module Nylas
     #   you can use {FileUtils::attach_file_request_builder} to build each object attach.
     # @return [Array(Hash, String)] The updated draft and API Request ID.
     def update(identifier:, draft_id:, request_body:)
-      form_body, opened_files = FileUtils.build_form_request(request_body)
+      payload = request_body
+      opened_files = []
+
+      # Use form data only if the attachment size is greater than 3mb
+      attachments = request_body[:attachments] || request_body["attachments"] || []
+      attachment_size = attachments&.sum { |attachment| attachment[:size] || 0 } || 0
+
+      if attachment_size >= FileUtils::FORM_DATA_ATTACHMENT_SIZE
+        payload, opened_files = FileUtils.build_form_request(request_body)
+      end
 
       response = put(
         path: "#{api_uri}/v3/grants/#{identifier}/drafts/#{draft_id}",
-        request_body: form_body
+        request_body: payload
       )
 
       opened_files.each(&:close)

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -5,6 +5,9 @@ require "mime/types"
 module Nylas
   # A collection of file-related utilities.
   module FileUtils
+    # The maximum size of an attachment that can be sent using json
+    FORM_DATA_ATTACHMENT_SIZE = 3 * 1024 * 1024
+
     # Build a form request for the API.
     # @param request_body The values to create the message with.
     # @return The form data to send to the API and the opened files.

--- a/spec/nylas/resources/drafts_spec.rb
+++ b/spec/nylas/resources/drafts_spec.rb
@@ -97,7 +97,33 @@ describe Nylas::Drafts do
       expect(draft_response).to eq(response)
     end
 
-    it "calls the post method with the correct parameters and attachments" do
+    it "calls the post method with the correct parameters for small attachments" do
+      identifier = "abc-123-grant-id"
+      mock_file = instance_double("file")
+      request_body = {
+        subject: "Hello from Nylas!",
+        to: [{ name: "Jon Snow", email: "jsnow@gmail.com" }],
+        cc: [{ name: "Arya Stark", email: "astark@gmail.com" }],
+        body: "This is the body of my draft message.",
+        attachments: [{
+          filename: "file.txt",
+          content_type: "text/plain",
+          size: 100,
+          content: mock_file
+        }]
+      }
+      path = "#{api_uri}/v3/grants/#{identifier}/drafts"
+
+      allow(drafts).to receive(:post)
+        .with(path: path, request_body: request_body)
+        .and_return(response)
+
+      draft_response = drafts.create(identifier: identifier, request_body: request_body)
+
+      expect(draft_response).to eq(response)
+    end
+
+    it "calls the post method with the correct parameters for large attachments" do
       identifier = "abc-123-grant-id"
       mock_file = instance_double("file")
       request_body = {
@@ -109,7 +135,7 @@ describe Nylas::Drafts do
       attachment = {
         filename: "file.txt",
         content_type: "text/plain",
-        size: 100,
+        size: 3 * 1024 * 1024,
         content: mock_file
       }
       expected_compiled_request = {
@@ -161,12 +187,39 @@ describe Nylas::Drafts do
         subject: "Hello from Nylas!",
         to: [{ name: "Jon Snow", email: "jsnow@gmail.com" }],
         cc: [{ name: "Arya Stark", email: "astark@gmail.com" }],
+        body: "This is the body of my draft message.",
+        attachments: [{
+          filename: "file.txt",
+          content_type: "text/plain",
+          size: 100,
+          content: mock_file
+        }]
+      }
+      path = "#{api_uri}/v3/grants/#{identifier}/drafts/#{draft_id}"
+      allow(drafts).to receive(:put)
+        .with(path: path, request_body: request_body)
+        .and_return(response)
+
+      draft_response = drafts.update(identifier: identifier, draft_id: draft_id,
+                                     request_body: request_body)
+
+      expect(draft_response).to eq(response)
+    end
+
+    it "calls the put method with the correct parameters for large attachments" do
+      identifier = "abc-123-grant-id"
+      draft_id = "5d3qmne77v32r8l4phyuksl2x"
+      mock_file = instance_double("file")
+      request_body = {
+        subject: "Hello from Nylas!",
+        to: [{ name: "Jon Snow", email: "jsnow@gmail.com" }],
+        cc: [{ name: "Arya Stark", email: "astark@gmail.com" }],
         body: "This is the body of my draft message."
       }
       attachment = {
         filename: "file.txt",
         content_type: "text/plain",
-        size: 100,
+        size: 3 * 1024 * 1024,
         content: mock_file
       }
       expected_compiled_request = {

--- a/spec/nylas/resources/messages_spec.rb
+++ b/spec/nylas/resources/messages_spec.rb
@@ -141,12 +141,38 @@ describe Nylas::Messages do
         subject: "Hello from Nylas!",
         to: [{ name: "Jon Snow", email: "jsnow@gmail.com" }],
         cc: [{ name: "Arya Stark", email: "astark@gmail.com" }],
+        body: "This is the body of my message message.",
+        attachments: [{
+          filename: "file.txt",
+          content_type: "text/plain",
+          size: 100,
+          content: mock_file
+        }]
+      }
+      path = "#{api_uri}/v3/grants/#{identifier}/messages/send"
+
+      allow(messages).to receive(:post)
+        .with(path: path, request_body: request_body)
+        .and_return(response)
+
+      message_response = messages.send(identifier: identifier, request_body: request_body)
+
+      expect(message_response).to eq(response)
+    end
+
+    it "calls the post method with the correct parameters and large attachments" do
+      identifier = "abc-123-grant-id"
+      mock_file = instance_double("file")
+      request_body = {
+        subject: "Hello from Nylas!",
+        to: [{ name: "Jon Snow", email: "jsnow@gmail.com" }],
+        cc: [{ name: "Arya Stark", email: "astark@gmail.com" }],
         body: "This is the body of my message message."
       }
       attachment = {
         filename: "file.txt",
         content_type: "text/plain",
-        size: 100,
+        size: 3 * 1024 * 1024,
         content: mock_file
       }
       expected_compiled_request = {


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR improves message send/draft create/update performance by always defaulting to application/json instead of multipart. Multipart will only be used for when a request contains a total attachments size of 3mb or higher.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.