### PR TITLE
v6.0.3 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-### Unreleased
+### 6.0.3 / 2024-03-05
 * Improved message sending and draft create/update performance
 * Change default timeout to match API (90 seconds)
+* Fixed error when invoking `Auth.detect_provider`
 
 ### 6.0.2 / 2024-02-27
 * Fixed the HTTP operation of updating grants

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.0.2"
+  VERSION = "6.0.3"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Changelog
* Improved message sending and draft create/update performance (#470)
* Change default timeout to match API (90 seconds) (#471)
* Fixed error when invoking `Auth.detect_provider` (#469, #468)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.