### PR TITLE
Adding support for query_params for messages endpoint

### DIFF
--- a/lib/nylas/resources/messages.rb
+++ b/lib/nylas/resources/messages.rb
@@ -38,10 +38,12 @@ module Nylas
     #
     # @param identifier [String] Grant ID or email account to query.
     # @param message_id [String] The id of the message to return.
+    # @param query_params [Hash, nil] Query params to pass to the request.
     # @return [Array(Hash, String)] The message and API request ID.
-    def find(identifier:, message_id:)
+    def find(identifier:, message_id:, query_params: nil)
       get(
-        path: "#{api_uri}/v3/grants/#{identifier}/messages/#{message_id}"
+        path: "#{api_uri}/v3/grants/#{identifier}/messages/#{message_id}",
+        query_params: query_params
       )
     end
 
@@ -50,11 +52,13 @@ module Nylas
     # @param identifier [String] Grant ID or email account in which to update an object.
     # @param message_id [String] The id of the message to update.
     # @param request_body [Hash] The values to update the message with
+    # @param query_params [Hash, nil] Query params to pass to the request.
     # @return [Array(Hash, String)] The updated message and API Request ID.
-    def update(identifier:, message_id:, request_body:)
+    def update(identifier:, message_id:, request_body:, query_params: nil)
       put(
         path: "#{api_uri}/v3/grants/#{identifier}/messages/#{message_id}",
-        request_body: request_body
+        request_body: request_body,
+        query_params: query_params
       )
     end
 

--- a/spec/nylas/resources/messages_spec.rb
+++ b/spec/nylas/resources/messages_spec.rb
@@ -66,12 +66,13 @@ describe Nylas::Messages do
     it "calls the get method with the correct parameters" do
       identifier = "abc-123-grant-id"
       message_id = "5d3qmne77v32r8l4phyuksl2x"
+      query_params = { fields: "include_headers" }
       path = "#{api_uri}/v3/grants/#{identifier}/messages/#{message_id}"
       allow(messages).to receive(:get)
-        .with(path: path)
+        .with(path: path, message_id: message_id, query_params: query_params)
         .and_return(response)
 
-      message_response = messages.find(identifier: identifier, message_id: message_id)
+      message_response = messages.find(identifier: identifier, message_id: message_id, query_params: query_params)
 
       expect(message_response).to eq(response)
     end
@@ -87,13 +88,14 @@ describe Nylas::Messages do
         folders: ["folder-123"],
         metadata: { foo: "bar" }
       }
+      query_params = { fields: "include_headers" }
       path = "#{api_uri}/v3/grants/#{identifier}/messages/#{message_id}"
       allow(messages).to receive(:put)
-        .with(path: path, request_body: request_body)
+        .with(path: path, request_body: request_body, query_params: query_params)
         .and_return(response)
 
       message_response = messages.update(identifier: identifier, message_id: message_id,
-                                         request_body: request_body)
+                                         request_body: request_body, query_params: query_params)
 
       expect(message_response).to eq(response)
     end

--- a/spec/nylas/resources/messages_spec.rb
+++ b/spec/nylas/resources/messages_spec.rb
@@ -72,7 +72,8 @@ describe Nylas::Messages do
         .with(path: path, query_params: query_params)
         .and_return(response)
 
-      message_response = messages.find(identifier: identifier, message_id: message_id, query_params: query_params)
+      message_response = messages.find(identifier: identifier, message_id: message_id,
+                                       query_params: query_params)
 
       expect(message_response).to eq(response)
     end

--- a/spec/nylas/resources/messages_spec.rb
+++ b/spec/nylas/resources/messages_spec.rb
@@ -69,7 +69,7 @@ describe Nylas::Messages do
       query_params = { fields: "include_headers" }
       path = "#{api_uri}/v3/grants/#{identifier}/messages/#{message_id}"
       allow(messages).to receive(:get)
-        .with(path: path, message_id: message_id, query_params: query_params)
+        .with(path: path, query_params: query_params)
         .and_return(response)
 
       message_response = messages.find(identifier: identifier, message_id: message_id, query_params: query_params)


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
Adding support for query_params to retrieve headers for messages along with field selection. `select` API parameter. It is addressing CUST-2909

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.