### PR TITLE
Adding support for `Accept-Encoding: gzip` in HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added support for `Accept-Encoding: gzip` in HTTP headers
+
 ### 6.2.0 / 2024-09-24
 * Added query support for folders
 * Added dependency on `ostruct` gem

--- a/lib/nylas/handler/http_client.rb
+++ b/lib/nylas/handler/http_client.rb
@@ -108,7 +108,8 @@ module Nylas
     def default_headers
       @default_headers ||= {
         "X-Nylas-API-Wrapper" => "ruby",
-        "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}"
+        "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
+        "Accept-Encoding" => "gzip"
       }
     end
 

--- a/spec/nylas/handler/http_client_spec.rb
+++ b/spec/nylas/handler/http_client_spec.rb
@@ -23,7 +23,8 @@ describe Nylas::HttpClient do
     it "returns the default headers" do
       expect(http_client.send(:default_headers)).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
-        "X-Nylas-API-Wrapper" => "ruby"
+        "X-Nylas-API-Wrapper" => "ruby",
+        "Accept-Encoding" => "gzip"
       )
     end
   end
@@ -64,7 +65,8 @@ describe Nylas::HttpClient do
       expect(request[:headers]).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
         "X-Nylas-API-Wrapper" => "ruby",
-        "Authorization" => "Bearer fake-key"
+        "Authorization" => "Bearer fake-key",
+        "Accept-Encoding" => "gzip"
       )
     end
 
@@ -84,7 +86,8 @@ describe Nylas::HttpClient do
         "X-Nylas-API-Wrapper" => "ruby",
         "Authorization" => "Bearer fake-key",
         "X-Custom-Header" => "custom-value",
-        "X-Custom-Header-2" => "custom-value-2"
+        "X-Custom-Header-2" => "custom-value-2",
+        "Accept-Encoding" => "gzip"
       )
     end
 
@@ -98,7 +101,8 @@ describe Nylas::HttpClient do
       expect(request[:headers]).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
         "X-Nylas-API-Wrapper" => "ruby",
-        "Authorization" => "Bearer fake-key"
+        "Authorization" => "Bearer fake-key",
+        "Accept-Encoding" => "gzip"
       )
       expect(request[:timeout]).to eq(30)
     end
@@ -114,7 +118,8 @@ describe Nylas::HttpClient do
       expect(request[:headers]).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
         "X-Nylas-API-Wrapper" => "ruby",
-        "Authorization" => "Bearer fake-key"
+        "Authorization" => "Bearer fake-key",
+        "Accept-Encoding" => "gzip"
       )
     end
 
@@ -131,7 +136,8 @@ describe Nylas::HttpClient do
           "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
           "X-Nylas-API-Wrapper" => "ruby",
           "Authorization" => "Bearer fake-key",
-          "Content-type" => "application/json"
+          "Content-type" => "application/json",
+          "Accept-Encoding" => "gzip"
         )
       end
 
@@ -146,7 +152,8 @@ describe Nylas::HttpClient do
         expect(request[:headers]).to eq(
           "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
           "X-Nylas-API-Wrapper" => "ruby",
-          "Authorization" => "Bearer fake-key"
+          "Authorization" => "Bearer fake-key",
+          "Accept-Encoding" => "gzip"
         )
       end
     end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
- Added`Accept-Encoding: gzip` header to HTTP requests.
-  This change allows the client to request Gzip-compressed responses from the server, improving data transfer efficiency and reducing load times.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.