### PR TITLE
[TA-3805] chore(release): v6.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### [6.8.1]
 * Documented `tentative_as_busy` support in the `Calendars#get_free_busy` request body, consistent with other Nylas SDKs
 
 ### [6.8.0]

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "6.8.0"
+  VERSION = "6.8.1"
 end


### PR DESCRIPTION
## Summary

Release v6.8.1. This is a documentation-only release that promotes the `Unreleased` CHANGELOG section to `6.8.1` and bumps `Nylas::VERSION`.

## Changes

- Bump `lib/nylas/version.rb` to `6.8.1`
- Promote the `Unreleased` CHANGELOG section to `### [6.8.1]`

## Included since 6.8.0

- [TA-3805] Documented `tentative_as_busy` support in the `Calendars#get_free_busy` request body, consistent with other Nylas SDKs (#546)

## Post-merge steps (manual, maintainer)

- [ ] Tag `v6.8.1` on the merged commit and push the tag
- [ ] `gem build nylas.gemspec && gem push nylas-6.8.1.gem` (requires RubyGems credentials)

## Related

- TA-3805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TA-3805]: https://nylas.atlassian.net/browse/TA-3805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ