### PR TITLE
Change default timeout to match API (90 seconds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Change default timeout to match API (90 seconds)
+
 ### 6.0.2 / 2024-02-27
 * Fixed the HTTP operation of updating grants
 * Fixed endpoint URL of rotating webhooks

--- a/lib/nylas/client.rb
+++ b/lib/nylas/client.rb
@@ -24,7 +24,7 @@ module Nylas
                    timeout: nil)
       @api_key = api_key
       @api_uri = api_uri
-      @timeout = timeout || 30
+      @timeout = timeout || 90
     end
 
     # The application resources for your Nylas application.

--- a/spec/nylas/client_spec.rb
+++ b/spec/nylas/client_spec.rb
@@ -8,7 +8,7 @@ describe Nylas::Client do
 
         expect(nylas.api_key).to eq("fake-key")
         expect(nylas.api_uri).to eq("https://api.us.nylas.com")
-        expect(nylas.timeout).to eq(30)
+        expect(nylas.timeout).to eq(90)
       end
     end
 
@@ -18,7 +18,7 @@ describe Nylas::Client do
 
         expect(nylas.api_key).to eq("fake-key")
         expect(nylas.api_uri).to eq("https://custom.nylas.com")
-        expect(nylas.timeout).to eq(30)
+        expect(nylas.timeout).to eq(90)
       end
     end
 


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
The API's default timeout is 90 seconds, so it's best we match that. We have updated the default value to match this, user can still override the default.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.