### PR TITLE
TT-4934: Document callback URI application updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added Workspaces resource for managing workspaces, auto-grouping, manual assignment, `default`, `policy_id`, and `rule_ids`
 * Added Domains resource and `ServiceAccountSigner` support for signed Service Account Manage Domains requests, including canonical signed bodies, encoded domain paths, info, and verify operations
 * Added Applications update support (PATCH /v3/applications)
+* Documented Applications update `callback_uris` ID preservation and Workspaces `auto_group` filters
 * Corrected RedirectUris update verb from PUT to PATCH
 * Fixed HTTParty content type issue when request body is nil - POST, PUT, PATCH, and DELETE now default to empty object to ensure Content-Type: application/json is sent (#536)
 * Added support for request_body parameter on DELETE (e.g. cancellation_reason for bookings) (#536)

--- a/lib/nylas/resources/applications.rb
+++ b/lib/nylas/resources/applications.rb
@@ -27,7 +27,9 @@ module Nylas
 
     # Update application details.
     #
-    # @param request_body [Hash] The values to update the application with.
+    # @param request_body [Hash] The values to update the application with. Include
+    #   +callback_uris+ entries with +id+ when preserving or updating existing
+    #   callback URIs.
     # @return [Array(Hash, String)] The updated application details and API Request ID.
     def update(request_body:)
       patch(

--- a/lib/nylas/resources/workspaces.rb
+++ b/lib/nylas/resources/workspaces.rb
@@ -83,7 +83,8 @@ module Nylas
     # Runs as a background job and returns immediately with a job ID. Rate limited to one
     # call per minute per application.
     #
-    # @param request_body [Hash] Optional filters to scope which grants are grouped.
+    # @param request_body [Hash] Optional filters to scope which grants are grouped,
+    #   including +after_created_at+, +invalid_also+, and +specific_domain+.
     # @return [Array(Hash, String, Hash)] The job info, API Request ID, and response headers.
     def auto_group(request_body: nil)
       post(

--- a/spec/nylas/resources/applications_spec.rb
+++ b/spec/nylas/resources/applications_spec.rb
@@ -77,7 +77,14 @@ describe Nylas::Applications do
           subtitle: "string",
           background_color: "#003400",
           spacing: 5
-        }
+        },
+        callback_uris: [
+          {
+            id: "0556d035-6cb6-4262-a035-6b77e11cf8fc",
+            url: "https://example.com/callback",
+            platform: "web"
+          }
+        ]
       }
       path = "#{api_uri}/v3/applications"
       allow(application).to receive(:patch)


### PR DESCRIPTION
## Context
Follow-up to the review feedback on nylas-java#327. Ruby already forwards raw request hashes for `Applications#update`, so callers can send `callback_uris` entries with existing `id`s. This PR adds explicit parity coverage and documentation.

## Summary
- Document that `Applications#update` can preserve existing callback URIs by passing `callback_uris` entries with `id`.
- Add focused coverage that `callback_uris` with `id` are forwarded unchanged.
- Document `Workspaces#auto_group` filters, including `invalid_also`.
- Update the Unreleased changelog for callback URI preservation and workspace auto-group filters.

## Testing
- `bundle exec rspec spec/nylas/resources/applications_spec.rb spec/nylas/resources/workspaces_spec.rb`
- GitHub Actions: passing