### PR TITLE
Allow custom filename when adding an attachment

### DIFF
--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -92,8 +92,8 @@ module Nylas
     # Build the request to attach a file to a message/draft object.
     # @param file_path [String] The path to the file to attach.
     # @return [Hash] The request that will attach the file to the message/draft
-    def self.attach_file_request_builder(file_path)
-      filename = File.basename(file_path)
+    def self.attach_file_request_builder(file_path, filename = nil)
+      filename ||= File.basename(file_path)
       content_type = MIME::Types.type_for(file_path)
       content_type = if !content_type.nil? && !content_type.empty?
                        content_type.first.to_s

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -91,6 +91,7 @@ module Nylas
 
     # Build the request to attach a file to a message/draft object.
     # @param file_path [String] The path to the file to attach.
+    # @param filename [String] The name of the attached file. Optional, derived from file_path by default.
     # @return [Hash] The request that will attach the file to the message/draft
     def self.attach_file_request_builder(file_path, filename = nil)
       filename ||= File.basename(file_path)

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -42,6 +42,21 @@ describe Nylas::FileUtils do
         file_path: file_path
       )
     end
+
+    it "accepts optional filename parameter" do
+      file_path = "/path/to/file.txt"
+      filename = "customm-file.txt"
+
+      attach_file_req = described_class.attach_file_request_builder(file_path, filename)
+
+      expect(attach_file_req).to eq(
+        filename: "customm-file.txt",
+        content_type: "text/plain",
+        size: 100,
+        content: mock_file,
+        file_path: file_path
+      )
+    end
   end
 
   describe "#build_form_request" do


### PR DESCRIPTION
# Description
When adding an attachment to an email, the filename that will be sent is determined by the provided file path. This is problematic when using `Tempfile` because part of the path will be random. I propose accepting an optional `filename` parameter in `FileUtils.attach_file_request_builder`.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.