### PR TITLE
Revert "Adding support for `Accept-Encoding: gzip` in HTTP headers"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-### Unreleased
-* Added support for `Accept-Encoding: gzip` in HTTP headers
-
 ### 6.2.0 / 2024-09-24
 * Added query support for folders
 * Added dependency on `ostruct` gem

--- a/lib/nylas/handler/http_client.rb
+++ b/lib/nylas/handler/http_client.rb
@@ -108,8 +108,7 @@ module Nylas
     def default_headers
       @default_headers ||= {
         "X-Nylas-API-Wrapper" => "ruby",
-        "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
-        "Accept-Encoding" => "gzip"
+        "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}"
       }
     end
 

--- a/spec/nylas/handler/http_client_spec.rb
+++ b/spec/nylas/handler/http_client_spec.rb
@@ -23,8 +23,7 @@ describe Nylas::HttpClient do
     it "returns the default headers" do
       expect(http_client.send(:default_headers)).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
-        "X-Nylas-API-Wrapper" => "ruby",
-        "Accept-Encoding" => "gzip"
+        "X-Nylas-API-Wrapper" => "ruby"
       )
     end
   end
@@ -65,8 +64,7 @@ describe Nylas::HttpClient do
       expect(request[:headers]).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
         "X-Nylas-API-Wrapper" => "ruby",
-        "Authorization" => "Bearer fake-key",
-        "Accept-Encoding" => "gzip"
+        "Authorization" => "Bearer fake-key"
       )
     end
 
@@ -86,8 +84,7 @@ describe Nylas::HttpClient do
         "X-Nylas-API-Wrapper" => "ruby",
         "Authorization" => "Bearer fake-key",
         "X-Custom-Header" => "custom-value",
-        "X-Custom-Header-2" => "custom-value-2",
-        "Accept-Encoding" => "gzip"
+        "X-Custom-Header-2" => "custom-value-2"
       )
     end
 
@@ -101,8 +98,7 @@ describe Nylas::HttpClient do
       expect(request[:headers]).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
         "X-Nylas-API-Wrapper" => "ruby",
-        "Authorization" => "Bearer fake-key",
-        "Accept-Encoding" => "gzip"
+        "Authorization" => "Bearer fake-key"
       )
       expect(request[:timeout]).to eq(30)
     end
@@ -118,8 +114,7 @@ describe Nylas::HttpClient do
       expect(request[:headers]).to eq(
         "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
         "X-Nylas-API-Wrapper" => "ruby",
-        "Authorization" => "Bearer fake-key",
-        "Accept-Encoding" => "gzip"
+        "Authorization" => "Bearer fake-key"
       )
     end
 
@@ -136,8 +131,7 @@ describe Nylas::HttpClient do
           "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
           "X-Nylas-API-Wrapper" => "ruby",
           "Authorization" => "Bearer fake-key",
-          "Content-type" => "application/json",
-          "Accept-Encoding" => "gzip"
+          "Content-type" => "application/json"
         )
       end
 
@@ -152,8 +146,7 @@ describe Nylas::HttpClient do
         expect(request[:headers]).to eq(
           "User-Agent" => "Nylas Ruby SDK 1.0.0 - 5.0.0",
           "X-Nylas-API-Wrapper" => "ruby",
-          "Authorization" => "Bearer fake-key",
-          "Accept-Encoding" => "gzip"
+          "Authorization" => "Bearer fake-key"
         )
       end
     end


### PR DESCRIPTION
Reverts nylas/nylas-ruby#497