### PR TITLE
Release v6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [Unreleased]
+### [6.6.0]
 * Added support for `single_level` query parameter in Folders API for Microsoft accounts
 * Added support for `include_hidden_folders` query parameter in folders list endpoint for Microsoft accounts to control whether hidden folders are included in the response
 * Added support for passing in string contents for multipart and base64 (<3MB) attachments (#528) 

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.5.0"
+  VERSION = "6.6.0"
 end


### PR DESCRIPTION
# Changelog
* Added support for `single_level` query parameter in Folders API for Microsoft accounts
* Added support for `include_hidden_folders` query parameter in folders list endpoint for Microsoft accounts to control whether hidden folders are included in the response
* Added support for passing in string contents for multipart and base64 (<3MB) attachments (#528) 
* Fixed HTTParty encoding compatibility issue with multipart requests (#528)

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.