### PR TITLE
feat: add support for include_hidden_folders query parameter in folders list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### [Unreleased]
+* Added support for `include_hidden_folders` query parameter in folders list endpoint for Microsoft accounts to control whether hidden folders are included in the response
+
 ### 6.5.0 / 2025-06-13
 * Replaced `rest-client` dependency with `httparty` for improved maintainability and security
   - `rest-client` is no longer actively maintained and has known security vulnerabilities

--- a/lib/nylas/resources/folders.rb
+++ b/lib/nylas/resources/folders.rb
@@ -15,6 +15,7 @@ module Nylas
     #
     # @param identifier [String] Grant ID or email account to query.
     # @param query_params [Hash, nil] Query params to pass to the request.
+    #   - include_hidden_folders [Boolean] (Microsoft only) When true, includes hidden folders.
     # @return [Array(Array(Hash), String, String)] The list of folders, API Request ID, and next cursor.
     def list(identifier:, query_params: nil)
       get_list(

--- a/spec/nylas/resources/folders_spec.rb
+++ b/spec/nylas/resources/folders_spec.rb
@@ -34,6 +34,19 @@ describe Nylas::Folders do
 
       expect(folders_response).to eq(list_response)
     end
+
+    it "calls the get method with the correct query parameters including include_hidden_folders" do
+      identifier = "abc-123-grant-id"
+      query_params = { include_hidden_folders: true }
+      path = "#{api_uri}/v3/grants/#{identifier}/folders"
+      allow(folders).to receive(:get_list)
+        .with(path: path, query_params: query_params)
+        .and_return(list_response)
+
+      folders_response = folders.list(identifier: identifier, query_params: query_params)
+
+      expect(folders_response).to eq(list_response)
+    end
   end
 
   describe "#find" do


### PR DESCRIPTION
# Description
- feat: add support for include_hidden_folders query parameter in folders list endpoint

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.