### PR TITLE
Release v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-### Unreleased
+### 6.4.0 / 2025-04-30
 * Added support for Notetaker APIs
 * Added support for Notetaker via the calendar and event APIs
+* Added MESSAGE_BOUNCE_DETECTED to the webhook triggers
+* Fixed issue to raise an explicit exception when the response lacks a JSON body (#520)
 
 ### 6.3.0 / 2025-03-03
 * Removed `file_path` from `File` object to match the Send API schema

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.3.0"
+  VERSION = "6.4.0"
 end


### PR DESCRIPTION
# Change log
- [x] Added support for Notetaker APIs
- [x] Added support for Notetaker via the calendar and event APIs
- [x] Added MESSAGE_BOUNCE_DETECTED to the webhook triggers
- [x] Fixed issue to raise an explicit exception when the response lacks a JSON body (#520)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.