### PR TITLE
Enable SDK to reattach large files to messages on retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Enable SDK to reattach large files to messages on retry
+
 ### 6.1.1 / 2024-08-20
 * Fixed sending attachments less than 3MB
 

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -13,20 +13,29 @@ module Nylas
     # @return The form data to send to the API and the opened files.
     # @!visibility private
     def self.build_form_request(request_body)
-      attachments = request_body.delete(:attachments) || request_body.delete("attachments") || []
+      attachments = request_body[:attachments] || request_body["attachments"] || []
+      serializable_body = request_body.reject { |key, _| [:attachments, "attachments"].include?(key) }
+      request_body_copy = Marshal.load(Marshal.dump(serializable_body))
 
       # RestClient will not send a multipart request if there are no attachments
-      # so we need to return the message payload to be used as a json payload
-      return [request_body, []] if attachments.empty?
+      return [request_body_copy, []] if attachments.empty?
 
       # Prepare the data to return
-      message_payload = request_body.to_json
+      message_payload = request_body_copy.to_json
 
       form_data = {}
       opened_files = []
 
       attachments.each_with_index do |attachment, index|
         file = attachment[:content] || attachment["content"]
+        if file.respond_to?(:closed?) && file.closed?
+          unless attachment[:file_path]
+            raise ArgumentError, "The file at index #{index} is closed and no file_path was provided."
+          end
+
+          file = File.open(attachment[:file_path], "rb")
+        end
+
         form_data.merge!({ "file#{index}" => file })
         opened_files << file
       end

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -98,7 +98,8 @@ module Nylas
         filename: filename,
         content_type: content_type,
         size: size,
-        content: content
+        content: content,
+        file_path: file_path
       }
     end
   end

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -21,7 +21,8 @@ describe Nylas::FileUtils do
         filename: "file.txt",
         content_type: "text/plain",
         size: 100,
-        content: mock_file
+        content: mock_file,
+        file_path: file_path
       )
     end
 
@@ -37,7 +38,8 @@ describe Nylas::FileUtils do
         filename: "file.txt",
         content_type: "application/octet-stream",
         size: file_size,
-        content: mock_file
+        content: mock_file,
+        file_path: file_path
       )
     end
   end

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -86,9 +86,9 @@ describe Nylas::FileUtils do
 
       allow(mock_file).to receive(:closed?).and_return(true)
 
-      expect {
+      expect do
         described_class.build_form_request(request_body)
-      }.to raise_error(ArgumentError, "The file at index 0 is closed and no file_path was provided.")
+      end.to raise_error(ArgumentError, "The file at index 0 is closed and no file_path was provided.")
     end
 
     it "opens the file if it is closed and file_path is provided" do


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR enables the SDK to re-attach large files when trying to retry the same request body. If a `file_path` is provided with the attachment request and the file stream is closed, the SDK will attempt to reopen it. The helper function `attach_file_request_builder` will now set the `file_path` in the object, so if you're currently using that helper function, the attachment will be ready for reattachment. 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.