### PR TITLE
[TA-3805] docs(calendars): document tentative_as_busy in get_free_busy request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Documented `tentative_as_busy` support in the `Calendars#get_free_busy` request body, consistent with other Nylas SDKs
+
 ### [6.8.0]
 * Added Policies resource for managing application policies
 * Added Rules resource for managing inbox rules and listing rule evaluations

--- a/lib/nylas/resources/calendars.rb
+++ b/lib/nylas/resources/calendars.rb
@@ -90,8 +90,13 @@ module Nylas
 
     # Get the free/busy schedule for a list of email addresses.
     #
-    # @param identifier [str] The identifier of the grant to act upon.
-    # @param request_body [Hash] Request body to pass to the request.
+    # @param identifier [String] The identifier of the grant to act upon.
+    # @param request_body [Hash] Request body to pass to the request. Supported keys:
+    #   - `:start_time` [Integer] Unix timestamp for the start time to check free/busy for.
+    #   - `:end_time` [Integer] Unix timestamp for the end time to check free/busy for.
+    #   - `:emails` [Array<String>] List of email addresses to check free/busy for.
+    #   - `:tentative_as_busy` [Boolean, nil] When set to `false`, treats tentative calendar events as
+    #     `busy: false`. Only applicable for Microsoft and EWS calendar providers. Defaults to `true`.
     # @return [Array(Array(Hash), String)] The free/busy response.
     def get_free_busy(identifier:, request_body:)
       post(

--- a/spec/nylas/resources/calendars_spec.rb
+++ b/spec/nylas/resources/calendars_spec.rb
@@ -251,5 +251,23 @@ describe Nylas::Calendars do
 
       calendars.get_free_busy(identifier: identifier, request_body: request_body)
     end
+
+    it "forwards the tentative_as_busy field in the request body" do
+      identifier = "abc-123-grant-id"
+      request_body = {
+        start_time: 1614556800,
+        end_time: 1614643200,
+        emails: ["test@gmail.com"],
+        tentative_as_busy: false
+      }
+
+      allow(calendars).to receive(:post)
+        .with(path: "#{api_uri}/v3/grants/#{identifier}/calendars/free-busy", request_body: request_body)
+
+      calendars.get_free_busy(identifier: identifier, request_body: request_body)
+
+      expect(calendars).to have_received(:post)
+        .with(path: "#{api_uri}/v3/grants/#{identifier}/calendars/free-busy", request_body: request_body)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds `tentative_as_busy` support to the `Calendars#get_free_busy` request body in the Ruby SDK, aligning it with the typed free/busy request models in the other Nylas SDKs (e.g. Python's `GetFreeBusyRequest`).

The Ruby SDK is entirely Hash-based and has no type system, so customers can already pass `tentative_as_busy` through the untyped `request_body` Hash. As with the other SDKs, this change makes the field a documented, first-class part of the request contract — the Ruby-idiomatic equivalent of a typed request model is documenting the accepted hash keys in the YARD comment (matching how `create`/`update` document their nested request fields).

## Changes

- Document the `get_free_busy` request body keys (`start_time`, `end_time`, `emails`, `tentative_as_busy`) in the YARD comment. `tentative_as_busy` uses wording consistent with the other SDKs: when set to `false`, treats tentative calendar events as `busy: false`; only applicable for Microsoft and EWS calendar providers; defaults to `true`.
- Fix the `identifier` param type in the same doc block (`str` → `String`).
- Add a spec asserting `tentative_as_busy` is forwarded in the request body.
- Add an `Unreleased` CHANGELOG entry.

## Testing

- `bundle exec rspec spec/nylas/resources/calendars_spec.rb` — 11 examples, 0 failures.
- `bundle exec rubocop lib/nylas/resources/calendars.rb spec/nylas/resources/calendars_spec.rb` — no offenses.

## Related

- TA-3805