### PR TITLE
Remove file_path from build JSON request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Removed `file_path` from `File` object to match the Send API schema
+
 ### 6.2.3 / 2025-01-23
 * Fixed issue where errors were not properly thrown due to an instance type of `String` instead of `Hash`
 

--- a/lib/nylas/utils/file_utils.rb
+++ b/lib/nylas/utils/file_utils.rb
@@ -62,6 +62,7 @@ module Nylas
       opened_files = []
 
       attachments.each_with_index do |attachment, _index|
+        attachment.delete(:file_path)
         current_attachment = attachment[:content]
         next unless current_attachment
 

--- a/spec/nylas/utils/file_utils_spec.rb
+++ b/spec/nylas/utils/file_utils_spec.rb
@@ -165,6 +165,14 @@ describe Nylas::FileUtils do
       expect(opened_files).to include(mock_file)
     end
 
+    it "removed the file_path key from the attachment" do
+      attachments = [{ content: mock_file, file_path: "/path/to/file.txt" }]
+
+      result, _opened_files = described_class.build_json_request(attachments)
+
+      expect(result.first).not_to have_key(:file_path)
+    end
+
     it "skips attachments with no content" do
       attachments = [{ content: nil }]
 


### PR DESCRIPTION
# Description
Remove file_path from the attachments object to prevent invalid requests in the future via our Send API.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.