### PR TITLE
v6.2.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-### Unreleased
-* Add support for private Scheduling configuration.
+### 6.2.2 / 2024-12-02
+* Added support for private Scheduling configuration.
+* Added ability to add optional `content_id` to support inline image on `send`.
+* Added custom filename support for large attachments.
 
 ### 6.2.1 / 2024-11-12
 * Added support for scheduler APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added support for private Scheduling configuration.
 * Added ability to add optional `content_id` to support inline image on `send`.
 * Added custom filename support for large attachments.
+* Adjusted the gendoc to show that the `provider_error` is a Hash.
 
 ### 6.2.1 / 2024-11-12
 * Added support for scheduler APIs

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.2.1"
+  VERSION = "6.2.2"
 end


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
* Added support for private Scheduling configuration (#503).
* Added ability to add optional `content_id` to support inline image on `send` (#506) (#505).
* Added custom filename support for large attachments (#502).
* Adjusted the gendoc to show that the `provider_error` is a Hash (#504).

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.