### PR TITLE
Fix: missing cgi import for webhooks

### DIFF
--- a/lib/nylas/resources/webhooks.rb
+++ b/lib/nylas/resources/webhooks.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require_relative "resource"
 require_relative "../handler/api_operations"
 


### PR DESCRIPTION
# Description
Missing cgi import

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.