### PR TITLE
Add dependency on ostruct gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Added dependency on `ostruct` gem
 * Enable SDK to reattach large files to messages on retry
 
 ### 6.1.1 / 2024-08-20

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |gem|
 
   # Runtime dependencies
   gem.add_runtime_dependency "mime-types", "~> 3.5", ">= 3.5.1"
+  gem.add_runtime_dependency "ostruct", "~> 0.6"
   gem.add_runtime_dependency "rest-client", ">= 2.0.0", "< 3.0"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.4.3", ">= 1.2.1"
 


### PR DESCRIPTION
# Description
As reported by @bmulholland:
```
warning: lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of nylas-6.1.1 to request adding ostruct into its gemspec.
```

Closes #489.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.