### PR TITLE
Release v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 6.3.0 / 2025-03-03
 * Removed `file_path` from `File` object to match the Send API schema
+* Add events import function to the RubySDK
 
 ### 6.2.3 / 2025-01-23
 * Fixed issue where errors were not properly thrown due to an instance type of `String` instead of `Hash`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 6.3.0 / 2025-03-03
 * Removed `file_path` from `File` object to match the Send API schema
 
 ### 6.2.3 / 2025-01-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 6.3.0 / 2025-03-03
 * Removed `file_path` from `File` object to match the Send API schema
-* Add events import function to the RubySDK
+* Added events import function to the RubySDK
+* Added response headers to Ruby SDK 
 
 ### 6.2.3 / 2025-01-23
 * Fixed issue where errors were not properly thrown due to an instance type of `String` instead of `Hash`

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.2.3"
+  VERSION = "6.3.0"
 end


### PR DESCRIPTION
# Changelog
* Removed `file_path` from `File` object to match the Send API schema
* Added events import function to the RubySDK
* Added response headers to Ruby SDK 

# Description
<!-- A clear and concise description of what the PR is introducing/changing. -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.