### PR TITLE
Handle response objects of instance String for API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Fixed issue where errors were not properly thrown due to an instance type of `String` instead of `Hash`
+
 ### 6.2.2 / 2024-12-02
 * Added support for private Scheduling configuration.
 * Added ability to add optional `content_id` to support inline image on `send`.

--- a/lib/nylas/handler/http_client.rb
+++ b/lib/nylas/handler/http_client.rb
@@ -198,10 +198,24 @@ module Nylas
 
     def throw_error(response, status_code)
       error_obj = response[:error]
-      provider_error = error_obj.fetch(:provider_error, nil)
 
-      NylasApiError.new(error_obj[:type], error_obj[:message], status_code, provider_error,
-                        response[:request_id])
+      # If `error_obj` is just a string, turn it into a hash with default keys.
+      if error_obj.is_a?(String)
+        error_obj = {
+          type: "NylasApiError",
+          message: error_obj
+        }
+      end
+
+      provider_error = error_obj.fetch(:provider_error, nil) if error_obj.is_a?(Hash)
+
+      NylasApiError.new(
+        error_obj[:type],
+        error_obj[:message],
+        status_code,
+        provider_error,
+        response[:request_id]
+      )
     end
 
     # Adds query parameters to a URL.

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.license = "MIT"
 
   # Runtime dependencies
+  gem.add_runtime_dependency 'base64'
   gem.add_runtime_dependency "mime-types", "~> 3.5", ">= 3.5.1"
   gem.add_runtime_dependency "ostruct", "~> 0.6"
   gem.add_runtime_dependency "rest-client", ">= 2.0.0", "< 3.0"

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.license = "MIT"
 
   # Runtime dependencies
-  gem.add_runtime_dependency 'base64'
+  gem.add_runtime_dependency "base64"
   gem.add_runtime_dependency "mime-types", "~> 3.5", ">= 3.5.1"
   gem.add_runtime_dependency "ostruct", "~> 0.6"
   gem.add_runtime_dependency "rest-client", ">= 2.0.0", "< 3.0"

--- a/spec/nylas/handler/http_client_spec.rb
+++ b/spec/nylas/handler/http_client_spec.rb
@@ -251,6 +251,22 @@ describe Nylas::HttpClient do
       expect(err_obj.type).to eq("api_error")
     end
 
+    it "raises NylasApiError if the error response is a string" do
+      response = {
+        request_id: "request-id",
+        error: "Bad Gateway"
+      }
+
+      err_obj = http_client.send(:error_hash_to_exception, response, 502, "https://test.api.nylas.com/foo")
+
+      expect(err_obj).to be_a(Nylas::NylasApiError)
+      expect(err_obj.message).to eq("Bad Gateway")
+      expect(err_obj.request_id).to eq("request-id")
+      expect(err_obj.provider_error).to eq(nil)
+      expect(err_obj.status_code).to eq(502)
+      expect(err_obj.type).to eq("NylasApiError")
+    end
+
     it "raises the correct error for OAuth" do
       response = {
         error: "invalid_request",


### PR DESCRIPTION
# Description
Due to unexpected errors such as Bad Gateway, the response object is of Instance string, while trying to fetch the provider_error we return a Ruby error of 
`undefined method `fetch' for "Bad Gateway":String`

This PR addresses the type before parsing the provider_error property

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.