### PR TITLE
Support custom attachment filename for large files

### DIFF
--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -36,6 +36,13 @@ module Nylas
           file = File.open(attachment[:file_path], "rb")
         end
 
+        # Setting original filename and content type if available. See code rest-client#lib/restclient/payload.rb
+        filename = attachment[:filename] || attachment["filename"]
+        file.define_singleton_method(:original_filename) { filename } if filename
+
+        content_type = attachment[:content_type] || attachment["content_type"]
+        file.define_singleton_method(:content_type) { content_type } if content_type
+
         form_data.merge!({ "file#{index}" => file })
         opened_files << file
       end

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -36,7 +36,7 @@ module Nylas
           file = File.open(attachment[:file_path], "rb")
         end
 
-        # Setting original filename and content type if available. See code rest-client#lib/restclient/payload.rb
+        # Setting original filename and content type if available. See rest-client#lib/restclient/payload.rb
         filename = attachment[:filename] || attachment["filename"]
         file.define_singleton_method(:original_filename) { filename } if filename
 

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -192,7 +192,7 @@ describe Nylas::FileUtils do
     let(:mock_file) { instance_double("file") }
 
     it "returns form data when attachment size is greater than 3MB" do
-      large_attachment = { size: 4 * 1024 * 1024, content: mock_file }
+      large_attachment = { size: 4 * 1024 * 1024, content: mock_file, filename: 'file.txt', content_type: 'text/plain' }
       request_body = { attachments: [large_attachment] }
 
       allow(mock_file).to receive(:read).and_return("file content")
@@ -202,6 +202,8 @@ describe Nylas::FileUtils do
 
       expect(payload).to include("multipart" => true)
       expect(opened_files).to include(mock_file)
+      expect(mock_file.original_filename).to eq('file.txt')
+      expect(mock_file.content_type).to eq('text/plain')
     end
 
     it "returns json data when attachment size is less than 3MB" do

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -192,7 +192,12 @@ describe Nylas::FileUtils do
     let(:mock_file) { instance_double("file") }
 
     it "returns form data when attachment size is greater than 3MB" do
-      large_attachment = { size: 4 * 1024 * 1024, content: mock_file, filename: 'file.txt', content_type: 'text/plain' }
+      large_attachment = {
+        size: 4 * 1024 * 1024,
+        content: mock_file,
+        filename: "file.txt",
+        content_type: "text/plain"
+      }
       request_body = { attachments: [large_attachment] }
 
       allow(mock_file).to receive(:read).and_return("file content")
@@ -202,8 +207,8 @@ describe Nylas::FileUtils do
 
       expect(payload).to include("multipart" => true)
       expect(opened_files).to include(mock_file)
-      expect(mock_file.original_filename).to eq('file.txt')
-      expect(mock_file.content_type).to eq('text/plain')
+      expect(mock_file.original_filename).to eq("file.txt")
+      expect(mock_file.content_type).to eq("text/plain")
     end
 
     it "returns json data when attachment size is less than 3MB" do


### PR DESCRIPTION
# Description
Add support for attachments > 3MB.
Follow-up of #496.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.