### PR TITLE
Support custom headers

### DIFF
--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -26,6 +26,8 @@ module Nylas
 
     attribute :tracking, :message_tracking
 
+    has_n_of_attribute :custom_headers, :hash
+
     # Sends the new message
     # @return [Message] The sent message
     # @raise [RuntimeError] if the API response data was not a hash

--- a/spec/nylas/new_message_spec.rb
+++ b/spec/nylas/new_message_spec.rb
@@ -14,7 +14,11 @@ describe Nylas::NewMessage do
       subject: "A draft emails subject",
       body: "<h1>A draft Email</h1>",
       file_ids: [1234, 5678],
-      tracking: { opens: true }
+      tracking: { opens: true },
+      custom_headers: [
+        { "name" => "List-Unsubscribe-Post", "value" => "List-Unsubscribe=One-Click" },
+        { "name" => "List-Unsubscribe", "value" => "<https://example.com/unsubscribe>" }
+      ]
     }
 
     it "sends the message directly" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
<!-- A clear and concise description of what the PR is introducing/changing. -->

Support sending a message with customer headers, on the `/send` endpoint, according to the documentation: https://developer.nylas.com/docs/api/v2/#post-/send

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.