### PR TITLE
Adjust gendoc to correctly show this as a hash

### DIFF
--- a/lib/nylas/errors.rb
+++ b/lib/nylas/errors.rb
@@ -21,7 +21,7 @@ module Nylas
     # @param type [Hash] Error type.
     # @param message [String] Error message.
     # @param status_code [Integer] Error status code.
-    # @param provider_error [String, nil] Provider error.
+    # @param provider_error [Hash, nil] The error from the provider.
     # @param request_id [Hash, nil] The ID of the request.
     def initialize(type, message, status_code, provider_error = nil, request_id = nil)
       super(message)


### PR DESCRIPTION
# Description

Adjusted the gendoc to show that the `provider_error` is a Hash, not a String. Per customer message.

# License

I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.