### PR TITLE
raise an explicit exception when response does not include a JSON body

### DIFF
--- a/lib/nylas/handler/http_client.rb
+++ b/lib/nylas/handler/http_client.rb
@@ -119,7 +119,7 @@ module Nylas
     def parse_response(response)
       return response if response.is_a?(Enumerable)
 
-      Yajl::Parser.new(symbolize_names: true).parse(response)
+      Yajl::Parser.new(symbolize_names: true).parse(response) || raise(Nylas::JsonParseError)
     rescue Yajl::ParseError
       raise Nylas::JsonParseError
     end

--- a/spec/nylas/handler/http_client_spec.rb
+++ b/spec/nylas/handler/http_client_spec.rb
@@ -46,6 +46,12 @@ describe Nylas::HttpClient do
 
       expect { http_client.send(:parse_response, response) }.to raise_error(Nylas::JsonParseError)
     end
+
+    it "raises an error if the response is empty" do
+      response = ""
+
+      expect { http_client.send(:parse_response, response) }.to raise_error(Nylas::JsonParseError)
+    end
   end
 
   describe "#build_request" do


### PR DESCRIPTION
# Description
There should be no reason for the API to respond with a `200 OK` and an empty body, however, sometimes that has happened to us, resulting in this exception:

```
NoMethodError: undefined method `[]' for nil
```

This comes from:

* `nylas/handler/api_operations.rb` in `get_list` at line `34`
* `nylas/resources/messages.rb` in `list` at line `31`

Instead of raising a `NoMethodError` when trying to access `response`, `parse_response` now explicitly checks that it's returning *something*.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.