### PR TITLE
Added query support for folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+* Added query support for folders
 * Enable SDK to reattach large files to messages on retry
 
 ### 6.1.1 / 2024-08-20

--- a/lib/nylas/resources/folders.rb
+++ b/lib/nylas/resources/folders.rb
@@ -14,10 +14,12 @@ module Nylas
     # Return all folders.
     #
     # @param identifier [String] Grant ID or email account to query.
+    # @param query_params [Hash, nil] Query params to pass to the request.
     # @return [Array(Array(Hash), String, String)] The list of folders, API Request ID, and next cursor.
-    def list(identifier:)
+    def list(identifier:, query_params: nil)
       get_list(
-        path: "#{api_uri}/v3/grants/#{identifier}/folders"
+        path: "#{api_uri}/v3/grants/#{identifier}/folders",
+        query_params: query_params
       )
     end
 

--- a/spec/nylas/resources/folders_spec.rb
+++ b/spec/nylas/resources/folders_spec.rb
@@ -27,7 +27,7 @@ describe Nylas::Folders do
       identifier = "abc-123-grant-id"
       path = "#{api_uri}/v3/grants/#{identifier}/folders"
       allow(folders).to receive(:get_list)
-        .with(path: path)
+        .with(path: path, query_params: nil)
         .and_return(list_response)
 
       folders_response = folders.list(identifier: identifier)


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
This PR adds the ability to pass query parameters for listing folders. Closes #488.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.