### PR TITLE
Loosen rest-client version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 
 source "https://rubygems.org"
 
+gem "rest-client", "2.0.0"
 gemspec name: "nylas"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "rest-client", "2.0.0"
 gemspec name: "nylas"

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
 
   # Runtime dependencies
   gem.add_runtime_dependency "mime-types", "~> 3.5", ">= 3.5.1"
-  gem.add_runtime_dependency "rest-client", ">= 2.0.0", "< 3.0"
+  gem.add_runtime_dependency "rest-client", "~> 2", "< 3.0"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.4.3", ">= 1.2.1"
 
   # Add remaining gem details and dev dependencies

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
 
   # Runtime dependencies
   gem.add_runtime_dependency "mime-types", "~> 3.5", ">= 3.5.1"
-  gem.add_runtime_dependency "rest-client", "~> 2", "< 3.0"
+  gem.add_runtime_dependency "rest-client", ">= 2.0.0", "< 3.0"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.4.3", ">= 1.2.1"
 
   # Add remaining gem details and dev dependencies

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
 
   # Runtime dependencies
   gem.add_runtime_dependency "mime-types", "~> 3.5", ">= 3.5.1"
-  gem.add_runtime_dependency "rest-client", "~> 2.1", "< 3.0"
+  gem.add_runtime_dependency "rest-client", ">= 2.0.0", "< 3.0"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.4.3", ">= 1.2.1"
 
   # Add remaining gem details and dev dependencies


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
<!-- A clear and concise description of what the PR is introducing/changing. -->
Hi there,

In my current organisation, we are trying to upgrade to nylas API v3, however nylas 6.x Ruby SDK conflicts with one of our [chargebee-ruby ](https://github.com/chargebee/chargebee-ruby) sub-dependency:

```
chargebee (2.43.0)
      rest-client (>= 1.8, <= 2.0.2)
nylas (6.1.1)
  	  rest-client (~> 2.1, < 3.0) 
```

While there's already a PR to upgrade chargebee usage of rest-client, https://github.com/chargebee/chargebee-ruby/pull/83, we're unsure whether that will land on time, so we were wondering whether for the time being we could loosen up the version on your side?

When running the CI against `rest-client 2.0.0` there seems to be ✅. Do you see any repercussions against doing that?

```
❯ bi
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Using rest-client 2.0.0 (was 2.1.0)
Bundle complete! 12 Gemfile dependencies, 47 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
❯ be rspec
....................................................................................................................................................................

Finished in 0.05607 seconds (files took 0.39409 seconds to load)
164 examples, 0 failures
```

This is currently blocking us from migrating to Nylas API v3.

Thanks in advance for your help.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.