### PR TITLE
Add ability to send inline image > 3mb

### DIFF
--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -43,7 +43,9 @@ module Nylas
         content_type = attachment[:content_type] || attachment["content_type"]
         file.define_singleton_method(:content_type) { content_type } if content_type
 
-        form_data.merge!({ "file#{index}" => file })
+        content_id = attachment[:content_id] || attachment["content_id"] || "file#{index}"
+
+        form_data.merge!({ content_id => file })
         opened_files << file
       end
 
@@ -100,7 +102,7 @@ module Nylas
     # @param file_path [String] The path to the file to attach.
     # @param filename [String] The name of the attached file. Optional, derived from file_path by default.
     # @return [Hash] The request that will attach the file to the message/draft
-    def self.attach_file_request_builder(file_path, filename = nil)
+    def self.attach_file_request_builder(file_path, filename = nil, content_id = nil)
       filename ||= File.basename(file_path)
       content_type = MIME::Types.type_for(file_path)
       content_type = if !content_type.nil? && !content_type.empty?
@@ -110,12 +112,12 @@ module Nylas
                      end
       size = File.size(file_path)
       content = File.new(file_path, "rb")
-
       {
         filename: filename,
         content_type: content_type,
         size: size,
         content: content,
+        content_id: content_id,
         file_path: file_path
       }
     end

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -22,6 +22,7 @@ describe Nylas::FileUtils do
         content_type: "text/plain",
         size: 100,
         content: mock_file,
+        content_id: nil,
         file_path: file_path
       )
     end
@@ -39,6 +40,7 @@ describe Nylas::FileUtils do
         content_type: "application/octet-stream",
         size: file_size,
         content: mock_file,
+        content_id: nil,
         file_path: file_path
       )
     end
@@ -54,6 +56,23 @@ describe Nylas::FileUtils do
         content_type: "text/plain",
         size: 100,
         content: mock_file,
+        content_id: nil,
+        file_path: file_path
+      )
+    end
+
+    it "accepts optional content_id parameter" do
+      file_path = "/path/to/file.txt"
+      content_id = "content-id-123"
+
+      attach_file_req = described_class.attach_file_request_builder(file_path, nil, content_id)
+
+      expect(attach_file_req).to eq(
+        filename: "file.txt",
+        content_type: "text/plain",
+        size: 100,
+        content: mock_file,
+        content_id: content_id,
         file_path: file_path
       )
     end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
- Add ability to provide `content_id` so developers can send inline image using cid in the body.
- https://github.com/nylas/nylas-ruby/issues/505

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.