### PR TITLE
v6.2.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-### Unreleased
+### 6.2.0 / 2024-09-24
 * Added query support for folders
 * Added dependency on `ostruct` gem
 * Enable SDK to reattach large files to messages on retry
+* Downgraded `rest-client` to `2.0` for better compatibility
 
 ### 6.1.1 / 2024-08-20
 * Fixed sending attachments less than 3MB

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.1.1"
+  VERSION = "6.2.0"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Changelog
* Added query support for folders (#492, #488)
* Added dependency on `ostruct` gem (#491, #489)
* Enable SDK to reattach large files to messages on retry (#487)
* Downgraded `rest-client` to `2.0` for better compatibility (#490)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.